### PR TITLE
fix: a passing assertion ends the step (15% flake to 0%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes are recorded here. This project follows [semantic versioning](https://semver.org/);
 while it is pre-1.0, a minor bump may change existing behaviour and a patch never does.
 
+## [Unreleased]
+
+### Fixed
+- A step whose `assert` judgment passed did not end the step: the executor recorded the pass and
+  looped for another action, and `fail` was still legal on that extra turn — so the model could, and
+  measurably did, fail a step it had just proved succeeded. A passing assertion now terminates the
+  step immediately, exactly as `done` does; the failing-assertion path (retry within budget, then
+  fail) is unchanged. Measured over twenty dogfood runs against an unchanged tree and app: 15% before
+  the fix (3/20, one hole across five tests) — **after: TBD, pending the twenty-run re-measurement.**
+
 ## [0.2.2] — 2026-07-28
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ while it is pre-1.0, a minor bump may change existing behaviour and a patch neve
   looped for another action, and `fail` was still legal on that extra turn — so the model could, and
   measurably did, fail a step it had just proved succeeded. A passing assertion now terminates the
   step immediately, exactly as `done` does; the failing-assertion path (retry within budget, then
-  fail) is unchanged. Measured over twenty dogfood runs against an unchanged tree and app: 15% before
-  the fix (3/20, one hole across five tests) — **after: TBD, pending the twenty-run re-measurement.**
+  fail) is unchanged. Measured over twenty dogfood runs against an unchanged tree and app: **15%
+  before the fix (3/20, one hole across five tests), 0% after (0/20)**. Under the old rate, twenty
+  consecutive clean runs would occur about 3.9% of the time. The fix also removes the redundant turn
+  each step spent after its assertion, so runs make fewer model calls than before.
 
 ## [0.2.2] — 2026-07-28
 

--- a/openspec/changes/assertion-ends-step/.openspec.yaml
+++ b/openspec/changes/assertion-ends-step/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/assertion-ends-step/design.md
+++ b/openspec/changes/assertion-ends-step/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`src/runner/executor.ts` drives each step as a loop: snapshot, ask for an action, perform it, repeat. The `assert` branch judges an expectation and, on a pass, records the result and `continue`s. The loop then asks for another action, and `fail` is still in the vocabulary.
+
+That extra turn is where the defect lives. The model, looking at a page where the step has plainly succeeded, reports `fail` — reasoning correctly that the action can no longer be performed and incorrectly that this means failure. It is not confused about the world, only about the word.
+
+Measured: twenty runs, unchanged tree and app, three failures (15%), all of them this. Four of the five tests failed zero times in nineteen runs each.
+
+The failure surfaces at two blast radii. Inside a test it costs one P0 and the score gate blocks correctly at 77. Inside `auth:`, `authenticate()` throws and the whole run aborts with exit 2 before a single test runs — no score, no report.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A step that has demonstrably succeeded cannot be failed.
+- Remove the redundant turn, and with it a meaningful share of the per-run model calls.
+- Keep the failed-assertion path — retry within budget — byte-for-byte as it is.
+
+**Non-Goals:**
+- Prompt wording. This is a termination condition in the executor, enforced by code.
+- The retry budget, self-healing, or screenshot capture.
+- Removing `done`, which remains how a step without an assertion ends.
+
+## Decisions
+
+**D1 — A passing assertion terminates the step.**
+
+The assert branch breaks instead of continuing. Chosen over three alternatives:
+
+- *Downgrade a later `fail` to `done` when an earlier assertion passed.* Rejected, and it was the first instinct. An assertion proves its own expectation, not the whole step. If an intermediate expectation passes and the step then genuinely breaks, the downgrade yields a **false PASS** — a gate approving broken code, which is strictly worse than the defect being fixed.
+- *Make `fail` illegal after a passing assertion, then re-prompt.* Correct but wasteful: it spends a round trip to obtain an answer already known.
+- *Match the reasoning text for completion phrasing.* Rejected on principle — string-matching a model's prose, in whichever language it emits.
+
+**D2 — Safe because the evidence says so, not because it is simpler.**
+
+The obvious objection is truncation: a step that asserts an intermediate condition and legitimately continues. Across the observed runs no step did this. Where a step asserted more than once, every repeat re-confirmed an already-passing expectation in different words before emitting `done` — one step spent three judge calls plus a `done` where one sufficed. Terminating on the first pass reaches the same outcome the model already reaches, minus the opportunity to contradict itself.
+
+**D3 — The win is also economic.**
+
+Every step currently pays for at least one redundant `nextAction` call after its assertion, plus any repeated judgments. On the demo suite that is roughly a third of the calls in a run. Cost and wall-clock improve as a side effect, but correctness is the reason.
+
+## Risks / Trade-offs
+
+- **A future step genuinely needs a second assertion after a passing one** → It cannot express that any more. Accepted: no observed step does, and the model reliably signals completion via `done` when it has more to do. If it appears, the step is better split in two — which reads better in a report anyway.
+- **A model asserts a weak expectation that passes while the step is incomplete** → The step ends early and passes. This risk exists identically today, since the model already emits `done` immediately after such an assertion. Not made worse; not fixed here.
+- **The 15% figure comes from one suite on one app** → The rate is specific to blastproof's own demo. The defect is not: any step whose success navigates away from the element it acted on can reach it.
+
+## Migration Plan
+
+Behavioural change only — no config, no API, no data. Existing suites keep passing; some get faster. Rollback is reverting the branch.
+
+Closure requires re-measuring, not merely a green test: twenty dogfood runs against an unchanged tree, with the observed rate stated in the result. A unit test proves the branch; only the rate proves the gate.
+
+## Open Questions
+
+- Should a step that ends on a passing assertion be visually distinct in the report from one that ended on `done`? Leaning no — same outcome, and the distinction would leak executor mechanics into a user-facing artifact.

--- a/openspec/changes/assertion-ends-step/proposal.md
+++ b/openspec/changes/assertion-ends-step/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+A passing assertion does not end the step: the executor records it and loops, so the model gets another turn and `fail` is still legal. The model can fail a step it has just proved succeeded.
+
+Measured over twenty dogfood runs against an unchanged tree and app: **three failures, 15%**, all this defect on the same step shape. The other four tests failed zero times in nineteen runs each, so this is one hole, not diffuse instability. A gate that blocks a good pull request one run in seven gets marked non-required, which makes every other capability on the backlog worth less than this one.
+
+## What Changes
+
+- A passing assertion terminates its step as complete. The executor stops asking for further actions.
+- **BREAKING** (behavioural, not API): `done` is no longer required after a passing assertion, and `fail` can no longer follow one within the same step.
+- A step whose assertion failed keeps today's behaviour exactly: retry within the budget, fail when exhausted.
+
+Evidence that this is safe rather than merely simpler: in the observed runs, every repeated assertion re-confirmed an already-passing expectation in different words, then emitted `done`. No step used a second assertion to check a *different* condition, so nothing is truncated. One step spent three judge calls plus a `done` where one call sufficed — so this also removes roughly a third of the model calls in a run, cutting cost and wall-clock alongside the defect.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agentic-execution`: the per-step loop terminates on a passing assertion; the assert judgment scenario gains the terminal outcome, and `fail` after a passing assertion is no longer reachable.
+
+## Non-goals
+
+- **Not** downgrading a later `fail` to `done` on the strength of an earlier assertion. That was the first instinct and it is dangerous: if an intermediate expectation passes and the step then genuinely breaks, the downgrade produces a false PASS. A gate that approves broken code is worse than one that blocks good code.
+- Not touching the retry budget, self-healing, or the failed-assertion path.
+- Not changing the action vocabulary. `done` stays valid for steps that end without an assertion.
+- Not prompt wording. The fix is a loop termination condition, enforced by the executor — consistent with the house rule that a guarantee is defined over a scope, not asked for in a prompt.
+
+## Impact
+
+- `src/runner/executor.ts` — the assert branch, where a passing judgment currently continues the loop.
+- `openspec/specs/agentic-execution/spec.md` — modified requirement and scenarios.
+- `tests/executor.test.ts` — a regression test that a `fail` offered after a passing assertion cannot fail the step.
+- Reporting is unaffected: step outcomes and screenshots keep their shape.
+- No new npm dependency.

--- a/openspec/changes/assertion-ends-step/specs/agentic-execution/spec.md
+++ b/openspec/changes/assertion-ends-step/specs/agentic-execution/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Per-step agentic loop
+The executor SHALL execute each plain-English step via a loop: capture the page accessibility snapshot, ask the LLM for a structured next action, perform the action on the page, and repeat until the step is complete or failed. A step SHALL be complete when the LLM returns `done` **or** when an `assert` judgment passes; the executor SHALL NOT request a further action once either has occurred.
+
+#### Scenario: Step completes
+- **WHEN** the LLM returns action `done` for a step
+- **THEN** the executor records the step as passed and advances to the next step
+
+#### Scenario: Step completes on a passing assertion
+- **WHEN** an `assert` action's judgment passes
+- **THEN** the executor records the step as passed and advances to the next step, without requesting a further action
+
+#### Scenario: Step fails
+- **WHEN** the LLM returns action `fail` or the retry budget is exhausted
+- **THEN** the executor records the step as failed with the LLM-provided reason, captures a screenshot, and the test is marked failed
+
+#### Scenario: A satisfied step cannot subsequently be failed
+- **WHEN** a step's assertion has passed
+- **THEN** the step is already complete, so no later `fail` can apply to it
+
+### Requirement: Supported actions
+The executor SHALL support the actions `navigate`, `click`, `fill`, `press`, `select`, `assert`, `done`, and `fail`, mapping them to Playwright operations resolved via `getByRole`/`getByLabel`/`getByText`. Action payloads SHALL have `{{env.*}}` placeholders substituted at the moment the action is performed, and `navigate` SHALL be bounded by the allowed origins.
+
+#### Scenario: Assert judgment
+- **WHEN** the LLM action is `assert` with an expectation
+- **THEN** the LLM judges the current snapshot against the expectation and returns pass/fail with a reason, which the executor records
+
+#### Scenario: Assert judgment passes
+- **WHEN** an `assert` judgment returns pass
+- **THEN** the executor records the result and treats the step as complete
+
+#### Scenario: Assert judgment fails
+- **WHEN** an `assert` judgment returns fail
+- **THEN** the executor records the result and retries within the per-step retry budget, failing the step when the budget is exhausted
+
+#### Scenario: Placeholder resolved at action time
+- **WHEN** a fill action carries `{{env.TEST_PASSWORD}}` as its value
+- **THEN** the environment value is substituted immediately before typing
+
+#### Scenario: Navigation outside the allowed origins
+- **WHEN** a navigate action resolves to an origin that is neither the application's nor declared
+- **THEN** the action fails and the step records the rejection

--- a/openspec/changes/assertion-ends-step/tasks.md
+++ b/openspec/changes/assertion-ends-step/tasks.md
@@ -17,8 +17,10 @@
 ## 4. Verification
 
 - [x] 4.1 Run `npm run build`, typecheck and the full vitest suite; all 248+ tests green.
-- [ ] 4.2 Re-measure: twenty dogfood runs against an unchanged tree, recording per run the gate conclusion and the `N passed, M failed` line. Serial — the workflow's concurrency group keeps only one queued run, so firing them at once silently cancels most.
-- [ ] 4.3 State the observed rate in the change and in issue #15. A green unit test proves the branch; only the rate proves the gate.
+- [x] 4.2 Re-measure: twenty dogfood runs against an unchanged tree, recording per run the gate conclusion and the `N passed, M failed` line. Serial — the workflow's concurrency group keeps only one queued run, so firing them at once silently cancels most.
+  - Result: **20/20 clean** (score 100, 5 passed 0 failed each) on `fix/assertion-ends-step`. Ten further dispatches failed on exhausted LLM provider credits and are excluded: all ten died at the first step with `requires more credits`, none reached a passing assertion, so none carries a signal about this defect.
+- [x] 4.3 State the observed rate in the change and in issue #15. A green unit test proves the branch; only the rate proves the gate.
+  - **15% before (3/20) → 0% after (0/20).** Under the old rate, twenty consecutive clean runs has probability 0.85^20 ≈ 3.9%.
 
 ## 5. Documentation
 

--- a/openspec/changes/assertion-ends-step/tasks.md
+++ b/openspec/changes/assertion-ends-step/tasks.md
@@ -1,0 +1,26 @@
+## 1. Executor
+
+- [x] 1.1 In `src/runner/executor.ts`, make a passing `assert` judgment terminate the step instead of continuing the loop: record the result, then break as `done` does. Leave the failing branch — retry within budget, `StepFailure` when exhausted — untouched.
+- [x] 1.2 Add a comment naming the reason the branch terminates, so a later reader does not "simplify" it back into a `continue`: the extra turn is what let the model contradict its own passing assertion.
+
+## 2. Regression tests
+
+- [x] 2.1 In `tests/executor.test.ts`, add a test with a brain that returns `assert` (judged pass) and then `fail`: the step must pass and the `fail` must never be requested.
+- [x] 2.2 Add a test that a failing assertion still retries to the budget and then fails the step, proving the failure path is unchanged.
+- [x] 2.3 Add a test that a step ending in `done` without any assertion still passes, so the ordinary path is covered.
+- [x] 2.4 Assert the call count: a step whose assertion passes makes no further `nextAction` call. This is the economic claim in design D3 and it should be pinned, not assumed.
+
+## 3. Authentication path
+
+- [x] 3.1 Confirm `authenticate()` inherits the fix through the shared executor, and add a test that a login journey whose assertion passes cannot then abort the run with `AuthError`. This is the blast radius that kills a whole run with no score and no report.
+
+## 4. Verification
+
+- [x] 4.1 Run `npm run build`, typecheck and the full vitest suite; all 248+ tests green.
+- [ ] 4.2 Re-measure: twenty dogfood runs against an unchanged tree, recording per run the gate conclusion and the `N passed, M failed` line. Serial — the workflow's concurrency group keeps only one queued run, so firing them at once silently cancels most.
+- [ ] 4.3 State the observed rate in the change and in issue #15. A green unit test proves the branch; only the rate proves the gate.
+
+## 5. Documentation
+
+- [ ] 5.1 Update `openspec/specs/agentic-execution/spec.md` via archive, not by hand.
+- [x] 5.2 Add a CHANGELOG entry under Unreleased describing the behavioural fix and the measured before/after rate.

--- a/src/runner/executor.ts
+++ b/src/runner/executor.ts
@@ -176,8 +176,12 @@ export async function executeTest(page: PageLike, test: TestFile, options: Execu
             : `assertion failed: ${judgment.reason}`;
           emitAction(index, action, result);
           if (judgment.pass) {
+            // Terminate here, exactly as `done` does. The extra turn this used to
+            // spend asking for a further action is what let the model contradict
+            // its own passing assertion by emitting `fail` next (see design D1) —
+            // don't reintroduce it by turning this back into a `continue`.
             lastResult = result;
-            continue;
+            break;
           }
           // A failed judgment may just mean the page hasn't settled: retry within budget.
           failedAttempts++;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -63,6 +63,25 @@ function stubBrain(opts: { succeed?: boolean; verifyPasses?: boolean } = {}): Ag
   };
 }
 
+/**
+ * Brain whose first turn is an assert that judges pass, and whose second turn —
+ * reachable only if the executor still `continue`s past a passing assertion —
+ * fails the step. Used to prove `authenticate()` inherits the fix (task 3.1).
+ */
+function assertThenFailBrain(): AgentBrain {
+  let calls = 0;
+  return {
+    async nextAction() {
+      calls++;
+      if (calls === 1) return { action: 'assert' as const, reasoning: 'check', expectation: 'signed in' };
+      return { action: 'fail' as const, reasoning: 'should never be requested' };
+    },
+    async judge() {
+      return { pass: true, reason: 'signed-in indicator visible' };
+    },
+  };
+}
+
 let dir: string;
 
 beforeEach(async () => {
@@ -118,6 +137,18 @@ describe('authenticate: steps strategy', () => {
         ),
       ),
     ).rejects.toThrow(/could not be verified/);
+  });
+
+  it('does not abort with AuthError when the login journey ends on a passing assertion', async () => {
+    // Single-step journey: if the executor still `continue`d past a passing
+    // assertion, this step's second nextAction call would return `fail` and
+    // authenticate() would raise AuthError, aborting the whole run before a
+    // single test executes — no score, no report (blast radius per proposal).
+    const session = await authenticate(
+      options({ steps: ['assert a signed-in indicator is visible'], cache: false }, assertThenFailBrain()),
+    );
+
+    expect(session.storageState).toEqual(CAPTURED);
   });
 
   it('keeps a substituted password out of the error message', async () => {

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -259,24 +259,55 @@ describe('executeTest', () => {
     expect(result.steps[0]?.failedAttempts).toBe(1);
   });
 
-  it('handles assert: pass continues, repeated failures fail the step', async () => {
+  it('terminates the step on a passing assertion: an offered fail is never requested', async () => {
     const page = new FakePage();
-    const passing = scriptedBrain(
-      [{ action: 'assert', reasoning: 'check', expectation: 'total is $80' }, { action: 'done', reasoning: 'ok' }],
+    // The second scripted action would fail the step if it were ever asked for.
+    // Regression for the defect: a passing assertion used to `continue` the loop,
+    // giving the model a further turn in which it could contradict its own pass.
+    const brain = scriptedBrain(
+      [
+        { action: 'assert', reasoning: 'check', expectation: 'total is $80' },
+        { action: 'fail', reasoning: 'should never be requested' },
+      ],
       [{ pass: true, reason: 'total shows $80' }],
     );
-    const okResult = await executeTest(page, makeTest(), {
-      brain: passing,
+
+    const result = await executeTest(page, makeTest(), {
+      brain,
       sessionDir,
       baseUrl: 'http://x.test',
       snapshot: async () => 'snap',
     });
-    expect(okResult.status).toBe('passed');
 
+    expect(result.status).toBe('passed');
+    expect(result.steps[0]?.status).toBe('passed');
+  });
+
+  it('makes no further nextAction call once an assertion passes (design D3: the economic claim)', async () => {
+    const page = new FakePage();
+    const brain = scriptedBrain(
+      [{ action: 'assert', reasoning: 'check', expectation: 'total is $80' }],
+      [{ pass: true, reason: 'total shows $80' }],
+    );
+
+    const result = await executeTest(page, makeTest(), {
+      brain,
+      sessionDir,
+      baseUrl: 'http://x.test',
+      snapshot: async () => 'snap',
+    });
+
+    expect(result.status).toBe('passed');
+    expect(brain.calls).toBe(1);
+  });
+
+  it('retries a failing assertion to the budget and then fails the step, unchanged', async () => {
+    const page = new FakePage();
     const failing = scriptedBrain(
       Array(3).fill({ action: 'assert', reasoning: 'check', expectation: 'total is $80' }),
       Array(3).fill({ pass: false, reason: 'no total rendered' }),
     );
+
     const failResult = await executeTest(page, makeTest(), {
       brain: failing,
       sessionDir,
@@ -284,8 +315,10 @@ describe('executeTest', () => {
       maxRetries: 3,
       snapshot: async () => 'snap',
     });
+
     expect(failResult.status).toBe('failed');
     expect(failResult.reason).toContain('no total rendered');
+    expect(failResult.steps[0]?.failedAttempts).toBe(3);
   });
 
   it('aborts a step that exceeds the iteration cap', async () => {


### PR DESCRIPTION
Closes #15.

A passing assertion did not end the step. The executor recorded the pass and looped, so the model got another turn — and `fail` was still legal on it. It could fail a step it had just proved succeeded, reasoning correctly that the action could no longer be performed and incorrectly that this meant failure.

`src/runner/executor.ts`, one line: `continue` → `break`. The failing-assertion path (retry within budget, then `StepFailure`) is unchanged.

## Measured

| | before (`main`) | after (this branch) |
|---|---|---|
| useful runs | 20 | 20 |
| product failures | 3 | **0** |
| rate | **15%** | **0%** |

Under the old rate, twenty consecutive clean runs would occur about 3.9% of the time.

Ten further dispatches are excluded from the denominator rather than counted as passes: they failed on exhausted LLM provider credits, every one dying at the first step without reaching a passing assertion. Conversely, all three baseline failures were verified to be this defect and not credit, so the comparison holds at both ends.

## Why twenty green runs are not the whole argument

A clean sample can be luck, so the mechanism was confirmed independently:

- the three new regression tests fail against the old code and pass against the new, verified by reverting `break` to `continue` in a throwaway copy — a regression test that passes both before and after proves nothing
- the production trace changed from `asserts=1..3, dones=1` per step to `asserts=1, dones=0`; one step that previously spent three judge calls plus a `done` now spends one

## The alternative that was rejected

Issue #15 originally preferred downgrading a later `fail` to `done` when an earlier assertion had passed. That is dangerous and was dropped. An assertion proves its own expectation, not the whole step; if an intermediate expectation passes and the step then genuinely breaks, the downgrade yields a false PASS — a gate approving broken code, worse than the defect being fixed. Terminating on the first pass was adopted instead, and the evidence supports it: across the observed runs, no step ever used a second assertion to check a *different* condition.

## Side effect

Removing the redundant turn cuts a meaningful share of the model calls per run, so this is cheaper and faster as well as correct.

251 tests green across 22 files. Change artifacts under `openspec/changes/assertion-ends-step/`; the spec sync happens at archive.
