### PR TITLE
feat: bound a run by model calls, tokens and wall-clock time

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -16,6 +16,14 @@ on:
     # manual dispatch re-arms them.
     - cron: '0 6 * * 1'
   workflow_dispatch:
+    inputs:
+      max_llm_calls:
+        # Left empty the run is unbounded, which is also the scheduled behaviour.
+        # `applyEnvOverrides` skips an empty variable, so passing it through
+        # unconditionally cannot make an unbounded run accidentally bounded.
+        description: 'Optional model-call ceiling for this run (empty = unbounded)'
+        required: false
+        default: ''
 
 concurrency:
   group: dogfood
@@ -35,6 +43,7 @@ jobs:
       BLASTPROOF_LLM_MODEL: anthropic/claude-haiku-4.5
       BLASTPROOF_LLM_BASE_URL: https://openrouter.ai/api/v1
       BLASTPROOF_LLM_API_KEY_ENV: OPENROUTER_API_KEY
+      BLASTPROOF_MAX_LLM_CALLS: ${{ inputs.max_llm_calls }}
 
     steps:
       - uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Pipeline: `git diff → impact mapping → test generation → agentic execution
 | CI integration | ✅ published to npm and a composite GitHub Action; PR comments still post-MVP |
 | Authentication | ✅ sign in once per run — login journey, captured session, or static headers/cookies |
 | Unclassified-change gate | ✅ `ignore:` globs + `--fail-on-unmapped` for files whose blast radius nobody declared |
+| Run budget & deadline | ✅ optional `budget:` (calls/tokens/duration) + matching flags; exhaustion stops the run as **incomplete**, never as a failed test — exits 1 regardless of `--min-score` |
 | SaaS backend, credits, dashboards | ❌ never — local-first BYOK |
 | VS Code extension, Flutter, session replay | ❌ post-MVP |
 
@@ -56,6 +57,7 @@ src/
     selection.ts    # tag/priority/query filters + impacted selection
     testfile.ts     # YAML test discovery and validation
     env.ts          # {{env.*}} substitution + secret masking
+    budget.ts       # run-wide call/token/deadline budget + dry-run ceiling
   llm/
     provider.ts     # AI SDK provider factory (anthropic|openai|ollama)
     prompts.ts      # system/user prompts for plan + execute + assert
@@ -76,6 +78,7 @@ src/
 - Secrets never enter a prompt: `{{env.*}}` placeholders survive to action time and are substituted immediately before use. Values are also masked in reports.
 - The agent may not navigate outside `base_url`'s origin plus any declared `allowed_origins`. Enforced in `actions.ts`, not by prompt wording.
 - Never log secrets; `{{env.*}}` values are masked in reports. A captured auth session is a live credential: git-ignored, never printed, never embedded in a report
+- A run's budget (calls/tokens/deadline, optional `budget:` in config) is a run-wide guarantee enforced at the single choke point every model call passes through — `createBrain`/`createPlanner` in `llm/brain.ts` — the same shape and the same reason as the secrets mask above: a guarantee implemented at a call site instead of over the whole scope is this codebase's recurring defect (it produced the secret leaks, and it produced #15). Exhausting it ends the run as **incomplete**, never as a failed test — see `openspec/changes/archive/run-budget-and-deadline` (once archived) for the reasoning
 
 ## Where the work comes from
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ while it is pre-1.0, a minor bump may change existing behaviour and a patch neve
 
 ## [Unreleased]
 
+### Added
+- **A run can now be bounded by a budget and a deadline.** Optional config section `budget:`
+  (`max_llm_calls`, `max_tokens`, `max_duration_s`) plus matching flags `--max-llm-calls`,
+  `--max-tokens`, `--max-duration`, and `BLASTPROOF_MAX_*` environment overrides (precedence
+  flag > env > file, same as every other setting) — on `run`, `plan`, and `test` alike, since the
+  spec counts "agent action, assert judgment, or test planning" against one budget and `plan` makes
+  model calls too. Enforced at the single choke point every model call already passes through
+  (`createBrain`/`createPlanner`), so it is total by construction — agent actions, assert judgments
+  and the planner are all counted. `test` composes `run` then `plan`; the two phases share one budget
+  instance rather than each resolving its own, so the pipeline stays bounded by the configured
+  maximum instead of up to double it. Exhausting it stops the run and reports it as **incomplete**:
+  unexecuted tests are a new `not-run` state, excluded from the score entirely rather than counted as
+  failures, and the process exits 1 unconditionally, even when the executed tests would satisfy
+  `--min-score`. `run --dry-run` now also prints the worst-case model-call ceiling for the selection,
+  labelled as a maximum, not a forecast: per step this is the iteration cap **plus** the configured
+  `max_retries_per_step` (read from config, not assumed — it has no upper bound), because a malformed
+  model response is retried without spending an iteration, so the two pools are independent and must
+  be added rather than one doubled while the other is ignored; and it includes the login journey's
+  steps when `auth.steps` is configured, since authentication spends model calls through the same loop
+  before any test runs. Absent config and flags, nothing binds and behaviour is unchanged — motivated
+  by measuring #15's flake rate exhausting a provider's credit mid-sequence with no partial accounting
+  and no warning.
+
 ### Fixed
 - A step whose `assert` judgment passed did not end the step: the executor recorded the pass and
   looped for another action, and `fail` was still legal on that extra turn — so the model could, and

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -1,0 +1,46 @@
+# Defects
+
+## DEF-001 — Dry-run ceiling (`estimateMaxModelCalls`) can undershoot the true worst-case call count
+- Status: CLOSED
+- Severity: HIGH (breaks a requirement)
+- Found by: qa
+- Steps: numbered, from a clean state, with exact commands
+  1. In `/home/heitor/blastproof`, note two constants that determine one test step's real worst-case model-call count in `src/runner/executor.ts`:
+     - `DEFAULT_MAX_ITERATIONS_PER_STEP = 15` (`N`), hardcoded, not configurable anywhere (no CLI flag, no config field).
+     - `config.max_retries_per_step` (`R`), a user-configurable value in `.blastproof/config.yaml` (`z.number().int().min(1)`, default 3, **no upper bound**, and not required to relate to `N` in any way).
+  2. In `src/runner/executor.ts`'s per-step loop (`executeTest`), a malformed/invalid model response (`brain.nextAction` throwing) increments `failedAttempts` (the retry budget, capped at `R`) but does **not** increment `iterations` (the cap checked against `N`). A failing `assert` judgment increments both `iterations` and `failedAttempts` and costs two real model calls (`nextAction` + `judge`). This means the real worst-case number of model calls for one step is `N + R`, not `2N` as `estimateMaxModelCalls` (`src/runner/budget.ts`) computes (`totalSteps * maxIterationsPerStep * 2`).
+  3. `2N > N + R` only holds while `R <= N` (true only for the *default* `max_retries_per_step: 3` vs. the fixed `N=15`). Setting `max_retries_per_step` above 15 in config — a perfectly legal value per the zod schema — makes `N + R > 2N`, i.e. the real ceiling exceeds the reported one.
+  4. Reproduced empirically (script run outside the repo, against unmodified `src/runner/executor.ts` and `src/runner/budget.ts`, no product code edited): a single-step test executed via `executeTest` with `maxIterationsPerStep = 15` and `maxRetries = 20`, driven by a scripted brain that (a) returns malformed output `R-1=19` times, (b) then returns `N-1=14` plain successful actions, (c) then one `assert` action whose judgment always fails (the step's final, terminating call) — produced **35** real model calls (34 `nextAction` + 1 `judge`), while `estimateMaxModelCalls([{steps:['single step']}], 15)` reports a ceiling of **30**.
+- Expected: per spec `run-budget`, "Scenario: Estimate is an upper bound, not a prediction" — the dry-run number must be "the ceiling the selection cannot exceed" (design D5). A real run must never spend more model calls than the number `--dry-run` reported.
+- Actual: with a legal (if unusual) `max_retries_per_step` value greater than the fixed 15-iteration cap, a real run can spend more model calls than the reported ceiling — the estimate undershoots, which design D5 and the task itself single out as strictly worse than reporting no ceiling at all ("an estimate that undershoots is worse than none").
+- Evidence: empirical repro script executed via `npx tsx` against the unmodified `src/runner/executor.ts` / `src/runner/budget.ts` (script and its output not persisted in the repo, per QA's read-only scope; output captured below):
+  ```
+  N (maxIterationsPerStep, fixed default) = 15
+  R (config.max_retries_per_step, user-configurable, e.g. 20) = 20
+  step status: failed / reason: forced failure to consume the last retry unit
+  nextAction calls: 34
+  judge calls: 1
+  TOTAL real model calls made: 35
+  estimateMaxModelCalls() ceiling for this 1-step test: 30
+  DEFECT CONFIRMED: real calls (35) EXCEED the reported ceiling (30)
+  ```
+  Formula for anyone who wants to reproduce without the script: true per-step worst case is `maxIterationsPerStep + max_retries_per_step` (not `maxIterationsPerStep * 2`); the two diverge, in the estimate's favor being wrong, exactly when `max_retries_per_step > maxIterationsPerStep` (i.e. > 15, since `maxIterationsPerStep` has no config/flag and is fixed at `DEFAULT_MAX_ITERATIONS_PER_STEP`).
+- History: 2026-07-29 filed by qa
+- History: 2026-07-29, dev: changed `estimateMaxModelCalls` (`src/runner/budget.ts`) from `totalSteps * maxIterationsPerStep * 2` to `totalSteps * (maxIterationsPerStep + maxRetriesPerStep)`, matching the `N + R` formula this report derived; `maxRetriesPerStep` is now a required parameter read from `config.max_retries_per_step` at the one call site (`src/commands/run.ts`'s `printDryRun`) instead of being unstated/assumed. Also included `auth.steps`' step count in the ceiling when a login journey is configured, since `authenticate()` spends model calls through the same `executeTest` loop before any test runs and was previously excluded — README/CHANGELOG updated to say so. Added a regression test (`tests/budget.test.ts`, "DEF-001 regression") that drives the real executor adversarially with `R > N` and asserts the ceiling is `>=` (in fact exactly equal to) the actual call count; updated `tests/run.test.ts`'s dry-run expectations to the new numbers and added a case covering the auth-journey inclusion. Left for qa to verify and close.
+- History: 2026-07-29, qa: retested and CLOSED.
+  - Re-derived the bound independently via LP over the three ways a model call can spend against the two budgets (standalone malformed retry, plain successful action, failing/passing assert) and got exactly `N + R` in every regime, including the "N-1 failing asserts + 1 passing assert" boundary the dev flagged — confirmed that scenario only reaches `2N` calls when `R >= N`, at which point `N + R = 2N`, so it never exceeds the new ceiling.
+  - Empirically drove the real, unmodified `executeTest` (no product code edited) adversarially across 7 `(N, R)` pairs spanning `R > N`, `R < N`, `R == N`, `R == 1`, and `N == R == 1`, using the LP-optimal schedule for each regime (script: `/tmp/claude-.../scratchpad/verify-def001.mts`, not part of the repo). Result: actual calls equalled `N + R` exactly in all 7 cases (tight, not just bounded), and the old `2N` formula was violated in exactly the 3 cases where `R > N` (matching the DEF-001 repro), never in the other 4 — confirming `N + R` is a genuine, regime-independent upper bound and not a formula that merely happens to fit the one case tested.
+    ```
+    N=1  R=1   actual=2   new(N+R)=2   HOLDS   old(2N)=2   holds   tight=true
+    N=3  R=5   actual=8   new(N+R)=8   HOLDS   old(2N)=6   VIOLATED tight=true
+    N=5  R=5   actual=10  new(N+R)=10  HOLDS   old(2N)=10  holds   tight=true
+    N=1  R=20  actual=21  new(N+R)=21  HOLDS   old(2N)=2   VIOLATED tight=true
+    N=15 R=20  actual=35  new(N+R)=35  HOLDS   old(2N)=30  VIOLATED tight=true
+    N=15 R=3   actual=18  new(N+R)=18  HOLDS   old(2N)=30  holds   tight=true
+    N=15 R=1   actual=16  new(N+R)=16  HOLDS   old(2N)=30  holds   tight=true
+    ```
+  - Confirmed `tests/budget.test.ts`'s "DEF-001 regression" test (N=3, R=5) would genuinely fail against the old formula: it asserts `ceiling >= actualCalls`, and old-formula `ceiling = totalSteps * N * 2 = 6 < actualCalls = 8` — a real, non-vacuous regression guard, not one that passes either way. Verified by inline computation against the unmodified `executeTest` (see table above, same N=3/R=5 row), without editing `src/runner/budget.ts`, per QA's read-only scope on product code.
+  - Confirmed auth inclusion is correct: `src/config.ts`'s `authSchema` enforces exactly one of `steps` / `storage_state` / `headers`+`cookies` (mutually exclusive, `superRefine`), so `config.auth?.steps` being non-empty in `printDryRun` correctly predicts that `authenticate()` (`src/auth.ts`) will take the `fromSteps` branch, the only one that calls `executeTest` and spends model calls — `fromStorageState`/`fromStatic` spend zero. The printed `", including the login journey"` suffix appears exactly when `auth.steps` is configured, never otherwise, so it never overclaims coverage. (Note: `auth.cache` with a valid cached session skips `fromSteps` even when `steps` is configured, making the ceiling an overcount in that case — safe, since a ceiling may overcount, never undercount.)
+  - `grep` confirms `estimateMaxModelCalls` has exactly one call site (`src/commands/run.ts`'s `printDryRun`); `src/commands/plan.ts` and `src/commands/test.ts` don't call it directly (`test.ts` composes `runCommand`, going through the same fixed path). `runOne` passes `maxRetries: config.max_retries_per_step` to `executeTest` and no `maxIterationsPerStep` (so it defaults to `DEFAULT_MAX_ITERATIONS_PER_STEP`), matching exactly what `printDryRun` estimates against — no CLI flag or env var overrides `max_retries_per_step` outside `loadConfig`'s merge, so there is no path where a real run's caps diverge from what was printed. `grep` for the old `* 2` formula found no stale references anywhere in `src/` or the docs.
+  - Verification suite: `npm run build` — success (tsup, ESM, no errors). `npm run typecheck` — clean, no output/errors (`tsc --noEmit`). `npm test` — `Test Files 24 passed (24)`, `Tests 311 passed (311)`.
+  - E2E: not run for this defect (it is a pure dry-run/arithmetic check exercised via `executeTest` directly and the existing test suite; local Chromium E2E remains blocked by missing system libs, pre-existing, orthogonal to this defect).

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ steps:
 | `blastproof run --min-score <n>` | Require a weighted score of at least `n` (0–100). **Replaces** the all-must-pass rule — see below |
 | `blastproof run --junit [path]` | Write a JUnit XML report; without a path it lands in `.blastproof/reports/<session>/junit.xml` |
 | `blastproof run --html [path]` | Write a self-contained HTML report with failure screenshots embedded inline |
+| `--max-llm-calls <n>` \| `--max-tokens <n>` \| `--max-duration <seconds>` | Bound `run`, `plan` or `test` by model calls, tokens or wall-clock time — every command that can call the model accepts these. Overrides `.blastproof/config.yaml`'s `budget:` section — see [Bounding a run](#bounding-a-run-budget-and-deadline) |
 | `blastproof test [--base <ref>]` | The full pipeline: run the tests covering the diff, then draft tests for the gaps |
 
 ### The full pipeline: `blastproof test`
@@ -119,7 +120,7 @@ blastproof plan --route /checkout      # bootstrap a route without a diff
 
 Drafts are **previews by default** — nothing touches disk until `--write`, and `--write` never overwrites an existing file, so a regeneration can't silently replace a test you edited by hand. Each written file carries a header recording its route, base ref and generation date. Review before committing: the steps are model-written and meant to be edited.
 
-Exit codes: 0 when every route generated (or nothing needed coverage), 1 when a route failed, 2 on usage/config/diff errors. A route that fails to load never aborts the others.
+Exit codes: 0 when every route generated (or nothing needed coverage), 1 when a route failed or the budget/deadline stopped generation early, 2 on usage/config/diff errors. A route that fails to load never aborts the others; a budget or deadline stop does — see [Bounding a run](#bounding-a-run-budget-and-deadline).
 
 `plan` uses the same `auth:` recipe as `run`, so a route behind a login is drafted from the real page rather than from the login wall.
 
@@ -172,6 +173,48 @@ blastproof run --impacted --base "$BASE_REF" --min-score 80 --junit junit.xml
 ```
 
 Exit 0 merge-able, 1 blocked, 2 usage/config error. The JUnit report carries the score as a `<property name="score">` so a parser can read it without scraping stdout, and tests skipped for having no `routes:` appear as `<skipped/>` cases — the coverage gap shows up in CI instead of vanishing.
+
+## Bounding a run: budget and deadline
+
+Nothing stops a run by default — a suite runs to completion or the provider refuses. `budget:` puts a ceiling on it, in `.blastproof/config.yaml`. It applies to `run`, `plan` and `test` alike: every model call any of them makes — agent action, assert judgment, or test planning — is counted, because a budget that only covered `run` would leave `plan`'s calls unbounded.
+
+```yaml
+budget:
+  max_llm_calls: 500     # stop after this many model calls
+  max_tokens: 2000000    # stop after this many tokens spent across all calls
+  max_duration_s: 900    # stop after this many seconds of wall-clock time
+```
+
+Each limit is independent and optional; a config with no `budget:` section — or a run with none of `--max-llm-calls` / `--max-tokens` / `--max-duration` — behaves exactly as before. All three are counted in **calls and tokens, not currency**: a price table keyed by model and provider goes stale the day a provider reprices, and a limit that silently stops meaning what it says is worse than no limit, because it is trusted. Calls and tokens are exact, already reported by every provider, and yours to convert to a dollar figure with your own rates if you want one.
+
+`--dry-run` reports the ceiling before you spend anything — the worst case a selection could cost, computed from step counts alone, no provider contacted:
+
+```
+Dry run: 12 test(s) selected, base_url=http://localhost:4173
+Worst case: up to 216 model call(s) for this selection (a maximum, not a prediction).
+```
+
+That number is a ceiling, not a forecast — a real run almost always finishes in a fraction of it, because most steps complete long before either cap runs out. Per step it is the iteration cap **plus** `max_retries_per_step` (read from your config, not assumed): a malformed model response is retried without spending an iteration, and a failing `assert` spends a retry *and* an iteration in the same call — so the two caps are added, not one doubled and the other ignored. If `auth.steps` is configured, the login journey's steps are counted too — it runs once before any test and spends model calls through the same loop, so a ceiling that excluded it could be exceeded by the very first run that logs in.
+
+**Exhausting a budget stops the run — it does not fail a test.** Running out of quota says nothing about the application under test, so recording it as a failure would manufacture a defect that does not exist. Tests the run never reached are reported as **not run**, a third state distinct from passed and failed, and excluded from the score's denominator entirely — counting them as failures would just be a quieter version of the same lie a false pass would have been.
+
+An interrupted run is unmistakably incomplete: the process **exits 1 unconditionally**, even when `--min-score` is given and the tests that did execute would have satisfied it. The tests that finished are whichever ones happened to run first, not a representative sample, so nothing about them is a verdict:
+
+```
+Run incomplete: model call budget exhausted: reached the configured maximum of 500 call(s)
+Score over executed tests: 92 (not a verdict — exit code 1 regardless of --min-score)
+```
+
+Both the JUnit and HTML reports carry the same signal: unexecuted tests appear as `<skipped/>` cases naming the limit, distinct from `<failure>` cases, and the HTML report leads with a banner stating the run was stopped and why.
+
+Like the LLM provider settings, every field overrides from the environment (`BLASTPROOF_MAX_LLM_CALLS`, `BLASTPROOF_MAX_TOKENS`, `BLASTPROOF_MAX_DURATION_S`), and a CLI flag beats both:
+
+```bash
+blastproof run --impacted --max-llm-calls 200 --max-duration 300
+blastproof plan --max-llm-calls 200
+```
+
+`blastproof test` composes `run` then `plan` in one process. It resolves the budget once and hands the same instance to both phases, so the pipeline stays within the configured maximum overall — not up to double it, which is what each phase resolving its own budget would silently allow.
 
 ## blastproof tests itself
 
@@ -339,6 +382,9 @@ You never have to commit a provider choice just to configure a pipeline. These v
 | `BLASTPROOF_LLM_MODEL` | the model name |
 | `BLASTPROOF_LLM_BASE_URL` | the provider endpoint — *not* the app |
 | `BLASTPROOF_LLM_API_KEY_ENV` | the **name** of the variable holding your key |
+| `BLASTPROOF_MAX_LLM_CALLS` | `budget.max_llm_calls` — see [Bounding a run](#bounding-a-run-budget-and-deadline) |
+| `BLASTPROOF_MAX_TOKENS` | `budget.max_tokens` |
+| `BLASTPROOF_MAX_DURATION_S` | `budget.max_duration_s`, in seconds |
 
 Running the committed config against an OpenAI-compatible gateway, without editing a file:
 

--- a/openspec/changes/run-budget-and-deadline/.openspec.yaml
+++ b/openspec/changes/run-budget-and-deadline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/run-budget-and-deadline/design.md
+++ b/openspec/changes/run-budget-and-deadline/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Nothing bounds a run. `runCommand` loops over the selection, `executeTest` spends up to `maxIterationsPerStep` model round-trips per step, and no counter exists anywhere. The AI SDK returns `usage` on every call in `src/llm/brain.ts`; we discard it.
+
+This is not a theoretical exposure. Measuring #15 exhausted the provider's credit mid-sequence, and ten runs then died at the first step with `requires more credits`. The failure mode arrived from outside, in the least useful form: partway through, with no partial accounting and no warning.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A run cannot spend without limit, and the limit is enforced where every call already passes.
+- An interrupted run is unmistakably incomplete, in the exit code and in both reports.
+- The ceiling of a selection is knowable before spending anything.
+
+**Non-Goals:**
+- Worker parallelism. Different change, different risks; #2 stays open for it.
+- Currency. See D1.
+- Per-test or per-step budgets — the run is the unit that has to survive.
+- Provider retry or backoff.
+
+## Decisions
+
+**D1 — The budget counts calls and tokens, not money.**
+
+Denominating in dollars requires a price table keyed by model and provider. It would be wrong the day a provider changes pricing, wrong for anyone routing through a gateway, and wrong in a way nobody notices until the cap fails to bind. A limit that silently stops meaning what it says is worse than no limit, because it is trusted.
+
+Calls and tokens are exact, already reported, and provider-agnostic. Someone who wants a dollar figure can compute it from their own rates, with numbers that are actually true. Rejected: a built-in price table; an estimate-only warning with no enforcement.
+
+**D2 — Enforcement lives in `createBrain`, not at the call sites.**
+
+Every model call in the product — agent action, assert judgment, planner — goes through the `generate` wrapper in `src/llm/brain.ts`. The budget wraps that one function and is therefore total by construction: a future command that starts prompting cannot forget to be counted.
+
+This is deliberately the same shape as the run-wide secrets mask, and for the same reason. The recurring defect in this codebase has been implementing a guarantee at a call site instead of defining it over a scope — it produced three rounds of secret leaks, and it produced #15. A budget checked in `runCommand`'s loop would miss the planner and every future caller.
+
+**D3 — Exhaustion ends the run; it does not fail a test.**
+
+A budget stop says nothing about the application under test. Recording it as a step failure would manufacture a defect that does not exist, and a red test that means "we ran out of quota" is worse than useless in review.
+
+So exhaustion raises a distinct condition that unwinds the run, and unexecuted tests are recorded as **not run** — a third state, separate from passed and failed.
+
+**D4 — An incomplete run can never report success, and `--min-score` does not override it.**
+
+The tests that finished are a biased sample: they are the ones that came first, not the ones that mattered. Scoring on them and passing the gate would be a false green produced by running out of money.
+
+This is the same reasoning that rejected the `fail`-to-`done` downgrade in `assertion-ends-step`: a gate that approves on incomplete evidence is worse than one that blocks. So an incomplete run exits non-zero unconditionally, and the threshold does not apply.
+
+**D5 — The dry-run estimate is a ceiling, not a forecast.**
+
+Worst case is computable exactly: steps × the per-step iteration ceiling, plus judgments. A predicted average would require usage history we do not have and would be wrong per app. A ceiling is honest, deterministic, and is the number someone sizing a budget actually needs. It must be labelled as the maximum, or it will be read as an estimate and mistrusted when the real run costs a fraction of it.
+
+## Risks / Trade-offs
+
+- **The token count trails by one call** — tokens are known only after a call returns, so the last call can cross the line. Mitigation: check before each call and stop when the *next* call could exceed; accept overshoot bounded by one call. Documented rather than hidden.
+- **A budget set too low turns a healthy suite red** → mitigation: the message names the limit and the observed count, and `--dry-run` reports the ceiling so the number can be chosen from evidence rather than guessed.
+- **`not run` is a third state and touches both reports plus scoring** → this is the bulk of the work and the likeliest place for a defect. Scoring must exclude unexecuted tests from the denominator rather than treat them as failures, or the score becomes a second, quieter lie.
+- **Wall-clock checks are not preemptive** — a single hung page action can exceed the deadline. Playwright's own timeouts bound that; the deadline is checked between calls and between tests, not by interrupting in-flight work.
+
+## Migration Plan
+
+Additive and inert by default: absent config and flags, no limit binds and existing suites behave exactly as now. Rollback is reverting.
+
+Verification cannot be unit tests alone, given #15's lesson. Closure requires a dogfood run with a deliberately tiny budget, confirming the run stops, exits 1, reports incomplete, and names the limit — plus an ordinary run confirming an unconfigured budget still does not bind.
+
+## Open Questions
+
+- Should a warning appear as the budget nears exhaustion (say 80%), or only at the stop? Leaning toward only at the stop for now: a warning nobody can act on mid-run is noise, and CI logs are read after the fact.

--- a/openspec/changes/run-budget-and-deadline/proposal.md
+++ b/openspec/changes/run-budget-and-deadline/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+A run has no upper bound. `runCommand` loops over the selected tests, each step spends up to `maxIterationsPerStep` model round-trips, and nothing counts, caps or estimates any of it. The only thing that stops a run is finishing — or the provider refusing.
+
+That is not hypothetical. Measuring the flake rate for #15 exhausted the provider's credit mid-sequence; ten runs then died at the first step with `requires more credits`. The tool spent everything it could and discovered the limit from the outside.
+
+An agent that empties an API key with nothing to interrupt it is an adoption risk out of proportion to the work required to bound it.
+
+## What Changes
+
+- A run carries a **budget**: a maximum number of model calls and a maximum number of tokens. Every model call decrements it.
+- A run carries a **deadline**: a maximum wall-clock duration.
+- Exceeding either stops the run immediately and reports it as **incomplete**. It is never scored as though it had finished.
+- `--dry-run` reports the worst-case model-call count for the selection, so the ceiling is knowable before spending anything.
+- New config section and matching CLI flags; absent configuration, behaviour is what it is today (unbounded), so no existing suite changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `run-budget`: bounding a run by model calls, tokens and wall-clock time; the incomplete-run outcome; worst-case estimation before a run.
+
+### Modified Capabilities
+
+- `cli-run-command`: `run` gains budget and deadline flags, a new exit condition, and the estimate in `--dry-run` output.
+- `agentic-execution`: model calls are counted and bounded; exhausting the budget ends the run rather than the step.
+
+## Non-goals
+
+- **Not** worker parallelism. Issue #2 bundles it, and it is a change of a different kind — concurrency, browser context lifecycle, interleaved output, deterministic report ordering. It gets its own proposal; #2 stays open for it.
+- **Not** a budget denominated in currency. See design D1: a price table per model and provider goes stale silently and would make the cap a guess.
+- Not per-test or per-step budgets. The run is the unit that has to be survivable.
+- Not retry or backoff behaviour on provider errors.
+
+## Impact
+
+- `src/llm/brain.ts` — the single point every model call passes through; where counting belongs.
+- `src/config.ts` — new optional `budget` section.
+- `src/commands/run.ts` — seeding the budget, the deadline check between tests, the incomplete outcome, the dry-run estimate.
+- `src/cli.ts` — flags and a distinct exit condition.
+- `src/report/*` — an incomplete run must be visibly incomplete in both reports.
+- No new npm dependency: the AI SDK already returns `usage` on every call and we currently discard it.

--- a/openspec/changes/run-budget-and-deadline/specs/agentic-execution/spec.md
+++ b/openspec/changes/run-budget-and-deadline/specs/agentic-execution/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Per-step agentic loop
+The executor SHALL execute each plain-English step via a loop: capture the page accessibility snapshot, ask the LLM for a structured next action, perform the action on the page, and repeat until the step is complete or failed. A step SHALL be complete when the LLM returns `done` **or** when an `assert` judgment passes; the executor SHALL NOT request a further action once either has occurred. Where a run budget is configured, exhausting it SHALL end the run rather than fail the step, so an exhausted budget is never mistaken for a defect in the application under test.
+
+#### Scenario: Step completes
+- **WHEN** the LLM returns action `done` for a step
+- **THEN** the executor records the step as passed and advances to the next step
+
+#### Scenario: Step completes on a passing assertion
+- **WHEN** an `assert` action's judgment passes
+- **THEN** the executor records the step as passed and advances to the next step, without requesting a further action
+
+#### Scenario: Step fails
+- **WHEN** the LLM returns action `fail` or the retry budget is exhausted
+- **THEN** the executor records the step as failed with the LLM-provided reason, captures a screenshot, and the test is marked failed
+
+#### Scenario: A satisfied step cannot subsequently be failed
+- **WHEN** a step's assertion has passed
+- **THEN** the step is already complete, so no later `fail` can apply to it
+
+#### Scenario: Budget exhausted mid-step
+- **WHEN** the run budget is exhausted while a step is in progress
+- **THEN** the run stops and is reported as incomplete, and the step is recorded as not run rather than as failed

--- a/openspec/changes/run-budget-and-deadline/specs/cli-run-command/spec.md
+++ b/openspec/changes/run-budget-and-deadline/specs/cli-run-command/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Exit codes
+Without `--min-score`, the `run` command SHALL exit with code 0 when all executed tests pass and 1 when any test fails. With `--min-score <n>`, the threshold decides instead: exit 0 when the score is at least `n`, 1 otherwise. A run stopped by its budget or deadline SHALL exit 1 in both modes, since its result is incomplete rather than passing. Exit code 2 is reserved for usage/config errors in all modes.
+
+#### Scenario: Failing test exits 1
+- **WHEN** at least one executed test fails and no threshold was given
+- **THEN** the process exits with code 1 after all tests complete
+
+#### Scenario: Score below threshold exits 1
+- **WHEN** the run is given `--min-score 80` and scores 60
+- **THEN** the process exits with code 1
+
+#### Scenario: Interrupted run exits 1
+- **WHEN** a run is stopped by its budget or deadline, whatever the executed tests scored
+- **THEN** the process exits with code 1
+
+#### Scenario: Missing config exits 2
+- **WHEN** `blastproof run` executes in a directory without `.blastproof/config.yaml`
+- **THEN** the CLI exits with code 2 and an actionable error message
+
+### Requirement: Dry run
+The `run` command SHALL support `--dry-run`, printing the impacted selection (affected routes, unmapped files, selected and skipped tests) and the worst-case model-call count for that selection, without launching a browser or calling the LLM, exiting with code 0.
+
+#### Scenario: Dry run output
+- **WHEN** the user runs `blastproof run --impacted --dry-run`
+- **THEN** the console shows affected routes, unmapped files and the tests that would run, and no browser is launched
+
+#### Scenario: Dry run reports the ceiling
+- **WHEN** a dry run reports its selection
+- **THEN** it also reports the maximum number of model calls that selection could make
+
+## ADDED Requirements
+
+### Requirement: Budget and deadline flags
+The `run` command SHALL accept `--max-llm-calls <n>`, `--max-tokens <n>` and `--max-duration <seconds>`, each overriding the corresponding config value. A non-positive or non-numeric value SHALL be a usage error.
+
+#### Scenario: Flag overrides config
+- **WHEN** the config sets a maximum of 500 model calls and the run is given `--max-llm-calls 100`
+- **THEN** the run is bounded at 100
+
+#### Scenario: Invalid limit
+- **WHEN** the run is given `--max-llm-calls 0` or a non-numeric value
+- **THEN** the CLI exits with code 2 and an actionable message

--- a/openspec/changes/run-budget-and-deadline/specs/run-budget/spec.md
+++ b/openspec/changes/run-budget-and-deadline/specs/run-budget/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: A run is bounded by model calls, tokens and wall-clock time
+A run SHALL carry a budget of a maximum number of model calls and a maximum number of tokens, and a deadline of a maximum wall-clock duration. Each SHALL be optional and independently configurable; an unconfigured limit SHALL NOT bound the run. Every model call made anywhere in the run — agent action, assert judgment, or test planning — SHALL count against the budget.
+
+#### Scenario: Call budget exhausted
+- **WHEN** a run configured with a maximum of 200 model calls attempts the 201st
+- **THEN** the call is not made, the run stops, and the reason names the limit that was reached
+
+#### Scenario: Token budget exhausted
+- **WHEN** the tokens reported by completed calls reach the configured maximum
+- **THEN** the run stops before the next call and the reason names the limit that was reached
+
+#### Scenario: Deadline reached
+- **WHEN** the configured wall-clock duration elapses
+- **THEN** the run stops at the next check point and the reason names the elapsed limit
+
+#### Scenario: No budget configured
+- **WHEN** no budget or deadline is configured
+- **THEN** the run proceeds without any limit, as it does today
+
+### Requirement: An interrupted run is reported as incomplete, never scored as finished
+A run stopped by its budget or deadline SHALL be reported as incomplete. The tests that did not execute SHALL NOT be counted as passing, the run SHALL NOT report a passing outcome on the strength of the tests that happened to finish first, and the process SHALL exit non-zero regardless of any `--min-score` threshold.
+
+#### Scenario: Partial run does not report success
+- **WHEN** a run of ten tests is stopped by its budget after six, all six having passed
+- **THEN** the outcome is incomplete, the four unexecuted tests are reported as not run, and the process exits non-zero
+
+#### Scenario: Threshold does not rescue an incomplete run
+- **WHEN** an incomplete run's executed tests would satisfy `--min-score`
+- **THEN** the threshold does not apply and the process still exits non-zero
+
+#### Scenario: Reports mark the run incomplete
+- **WHEN** an incomplete run writes a JUnit or HTML report
+- **THEN** both state that the run was stopped, name the limit reached, and distinguish unexecuted tests from failed ones
+
+### Requirement: The worst case is knowable before spending anything
+The `run` command SHALL be able to report the maximum number of model calls a selection could make, derived from the step counts and the per-step iteration ceiling, without contacting a provider.
+
+#### Scenario: Estimate in a dry run
+- **WHEN** the user runs `blastproof run --impacted --dry-run`
+- **THEN** the output includes the worst-case model-call count for the selected tests, alongside the selection itself
+
+#### Scenario: Estimate is an upper bound, not a prediction
+- **WHEN** the estimate is reported
+- **THEN** it is presented as the ceiling the selection cannot exceed, not as an expected cost

--- a/openspec/changes/run-budget-and-deadline/tasks.md
+++ b/openspec/changes/run-budget-and-deadline/tasks.md
@@ -41,12 +41,14 @@
 ## 7. Verification
 
 - [x] 7.1 `npm run build`, typecheck, full vitest suite green.
-- [ ] 7.2 Dogfood with a deliberately tiny budget: the run stops, exits 1, reports incomplete, and names the limit.
-- [ ] 7.3 Dogfood with no budget configured: unchanged behaviour, score 100, exit 0. An inert default that turns out not to be inert is the worst outcome of this change.
+- [x] 7.2 Dogfood with a deliberately tiny budget: the run stops, exits 1, reports incomplete, and names the limit.
+  - Verified on `fix/run-budget-and-deadline`, run `30473778580` with `max_llm_calls=20`: 1 passed, 4 not run, `Run incomplete: model call budget exhausted: reached the configured maximum of 20 call(s)`, `Score over executed tests: 100 (not a verdict — exit code 1 regardless of --min-score)`, exit 1.
+- [x] 7.3 Dogfood with no budget configured: unchanged behaviour, score 100, exit 0. An inert default that turns out not to be inert is the worst outcome of this change.
+  - Verified on the same branch, run `30473914460` with no budget: `Score: 100 — min-score 80: pass`, 5 passed 0 failed, no incomplete or not-run output, exit 0. The default is genuinely inert.
 
 ## 8. Documentation
 
 - [x] 8.1 README: the budget section, what an incomplete run means, and that limits are counted in calls and tokens rather than currency, with the reason.
 - [x] 8.2 `AGENTS.md`: note the budget as a run-wide guarantee enforced at the brain, alongside the mask.
 - [x] 8.3 CHANGELOG entry under Unreleased.
-- [ ] 8.4 Update issue #2 to record that the budget and deadline half is done and that it stays open for worker parallelism.
+- [x] 8.4 Update issue #2 to record that the budget and deadline half is done and that it stays open for worker parallelism.

--- a/openspec/changes/run-budget-and-deadline/tasks.md
+++ b/openspec/changes/run-budget-and-deadline/tasks.md
@@ -1,0 +1,52 @@
+## 1. The budget itself
+
+- [x] 1.1 Add `src/runner/budget.ts` with a `RunBudget` holding optional `maxCalls`, `maxTokens`, `maxDurationMs`; a `start` timestamp; running counts; a `check()` that raises when the *next* call could exceed a limit; and a `record(usage)` for what a completed call spent.
+- [x] 1.2 Add a distinct `BudgetExhaustedError` carrying which limit was reached and the observed counts, so callers can tell it apart from a step failure.
+- [x] 1.3 Unit-test each limit independently, the unconfigured case (never binds), and that the message names the limit and the count.
+
+## 2. Enforcement at the single choke point
+
+- [x] 2.1 In `src/llm/brain.ts`, accept an optional budget and wrap the `generate` call: `check()` before, `record()` after, using the `usage` the AI SDK already returns and we currently discard. Both `createBrain` and the planner brain go through it.
+- [x] 2.2 Test that the planner is counted too — a budget that only covered `run` would repeat the class of defect that produced #15 and the secret leaks.
+- [x] 2.3 Test that a call which would exceed the budget is never issued, rather than issued and then rejected.
+
+## 3. Configuration and flags
+
+- [x] 3.1 Add an optional `budget` section to `src/config.ts` (`max_llm_calls`, `max_tokens`, `max_duration_s`), all optional, absent meaning unbounded.
+- [x] 3.2 Add `--max-llm-calls`, `--max-tokens`, `--max-duration` in `src/cli.ts`, overriding config; non-positive or non-numeric is `EXIT_USAGE`.
+- [x] 3.3 Wire into `ENV_OVERRIDES` for consistency with the existing precedence (flag > env > file).
+- [x] 3.4 Tests for precedence and for the invalid-value path.
+
+## 4. The incomplete outcome
+
+- [x] 4.1 Introduce `not run` as a third test state, distinct from passed and failed, for tests the run never reached.
+- [x] 4.2 In `src/commands/run.ts`, catch `BudgetExhaustedError`, stop the run, mark the remaining selection as not run, and check the deadline between tests as well as between calls.
+- [x] 4.3 Make an incomplete run exit 1 unconditionally, including when `--min-score` is given and the executed tests would satisfy it.
+- [x] 4.4 Exclude unexecuted tests from the score denominator rather than counting them as failures — treating them as failures would replace one lie with a quieter one.
+- [x] 4.5 Tests: partial run does not report success; threshold does not rescue it; score arithmetic over a partial selection.
+
+## 5. Reporting
+
+- [x] 5.1 `src/report/junit.ts`: unexecuted tests as `<skipped/>` with a reason naming the limit, and the run marked incomplete.
+- [x] 5.2 `src/report/html.ts`: a visible banner stating the run was stopped and which limit was reached, with unexecuted tests distinguished from failed ones.
+- [x] 5.3 Console summary states the stop and the limit rather than printing an ordinary score line.
+- [x] 5.4 Tests for all three surfaces.
+
+## 6. The dry-run ceiling
+
+- [x] 6.1 Compute the worst-case model-call count for a selection: steps times the per-step iteration ceiling, plus judgments.
+- [x] 6.2 Print it in `--dry-run`, labelled explicitly as a maximum and not a prediction.
+- [x] 6.3 Test the arithmetic against a known selection.
+
+## 7. Verification
+
+- [x] 7.1 `npm run build`, typecheck, full vitest suite green.
+- [ ] 7.2 Dogfood with a deliberately tiny budget: the run stops, exits 1, reports incomplete, and names the limit.
+- [ ] 7.3 Dogfood with no budget configured: unchanged behaviour, score 100, exit 0. An inert default that turns out not to be inert is the worst outcome of this change.
+
+## 8. Documentation
+
+- [x] 8.1 README: the budget section, what an incomplete run means, and that limits are counted in calls and tokens rather than currency, with the reason.
+- [x] 8.2 `AGENTS.md`: note the budget as a run-wide guarantee enforced at the brain, alongside the mask.
+- [x] 8.3 CHANGELOG entry under Unreleased.
+- [ ] 8.4 Update issue #2 to record that the budget and deadline half is done and that it stays open for worker parallelism.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { AuthConfig } from './config.js';
 import type { AgentBrain } from './llm/brain.js';
 import type { PageLike } from './runner/actions.js';
+import { BudgetExhaustedError } from './runner/budget.js';
 import { SecretsMask, substituteEnv } from './runner/env.js';
 import { defaultSnapshot, executeTest, type ExecutorEvent } from './runner/executor.js';
 
@@ -134,6 +135,10 @@ async function runJourney(
   try {
     return await executeTest(...args);
   } catch (error) {
+    // A budget/deadline stop during login is still a budget stop, not a broken
+    // auth recipe (design D3): the run must end as incomplete, not be reported as
+    // a configuration failure. Let the caller (runCommand) handle it as such.
+    if (error instanceof BudgetExhaustedError) throw error;
     throw new AuthError(
       `Authentication could not run: ${error instanceof Error ? error.message : String(error)}`,
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,28 @@ function parseMinScore(value: string): number {
   return score;
 }
 
+/** `--max-llm-calls`/`--max-tokens`: counts, so non-positive or non-numeric is a usage error. */
+function parsePositiveInt(flag: string): (value: string) => number {
+  return (value: string) => {
+    const n = Number(value);
+    if (!Number.isInteger(n) || n <= 0) {
+      throw new InvalidArgumentError(`${flag} must be a positive integer`);
+    }
+    return n;
+  };
+}
+
+/** `--max-duration`: seconds, so a fractional value is fine, but not zero or negative. */
+function parsePositiveNumber(flag: string): (value: string) => number {
+  return (value: string) => {
+    const n = Number(value);
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new InvalidArgumentError(`${flag} must be a positive number`);
+    }
+    return n;
+  };
+}
+
 const program = new Command();
 
 program
@@ -66,6 +88,21 @@ program
   .option('--junit [path]', 'write a JUnit XML report (default: .blastproof/reports/<session>/junit.xml)')
   .option('--html [path]', 'write a self-contained HTML report (default: .blastproof/reports/<session>/report.html)')
   .option('--fail-on-unmapped', 'fail when a changed file matches no routes: or ignore: glob')
+  .option(
+    '--max-llm-calls <n>',
+    'stop the run after this many model calls, reported as incomplete (overrides config)',
+    parsePositiveInt('--max-llm-calls'),
+  )
+  .option(
+    '--max-tokens <n>',
+    'stop the run after this many tokens spent across all model calls (overrides config)',
+    parsePositiveInt('--max-tokens'),
+  )
+  .option(
+    '--max-duration <seconds>',
+    'stop the run after this many seconds of wall-clock time (overrides config)',
+    parsePositiveNumber('--max-duration'),
+  )
   .action(
     async (options: {
       tag: string[];
@@ -79,6 +116,9 @@ program
       junit?: string | boolean;
       html?: string | boolean;
       failOnUnmapped?: boolean;
+      maxLlmCalls?: number;
+      maxTokens?: number;
+      maxDuration?: number;
     }) => {
       try {
         process.exitCode = await runCommand({
@@ -94,6 +134,9 @@ program
           junit: options.junit,
           html: options.html,
           failOnUnmapped: options.failOnUnmapped,
+          maxLlmCalls: options.maxLlmCalls,
+          maxTokens: options.maxTokens,
+          maxDuration: options.maxDuration,
         });
       } catch (error) {
         console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
@@ -109,20 +152,48 @@ program
   .option('--url <url>', 'override config base_url for this run only (config file untouched)')
   .option('--route <route>', 'generate for this route, bypassing the diff (repeatable)', collect, [])
   .option('--write', 'persist drafts under .blastproof/tests/ instead of previewing them')
-  .action(async (options: { base: string; url?: string; route: string[]; write?: boolean }) => {
-    try {
-      process.exitCode = await planCommand({
-        cwd: process.cwd(),
-        base: options.base,
-        url: options.url,
-        routes: options.route,
-        write: options.write,
-      });
-    } catch (error) {
-      console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
-      process.exitCode = EXIT_USAGE;
-    }
-  });
+  .option(
+    '--max-llm-calls <n>',
+    'stop after this many model calls, reported as incomplete (overrides config)',
+    parsePositiveInt('--max-llm-calls'),
+  )
+  .option(
+    '--max-tokens <n>',
+    'stop after this many tokens spent across all model calls (overrides config)',
+    parsePositiveInt('--max-tokens'),
+  )
+  .option(
+    '--max-duration <seconds>',
+    'stop after this many seconds of wall-clock time (overrides config)',
+    parsePositiveNumber('--max-duration'),
+  )
+  .action(
+    async (options: {
+      base: string;
+      url?: string;
+      route: string[];
+      write?: boolean;
+      maxLlmCalls?: number;
+      maxTokens?: number;
+      maxDuration?: number;
+    }) => {
+      try {
+        process.exitCode = await planCommand({
+          cwd: process.cwd(),
+          base: options.base,
+          url: options.url,
+          routes: options.route,
+          write: options.write,
+          maxLlmCalls: options.maxLlmCalls,
+          maxTokens: options.maxTokens,
+          maxDuration: options.maxDuration,
+        });
+      } catch (error) {
+        console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = EXIT_USAGE;
+      }
+    },
+  );
 
 program
   .command('test')
@@ -138,6 +209,21 @@ program
   .option('--html [path]', 'write a self-contained HTML report (default: .blastproof/reports/<session>/report.html)')
   .option('--write', 'persist generated drafts under .blastproof/tests/ instead of previewing them')
   .option('--fail-on-unmapped', 'fail when a changed file matches no routes: or ignore: glob')
+  .option(
+    '--max-llm-calls <n>',
+    'stop the pipeline after this many model calls, shared by both phases (overrides config)',
+    parsePositiveInt('--max-llm-calls'),
+  )
+  .option(
+    '--max-tokens <n>',
+    'stop the pipeline after this many tokens, shared by both phases (overrides config)',
+    parsePositiveInt('--max-tokens'),
+  )
+  .option(
+    '--max-duration <seconds>',
+    'stop the pipeline after this many seconds of wall-clock time (overrides config)',
+    parsePositiveNumber('--max-duration'),
+  )
   .action(
     async (options: {
       base: string;
@@ -147,6 +233,9 @@ program
       html?: string | boolean;
       write?: boolean;
       failOnUnmapped?: boolean;
+      maxLlmCalls?: number;
+      maxTokens?: number;
+      maxDuration?: number;
     }) => {
       try {
         process.exitCode = await testCommand({
@@ -158,6 +247,9 @@ program
           html: options.html,
           write: options.write,
           failOnUnmapped: options.failOnUnmapped,
+          maxLlmCalls: options.maxLlmCalls,
+          maxTokens: options.maxTokens,
+          maxDuration: options.maxDuration,
         });
       } catch (error) {
         console.error(`error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -15,6 +15,7 @@ import {
   type TestDraft,
 } from '../planner.js';
 import type { PageLike } from '../runner/actions.js';
+import { BudgetExhaustedError, RunBudget } from '../runner/budget.js';
 import type { ExecutorEvent } from '../runner/executor.js';
 import {
   discoverTestFiles,
@@ -24,9 +25,16 @@ import {
   type TestFile,
 } from '../runner/testfile.js';
 import { SecretsMask } from '../runner/env.js';
-import { applyUrlOverride, EXIT_FAILED, EXIT_OK, EXIT_USAGE } from './run.js';
+import {
+  applyUrlOverride,
+  EXIT_FAILED,
+  EXIT_OK,
+  EXIT_USAGE,
+  resolveBudgetOptions,
+  type BudgetFlags,
+} from './run.js';
 
-export interface PlanOptions {
+export interface PlanOptions extends BudgetFlags {
   cwd: string;
   /** Base git ref for the diff (default "main"). Ignored when `routes` is given. */
   base?: string;
@@ -36,6 +44,11 @@ export interface PlanOptions {
   routes?: string[];
   /** Persist drafts under `.blastproof/tests/` instead of previewing them. */
   write?: boolean;
+  /**
+   * A budget already constructed by a composing caller (`test`), so both phases
+   * share one allowance. When absent, resolved here from `flag > env > file`.
+   */
+  budget?: RunBudget;
 }
 
 /** Prints login-journey progress, so a failing authentication is not a black box. */
@@ -115,8 +128,9 @@ async function resolveTargets(
 /**
  * `blastproof plan`: diff → impact → uncovered routes → snapshot-grounded test drafts.
  * Preview by default; `--write` persists without ever overwriting (design D7).
- * Returns the exit code: 0 all generated (or nothing to do), 1 any route failed,
- * 2 usage/config/diff error.
+ * Returns the exit code: 0 all generated (or nothing to do), 1 any route failed or
+ * the run's budget/deadline stopped it before every route was attempted (spec
+ * run-budget), 2 usage/config/diff error.
  */
 export async function planCommand(options: PlanOptions): Promise<number> {
   let config: BlastproofConfig;
@@ -167,7 +181,11 @@ export async function planCommand(options: PlanOptions): Promise<number> {
   }
 
   const { model, provider, modelId } = createModel(config.llm);
-  const brain = createPlanner(model);
+  // Unconfigured (the common case) never binds. A composing caller (`test`) may
+  // hand in an already-started budget so both phases share one allowance instead
+  // of `plan` resolving a fresh one (spec run-budget counts test planning too).
+  const budget = options.budget ?? new RunBudget(resolveBudgetOptions(config, options));
+  const brain = createPlanner(model, undefined, budget);
   const base = options.routes && options.routes.length > 0 ? undefined : (options.base ?? 'main');
   console.log(
     `blastproof plan: ${work.length} route(s), provider=${provider} model=${modelId}, base_url=${config.base_url}`,
@@ -185,6 +203,9 @@ export async function planCommand(options: PlanOptions): Promise<number> {
   const generated: string[] = [];
   const written: string[] = [];
   const failed: { route: string; reason: string }[] = [];
+  // Set only by a budget/deadline stop (design D3): a route never reaches a real
+  // failure once this is set, so `notAttempted` — not `failed` — is what remains.
+  let incomplete: BudgetExhaustedError | undefined;
 
   const browser = await chromium.launch({ headless: config.browser.headless });
   try {
@@ -200,21 +221,25 @@ export async function planCommand(options: PlanOptions): Promise<number> {
           baseUrl: config.base_url,
           allowedOrigins: config.allowed_origins,
           browser: browser as unknown as BrowserLike,
-          brain: createBrain(createModel(config.llm).model),
+          brain: createBrain(createModel(config.llm).model, undefined, budget),
           maxRetries: config.max_retries_per_step,
           mask,
           onEvent: printAuthEvent,
         });
       } catch (error) {
-        if (error instanceof AuthError) {
+        if (error instanceof BudgetExhaustedError) {
+          incomplete = error;
+        } else if (error instanceof AuthError) {
           console.error(`error: ${error.message}`);
           return EXIT_USAGE;
+        } else {
+          throw error;
         }
-        throw error;
       }
     }
 
-    for (const { route, changedFiles } of work) {
+    // The budget or deadline ran out during login: no route was ever attempted.
+    for (const { route, changedFiles } of incomplete ? [] : work) {
       console.log(`\n> ${route}`);
       let draft: TestDraft;
       const context = await browser.newContext(contextOptions(session));
@@ -229,6 +254,13 @@ export async function planCommand(options: PlanOptions): Promise<number> {
           mask: (text) => mask.mask(text),
         });
       } catch (error) {
+        if (error instanceof BudgetExhaustedError) {
+          // Not a route failure (design D3): the run's allowance ran out, so this
+          // route and everything after it stop here rather than being misreported
+          // as a generation defect.
+          incomplete = error;
+          break;
+        }
         // Per-route isolation (design D9): report and keep going.
         failed.push({ route, reason: error instanceof Error ? error.message : String(error) });
         console.log(`  X failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -260,6 +292,10 @@ export async function planCommand(options: PlanOptions): Promise<number> {
     await browser.close();
   }
 
+  const notAttempted = incomplete
+    ? work.map((item) => item.route).filter((route) => !generated.includes(route) && !failed.some((f) => f.route === route))
+    : [];
+
   console.log('\n--- Plan -------------------------------------------------------');
   console.log(`Generated: ${generated.length > 0 ? generated.join(', ') : 'none'}`);
   if (written.length > 0) {
@@ -273,7 +309,16 @@ export async function planCommand(options: PlanOptions): Promise<number> {
     console.log('Failed:');
     for (const { route, reason } of failed) console.log(`  ${route}: ${reason}`);
   }
+  if (incomplete) {
+    // Never a quiet success (design D4's reasoning applies here too): a budget or
+    // deadline stop is reported, not swallowed into "nothing to generate".
+    console.log(`Stopped: ${incomplete.message}`);
+    if (notAttempted.length > 0) {
+      console.log('Not attempted (run out of budget):');
+      for (const route of notAttempted) console.log(`  ${route}`);
+    }
+  }
   console.log('---------------------------------------------------------------');
 
-  return failed.length > 0 ? EXIT_FAILED : EXIT_OK;
+  return incomplete || failed.length > 0 ? EXIT_FAILED : EXIT_OK;
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,10 +8,16 @@ import { createBrain } from '../llm/brain.js';
 import { createModel, MissingApiKeyError } from '../llm/provider.js';
 import { renderHtml, writeHtml } from '../report/html.js';
 import { renderJUnit, writeJUnit, type SkippedCase } from '../report/junit.js';
-import { computeScore, formatScoreLine } from '../report/score.js';
+import { computeScore, formatIncompleteLine, formatScoreLine } from '../report/score.js';
 import type { PageLike } from '../runner/actions.js';
+import { BudgetExhaustedError, estimateMaxModelCalls, RunBudget, type RunBudgetOptions } from '../runner/budget.js';
 import { MissingEnvError, SecretsMask, substituteEnv } from '../runner/env.js';
-import { executeTest, type ExecutorEvent, type TestResult } from '../runner/executor.js';
+import {
+  DEFAULT_MAX_ITERATIONS_PER_STEP,
+  executeTest,
+  type ExecutorEvent,
+  type TestResult,
+} from '../runner/executor.js';
 import {
   matchesFilters,
   selectImpactedTests,
@@ -30,7 +36,22 @@ export const EXIT_OK = 0;
 export const EXIT_FAILED = 1;
 export const EXIT_USAGE = 2;
 
-export interface RunOptions extends TestFilters {
+/**
+ * The budget flags shared by every command that can make a model call. Spec
+ * run-budget counts "agent action, assert judgment, or test planning" against one
+ * budget, so the flags that configure it cannot belong to `run` alone — `plan` and
+ * `test` (which composes both) accept the same three.
+ */
+export interface BudgetFlags {
+  /** Overrides config `budget.max_llm_calls` for this invocation (`--max-llm-calls`). */
+  maxLlmCalls?: number;
+  /** Overrides config `budget.max_tokens` for this invocation (`--max-tokens`). */
+  maxTokens?: number;
+  /** Overrides config `budget.max_duration_s`, in seconds, for this invocation (`--max-duration`). */
+  maxDuration?: number;
+}
+
+export interface RunOptions extends TestFilters, BudgetFlags {
   cwd: string;
   /** Run only tests impacted by the diff vs `base` (uses routes: mappings). */
   impacted?: boolean;
@@ -56,6 +77,28 @@ export interface RunOptions extends TestFilters {
    * selected and still be blocked by a change nobody has classified (design D4).
    */
   failOnUnmapped?: boolean;
+  /**
+   * A budget already constructed by a composing caller (`test`), so both of its
+   * phases draw against one allowance instead of each resolving and starting its
+   * own (a budget that resets between phases is two allowances, not one bound).
+   * When absent, resolved here from `flag > env > file` as usual.
+   */
+  budget?: RunBudget;
+}
+
+/**
+ * Resolves the run's budget: flag beats config (spec cli-run-command). Env already
+ * beat the file by the time `config.budget` reaches here, since `loadConfig` merges
+ * `BLASTPROOF_MAX_*` before validating (design run-budget, precedence flag > env >
+ * file). Absent everywhere, every limit is undefined and `RunBudget` never binds.
+ */
+export function resolveBudgetOptions(config: BlastproofConfig, options: BudgetFlags): RunBudgetOptions {
+  const maxDurationSeconds = options.maxDuration ?? config.budget?.max_duration_s;
+  return {
+    maxCalls: options.maxLlmCalls ?? config.budget?.max_llm_calls,
+    maxTokens: options.maxTokens ?? config.budget?.max_tokens,
+    maxDurationMs: maxDurationSeconds === undefined ? undefined : maxDurationSeconds * 1000,
+  };
 }
 
 function sessionId(): string {
@@ -111,6 +154,24 @@ function resolveSecretsAndSteps(test: TestFile): { test: TestFile } {
   return { test };
 }
 
+/**
+ * Records tests the run's budget or deadline stopped before they executed (design
+ * D3, spec run-budget): a distinct `not-run` status, never `failed` — exhaustion
+ * says nothing about the application under test.
+ */
+function notRunResults(tests: TestFile[], reason: string): TestResult[] {
+  return tests.map((test) => ({
+    file: test.path,
+    summary: test.summary,
+    priority: test.priority,
+    tags: test.tags,
+    status: 'not-run',
+    steps: [],
+    reason,
+    durationMs: 0,
+  }));
+}
+
 function printEvent(event: ExecutorEvent): void {
   switch (event.type) {
     case 'step-start':
@@ -131,13 +192,20 @@ function printEvent(event: ExecutorEvent): void {
   }
 }
 
+function statusLabel(status: TestResult['status']): string {
+  if (status === 'passed') return 'PASS';
+  if (status === 'failed') return 'FAIL';
+  return 'NOT RUN';
+}
+
 function printSummary(results: TestResult[]): void {
   const passed = results.filter((r) => r.status === 'passed');
   const failed = results.filter((r) => r.status === 'failed');
+  const notRun = results.filter((r) => r.status === 'not-run');
 
   console.log('\n--- Summary ---------------------------------------------------');
   const rows = results.map((r) => ({
-    status: r.status === 'passed' ? 'PASS' : 'FAIL',
+    status: statusLabel(r.status),
     priority: r.priority,
     summary: r.summary,
     duration: `${(r.durationMs / 1000).toFixed(1)}s`,
@@ -151,13 +219,24 @@ function printSummary(results: TestResult[]): void {
     );
   }
   console.log('---------------------------------------------------------------');
-  console.log(`${passed.length} passed, ${failed.length} failed, ${results.length} total`);
+  // The "not run" clause only appears when a budget/deadline actually stopped the
+  // run, so an ordinary run's line is unchanged (design: inert by default).
+  console.log(
+    notRun.length > 0
+      ? `${passed.length} passed, ${failed.length} failed, ${notRun.length} not run, ${results.length} total`
+      : `${passed.length} passed, ${failed.length} failed, ${results.length} total`,
+  );
 
   for (const r of failed) {
     console.log(`\nX ${r.summary} (${r.file})`);
     if (r.failedStep) console.log(`  failing step: ${r.failedStep}`);
     if (r.reason) console.log(`  reason: ${r.reason}`);
     if (r.screenshot) console.log(`  screenshot: ${r.screenshot}`);
+  }
+
+  if (notRun.length > 0) {
+    console.log(`\n${notRun.length} test(s) not run (run stopped by its budget or deadline):`);
+    for (const r of notRun) console.log(`  - ${r.summary} (${r.file})`);
   }
 }
 
@@ -168,8 +247,9 @@ async function runOne(
   sessionDir: string,
   session: AuthSession | undefined,
   runMask: SecretsMask,
+  budget: RunBudget,
 ): Promise<TestResult> {
-  const brain = createBrain(createModel(config.llm).model);
+  const brain = createBrain(createModel(config.llm).model, undefined, budget);
 
   let resolved: TestFile;
   const mask = runMask;
@@ -248,7 +328,9 @@ function printImpactReport(
 /**
  * Prints the summary tail shared by every terminating path: score line, optional
  * JUnit report, and the exit code. With `--min-score` the threshold decides the
- * outcome instead of the all-must-pass rule (design D4).
+ * outcome instead of the all-must-pass rule (design D4) — unless `incomplete` is
+ * set, in which case nothing rescues the run: a budget or deadline stop always
+ * exits non-zero (spec run-budget, design D4), whatever the executed tests scored.
  */
 async function finalize(
   results: TestResult[],
@@ -257,18 +339,26 @@ async function finalize(
   sessionDir: string,
   durationMs: number,
   impact?: ImpactResult,
+  incomplete?: BudgetExhaustedError,
 ): Promise<number> {
   if (results.length > 0) printSummary(results);
 
   const score = computeScore(results);
-  console.log(formatScoreLine(score, results, options.minScore));
+  console.log(
+    incomplete ? formatIncompleteLine(score, incomplete.message) : formatScoreLine(score, results, options.minScore),
+  );
 
   if (options.junit) {
     const target =
       typeof options.junit === 'string'
         ? path.resolve(options.cwd, options.junit)
         : path.join(sessionDir, 'junit.xml');
-    const xml = renderJUnit(results, skipped, { score, durationMs, cwd: options.cwd });
+    const xml = renderJUnit(results, skipped, {
+      score,
+      durationMs,
+      cwd: options.cwd,
+      incomplete: incomplete?.message,
+    });
     await writeJUnit(target, xml);
     console.log(`JUnit report: ${path.relative(options.cwd, target)}`);
   }
@@ -283,11 +373,16 @@ async function finalize(
       durationMs,
       minScore: options.minScore,
       cwd: options.cwd,
+      incomplete: incomplete?.message,
     });
     await writeHtml(target, html);
     console.log(`HTML report: ${path.relative(options.cwd, target)}`);
   }
 
+  // Unconditional and first (spec run-budget, design D4): an incomplete run is
+  // never a pass, whatever --min-score would have said about the tests that
+  // happened to finish before the stop.
+  if (incomplete) return EXIT_FAILED;
 
   if (reportUnclassified(options, impact)) return EXIT_FAILED;
 
@@ -318,11 +413,32 @@ function reportUnclassified(options: RunOptions, impact: ImpactResult | undefine
   return true;
 }
 
-function printDryRun(selected: TestFile[], baseUrl: string, cwd: string): void {
-  console.log(`\nDry run: ${selected.length} test(s) selected, base_url=${baseUrl}`);
+function printDryRun(selected: TestFile[], config: BlastproofConfig, cwd: string): void {
+  console.log(`\nDry run: ${selected.length} test(s) selected, base_url=${config.base_url}`);
   for (const test of selected) {
     console.log(`  ${test.summary} [${test.priority}] (${path.relative(cwd, test.path)})`);
   }
+  // A ceiling, not a forecast (design D5): the arithmetic is exact (see
+  // estimateMaxModelCalls for the derivation), but a real run almost always
+  // finishes in far fewer calls than this ever allows.
+  //
+  // `auth.steps` runs once before any selected test and spends model calls
+  // through the same executeTest loop (design D8) — a login recipe with static
+  // headers/cookies/storage_state does not call the model at all, but `steps`
+  // does, and a ceiling that omitted it could be exceeded by the first run that
+  // configures a login journey. Included here for that reason (DEF-001 follow-up:
+  // the number must not be exceedable by anything it claims to bound).
+  const authSteps = config.auth?.steps ?? [];
+  const withAuth = authSteps.length > 0 ? [...selected, { steps: authSteps }] : selected;
+  const ceiling = estimateMaxModelCalls(
+    withAuth,
+    DEFAULT_MAX_ITERATIONS_PER_STEP,
+    config.max_retries_per_step,
+  );
+  const authNote = authSteps.length > 0 ? ', including the login journey' : '';
+  console.log(
+    `Worst case: up to ${ceiling} model call(s) for this selection${authNote} (a maximum, not a prediction).`,
+  );
   console.log('Dry run: no browser launched, no LLM calls made.');
 }
 
@@ -419,7 +535,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   }
 
   if (options.dryRun) {
-    printDryRun(selected, config.base_url, options.cwd);
+    printDryRun(selected, config, options.cwd);
     // A dry run is a pre-flight; reporting a clean plan while a file in the suite
     // cannot be parsed would bless a run that is about to fail and drop the score.
     if (results.length > 0) {
@@ -459,11 +575,21 @@ export async function runCommand(options: RunOptions): Promise<number> {
 
   const runMask = buildRunMask(config, parsed);
 
+  // Unconfigured (the common case) never binds: every limit inside is undefined,
+  // so check() never throws and this is a no-op wrapper (design: inert by default).
+  // A composing caller (`test`) may hand in an already-started budget so both of
+  // its phases share one allowance instead of `run` resolving a fresh one.
+  const budget = options.budget ?? new RunBudget(resolveBudgetOptions(config, options));
+
   const browser = await chromium.launch({ headless: config.browser.headless });
+  let incomplete: BudgetExhaustedError | undefined;
   try {
     // Authenticate once, before the first test (design D3). A failed login is a
     // configuration problem, not a product defect, so it aborts with exit 2 rather
-    // than surfacing as N failing tests and a meaningless score (design D6).
+    // than surfacing as N failing tests and a meaningless score (design D6). A
+    // budget/deadline stop during login is a different thing again (spec
+    // run-budget): the run is incomplete, not misconfigured, so none of the
+    // selected tests get to run.
     let session: AuthSession | undefined;
     if (config.auth) {
       try {
@@ -474,27 +600,61 @@ export async function runCommand(options: RunOptions): Promise<number> {
           baseUrl: config.base_url,
           allowedOrigins: config.allowed_origins,
           browser: browser as unknown as BrowserLike,
-          brain: createBrain(createModel(config.llm).model),
+          brain: createBrain(createModel(config.llm).model, undefined, budget),
           maxRetries: config.max_retries_per_step,
           mask: runMask,
           onEvent: printEvent,
         });
       } catch (error) {
-        if (error instanceof AuthError) {
+        if (error instanceof BudgetExhaustedError) {
+          incomplete = error;
+        } else if (error instanceof AuthError) {
           console.error(`error: ${error.message}`);
           return EXIT_USAGE;
+        } else {
+          throw error;
         }
-        throw error;
       }
     }
 
-    for (const test of selected) {
-      console.log(`\n> ${test.summary} [${test.priority}] (${path.relative(options.cwd, test.path)})`);
-      results.push(await runOne(browser, test, config, sessionDir, session, runMask));
+    if (incomplete) {
+      // The budget or deadline ran out during login: no selected test ever got
+      // to start, so every one of them is not run (design D3).
+      results.push(...notRunResults(selected, incomplete.message));
+    } else {
+      for (let i = 0; i < selected.length; i++) {
+        const test = selected[i]!;
+        console.log(`\n> ${test.summary} [${test.priority}] (${path.relative(options.cwd, test.path)})`);
+        try {
+          // Checked here too, not only inside the brain (design run-budget task
+          // 4.2): a deadline that has already passed must stop the *next test*
+          // rather than launching a fresh context only to fail on its first call.
+          budget.check();
+          results.push(await runOne(browser, test, config, sessionDir, session, runMask, budget));
+        } catch (error) {
+          if (error instanceof BudgetExhaustedError) {
+            incomplete = error;
+            // The test in progress, plus everything after it, never finished —
+            // recorded as not run rather than failed, and excluded from the
+            // score's denominator rather than counted against it (D3/D4).
+            results.push(...notRunResults(selected.slice(i), error.message));
+            break;
+          }
+          throw error;
+        }
+      }
     }
   } finally {
     await browser.close();
   }
 
-  return finalize(results, selection.unroutedSkipped, options, sessionDir, Date.now() - startedAt, impact);
+  return finalize(
+    results,
+    selection.unroutedSkipped,
+    options,
+    sessionDir,
+    Date.now() - startedAt,
+    impact,
+    incomplete,
+  );
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,7 +1,17 @@
+import { ConfigError, loadConfig, type BlastproofConfig } from '../config.js';
+import { RunBudget } from '../runner/budget.js';
 import { planCommand } from './plan.js';
-import { EXIT_FAILED, EXIT_OK, EXIT_USAGE, runCommand } from './run.js';
+import {
+  applyUrlOverride,
+  EXIT_FAILED,
+  EXIT_OK,
+  EXIT_USAGE,
+  resolveBudgetOptions,
+  runCommand,
+  type BudgetFlags,
+} from './run.js';
 
-export interface TestOptions {
+export interface TestOptions extends BudgetFlags {
   cwd: string;
   /** Base git ref for the diff (default "main"). */
   base?: string;
@@ -34,6 +44,23 @@ function section(title: string): void {
  * 0 otherwise (design D2).
  */
 export async function testCommand(options: TestOptions): Promise<number> {
+  // One budget for the whole pipeline (spec run-budget: "every model call made
+  // anywhere in the run... or test planning" counts against a single budget).
+  // `test` composes `run` then `plan`; resolving a fresh budget inside each phase
+  // would let a pipeline that must stay under N calls actually spend up to 2N —
+  // two allowances, not one bound. Resolved once, here, and handed to both.
+  let config: BlastproofConfig;
+  try {
+    config = applyUrlOverride(await loadConfig(options.cwd), options.url);
+  } catch (error) {
+    if (error instanceof ConfigError) {
+      console.error(`error: ${error.message}`);
+      return EXIT_USAGE;
+    }
+    throw error;
+  }
+  const budget = new RunBudget(resolveBudgetOptions(config, options));
+
   section('Verify: tests covering the affected routes');
   const runCode = await runCommand({
     cwd: options.cwd,
@@ -45,6 +72,7 @@ export async function testCommand(options: TestOptions): Promise<number> {
     junit: options.junit,
     html: options.html,
     failOnUnmapped: options.failOnUnmapped,
+    budget,
   });
   if (runCode === EXIT_USAGE) return EXIT_USAGE;
 
@@ -54,6 +82,7 @@ export async function testCommand(options: TestOptions): Promise<number> {
     base: options.base,
     url: options.url,
     write: options.write,
+    budget,
   });
   if (planCode === EXIT_USAGE) return EXIT_USAGE;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,19 @@ const browserSchema = z.object({
   timeout_ms: z.number().int().positive().default(30_000),
 });
 
+/**
+ * A run's budget and deadline (spec run-budget). Every field is optional and
+ * independent; an absent field never binds, so a run with no `budget:` section
+ * at all behaves exactly as it does today (design: inert by default). Coerced
+ * from strings too, since an env override (`BLASTPROOF_MAX_*`) arrives as text.
+ */
+const budgetSchema = z.object({
+  max_llm_calls: z.coerce.number().int().positive().optional(),
+  max_tokens: z.coerce.number().int().positive().optional(),
+  /** Seconds, not milliseconds, to match how a human would set a deadline. */
+  max_duration_s: z.coerce.number().positive().optional(),
+});
+
 const cookieSchema = z.object({
   name: z.string().min(1),
   value: z.string(),
@@ -79,12 +92,14 @@ const configSchema = z.object({
   allowed_origins: z.array(z.string().url()).optional(),
   auth: authSchema.optional(),
   max_retries_per_step: z.number().int().min(1).default(3),
+  budget: budgetSchema.optional(),
 });
 
 export type BlastproofConfig = z.infer<typeof configSchema>;
 export type LlmConfig = BlastproofConfig['llm'];
 export type BrowserConfig = BlastproofConfig['browser'];
 export type AuthConfig = NonNullable<BlastproofConfig['auth']>;
+export type BudgetConfig = NonNullable<BlastproofConfig['budget']>;
 
 /**
  * Environment overrides, one entry per settable field (design D2). `base_url` (the
@@ -98,6 +113,9 @@ export const ENV_OVERRIDES: Record<string, readonly [string] | readonly [string,
   BLASTPROOF_LLM_MODEL: ['llm', 'model'],
   BLASTPROOF_LLM_BASE_URL: ['llm', 'base_url'],
   BLASTPROOF_LLM_API_KEY_ENV: ['llm', 'api_key_env'],
+  BLASTPROOF_MAX_LLM_CALLS: ['budget', 'max_llm_calls'],
+  BLASTPROOF_MAX_TOKENS: ['budget', 'max_tokens'],
+  BLASTPROOF_MAX_DURATION_S: ['budget', 'max_duration_s'],
 };
 
 export interface OverrideResult {

--- a/src/llm/brain.ts
+++ b/src/llm/brain.ts
@@ -10,6 +10,7 @@ import {
   type AgentIterationInput,
   type PlannerInput,
 } from './prompts.js';
+import type { RunBudget } from '../runner/budget.js';
 import {
   agentActionSchema,
   assertJudgmentSchema,
@@ -35,7 +36,7 @@ export type GenerateObjectFn = (options: {
   schema: z.ZodTypeAny;
   system?: string;
   prompt?: string;
-}) => Promise<{ object: unknown }>;
+}) => Promise<{ object: unknown; usage?: { totalTokens?: number } }>;
 
 export class MalformedModelOutputError extends Error {
   constructor(message: string) {
@@ -44,13 +45,41 @@ export class MalformedModelOutputError extends Error {
   }
 }
 
+/**
+ * The budget (design D2) wraps this single function, not the callers: every model
+ * call in the product — agent action, assert judgment, planner (below) — is a
+ * `generate` call made here. `check()` before means an over-budget call is never
+ * issued; `record()` after means the AI SDK's `usage` (previously discarded) is
+ * what the budget counts against, so an unconfigured budget costs nothing extra
+ * and a configured one is total by construction, not by every caller remembering.
+ */
+async function countedGenerate(
+  generate: GenerateObjectFn,
+  budget: RunBudget,
+  options: Parameters<GenerateObjectFn>[0],
+): ReturnType<GenerateObjectFn> {
+  budget.check();
+  const result = await generate(options);
+  // Recorded even when the output later fails schema validation: the call was
+  // made and spent tokens regardless of whether the model's answer parses.
+  budget.record(result.usage);
+  return result;
+}
+
 export function createBrain(
   model: LanguageModel,
   generate: GenerateObjectFn = generateObject as unknown as GenerateObjectFn,
+  /**
+   * Required, not optional: `plan`'s planner brain shipped uncounted because this
+   * was optional and positional-third — exactly the shape that let it be skipped
+   * (design D2, spec run-budget). An unbounded run is still expressible; it is
+   * `new RunBudget()` with no limits, not the absence of an argument.
+   */
+  budget: RunBudget,
 ): AgentBrain {
   return {
     async nextAction(input) {
-      const result = await generate({
+      const result = await countedGenerate(generate, budget, {
         model,
         schema: agentActionSchema,
         system: agentSystemPrompt(),
@@ -66,7 +95,7 @@ export function createBrain(
     },
 
     async judge(expectation, snapshot) {
-      const result = await generate({
+      const result = await countedGenerate(generate, budget, {
         model,
         schema: assertJudgmentSchema,
         system: assertSystemPrompt(),
@@ -94,10 +123,12 @@ export interface PlannerBrain {
 export function createPlanner(
   model: LanguageModel,
   generate: GenerateObjectFn = generateObject as unknown as GenerateObjectFn,
+  /** Required for the same reason as {@link createBrain}'s: see its budget param. */
+  budget: RunBudget,
 ): PlannerBrain {
   return {
     async planTest(input) {
-      const result = await generate({
+      const result = await countedGenerate(generate, budget, {
         model,
         schema: generatedTestSchema,
         system: plannerSystemPrompt(),

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -42,6 +42,8 @@ export interface HtmlMeta {
   /** Repo root, so paths render relative rather than absolute. */
   cwd?: string;
   generatedAt?: Date;
+  /** The reason the run's budget or deadline stopped it, when it did (spec run-budget). */
+  incomplete?: string;
 }
 
 const STYLES = `
@@ -64,6 +66,8 @@ h1 { font-size:1.35rem; margin:0 0 .25rem; }
 .verdict { font-weight:600; }
 .verdict.pass { color:var(--pass); } .verdict.fail { color:var(--fail); }
 .counts { color:var(--muted); font-size:.9rem; }
+.incomplete { padding:1rem 1.25rem; border:1px solid var(--fail); border-radius:10px;
+  background:color-mix(in srgb, var(--fail) 10%, transparent); margin-bottom:1.5rem; font-weight:600; }
 table { width:100%; border-collapse:collapse; margin-bottom:1.5rem; }
 th, td { text-align:left; padding:.5rem .6rem; border-bottom:1px solid var(--line);
   font-size:.9rem; vertical-align:top; }
@@ -105,10 +109,13 @@ function renderSteps(steps: StepResult[]): string {
 
 async function renderTest(result: TestResult, cwd?: string): Promise<string> {
   const failed = result.status === 'failed';
+  const notRun = result.status === 'not-run';
+  const tagClass = failed ? 'fail' : notRun ? 'skip' : 'pass';
+  const label = failed ? 'FAIL' : notRun ? 'NOT RUN' : 'PASS';
   const file = cwd ? path.relative(cwd, result.file) : result.file;
   const parts = [
-    `    <details${failed ? ' open' : ''}>`,
-    `      <summary><span class="tag ${failed ? 'fail' : 'pass'}">${failed ? 'FAIL' : 'PASS'}</span> ` +
+    `    <details${failed || notRun ? ' open' : ''}>`,
+    `      <summary><span class="tag ${tagClass}">${label}</span> ` +
       `${escapeHtml(result.summary)} <span class="note">${escapeHtml(result.priority)} · ${escapeHtml(file)}</span></summary>`,
   ];
 
@@ -119,6 +126,10 @@ async function renderTest(result: TestResult, cwd?: string): Promise<string> {
     if (result.reason) {
       parts.push(`      <p class="reason">${escapeHtml(result.reason)}</p>`);
     }
+  }
+
+  if (notRun && result.reason) {
+    parts.push(`      <p class="note">${escapeHtml(result.reason)}</p>`);
   }
 
   parts.push(`      ${renderSteps(result.steps)}`);
@@ -148,10 +159,12 @@ export async function renderHtml(
 ): Promise<string> {
   const passed = results.filter((r) => r.status === 'passed').length;
   const failures = results.filter((r) => r.status === 'failed');
+  const notRun = results.filter((r) => r.status === 'not-run');
   const generatedAt = (meta.generatedAt ?? new Date()).toISOString();
 
-  // Failures first: the reader came for those.
-  const ordered = [...failures, ...results.filter((r) => r.status === 'passed')];
+  // Failures first, then the tests the run never reached: the reader came for
+  // those, and passing tests are the least interesting part of an incomplete run.
+  const ordered = [...failures, ...notRun, ...results.filter((r) => r.status === 'passed')];
   const detail = (await Promise.all(ordered.map((r) => renderTest(r, meta.cwd)))).join('\n');
 
   const verdict =
@@ -161,14 +174,21 @@ export async function renderHtml(
         ? `<span class="verdict pass">min-score ${meta.minScore}: pass</span>`
         : `<span class="verdict fail">min-score ${meta.minScore}: FAIL</span>`;
 
+  const banner =
+    meta.incomplete === undefined
+      ? ''
+      : `  <section class="incomplete">Run stopped: ${escapeHtml(meta.incomplete)}</section>\n\n`;
+
   const rows = results
     .map((r) => {
       const file = meta.cwd ? path.relative(meta.cwd, r.file) : r.file;
+      const tagClass = r.status === 'failed' ? 'fail' : r.status === 'not-run' ? 'skip' : 'pass';
+      const label = r.status === 'failed' ? 'FAIL' : r.status === 'not-run' ? 'NOT RUN' : 'PASS';
+      const time = r.status === 'not-run' ? '—' : seconds(r.durationMs);
       return (
-        `      <tr><td><span class="tag ${r.status === 'failed' ? 'fail' : 'pass'}">` +
-        `${r.status === 'failed' ? 'FAIL' : 'PASS'}</span></td>` +
+        `      <tr><td><span class="tag ${tagClass}">${label}</span></td>` +
         `<td>${escapeHtml(r.priority)}</td><td>${escapeHtml(r.summary)}</td>` +
-        `<td>${escapeHtml(file)}</td><td class="num">${seconds(r.durationMs)}</td></tr>`
+        `<td>${escapeHtml(file)}</td><td class="num">${time}</td></tr>`
       );
     })
     .join('\n');
@@ -197,12 +217,12 @@ export async function renderHtml(
   <h1>blastproof report</h1>
   <p class="sub">${escapeHtml(generatedAt)} · ${seconds(meta.durationMs)}</p>
 
-  <section class="score">
+${banner}  <section class="score">
     <b>${meta.score}</b>
     ${verdict}
     <span class="counts">${passed} passed · ${failures.length} failed${
-      skipped.length > 0 ? ` · ${skipped.length} skipped` : ''
-    }</span>
+      notRun.length > 0 ? ` · ${notRun.length} not run` : ''
+    }${skipped.length > 0 ? ` · ${skipped.length} skipped` : ''}</span>
   </section>
 
   <table>

--- a/src/report/junit.ts
+++ b/src/report/junit.ts
@@ -29,6 +29,8 @@ export interface JUnitMeta {
   durationMs: number;
   /** Repo root, so `classname` is repo-relative rather than absolute. */
   cwd?: string;
+  /** The reason the run's budget or deadline stopped it, when it did (spec run-budget). */
+  incomplete?: string;
 }
 
 function seconds(ms: number): string {
@@ -38,7 +40,11 @@ function seconds(ms: number): string {
 /**
  * Renders the run as a JUnit `testsuite` (design D7). Unrouted skipped tests are
  * emitted as `<skipped/>` cases so the coverage gap shows up in CI instead of
- * being absent from the report. Pure — returns the XML, writes nothing.
+ * being absent from the report; tests the run's budget or deadline stopped before
+ * they executed (`not-run`, spec run-budget) are emitted the same way, with the
+ * limit named in the reason rather than the fixed unrouted-skip message. When the
+ * run is incomplete, that is recorded as a run-level property, not folded into any
+ * one testcase. Pure — returns the XML, writes nothing.
  */
 export function renderJUnit(
   results: TestResult[],
@@ -49,15 +55,30 @@ export function renderJUnit(
     meta.cwd ? path.relative(meta.cwd, file) : file;
 
   const failures = results.filter((result) => result.status === 'failed').length;
+  const notRun = results.filter((result) => result.status === 'not-run');
   const lines = [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    `<testsuite name="blastproof" tests="${results.length + skipped.length}" failures="${failures}" skipped="${skipped.length}" time="${seconds(meta.durationMs)}">`,
+    `<testsuite name="blastproof" tests="${results.length + skipped.length}" failures="${failures}" skipped="${skipped.length + notRun.length}" time="${seconds(meta.durationMs)}">`,
     '  <properties>',
     `    <property name="score" value="${meta.score}"/>`,
+    ...(meta.incomplete !== undefined
+      ? [
+          '    <property name="incomplete" value="true"/>',
+          `    <property name="incomplete_reason" value="${escapeXml(meta.incomplete)}"/>`,
+        ]
+      : []),
     '  </properties>',
   ];
 
   for (const result of results) {
+    if (result.status === 'not-run') {
+      lines.push(
+        `  <testcase classname="${escapeXml(relative(result.file))}" name="${escapeXml(result.summary)}" time="0.000">`,
+        `    <skipped message="${escapeXml(result.reason ?? 'not run: the run stopped before this test executed')}"/>`,
+        '  </testcase>',
+      );
+      continue;
+    }
     const open = `  <testcase classname="${escapeXml(relative(result.file))}" name="${escapeXml(result.summary)}" time="${seconds(result.durationMs)}"`;
     if (result.status === 'passed') {
       lines.push(`${open}/>`);

--- a/src/report/score.ts
+++ b/src/report/score.ts
@@ -8,12 +8,17 @@ const DEFAULT_WEIGHT = WEIGHTS.P1!;
 /**
  * Weighted pass rate over executed tests, rounded to an integer 0–100.
  * An empty result list scores 100: nothing ran, so nothing is at risk (design D2).
- * Pure — the caller owns all I/O.
+ * A test the run's budget or deadline stopped before it started (`not-run`, spec
+ * run-budget) is excluded from the denominator entirely, not counted as a failure
+ * — treating it as a failure would replace one lie (the run passed) with a
+ * quieter one (the app broke), when neither claim has any evidence behind it
+ * (design D4, risk note). Pure — the caller owns all I/O.
  */
 export function computeScore(results: TestResult[]): number {
   let total = 0;
   let passed = 0;
   for (const result of results) {
+    if (result.status === 'not-run') continue;
     const weight = WEIGHTS[result.priority] ?? DEFAULT_WEIGHT;
     total += weight;
     if (result.status === 'passed') passed += weight;
@@ -40,4 +45,17 @@ export function formatScoreLine(
   return score >= threshold
     ? `Score: ${score} — min-score ${threshold}: pass`
     : `Score: ${score} — min-score ${threshold}: FAIL (below threshold)`;
+}
+
+/**
+ * The summary line for a run its budget or deadline stopped (spec run-budget,
+ * design D3/D4). States the stop plainly instead of an ordinary score line: the
+ * executed tests are whichever happened to run first, not a verdict, and
+ * `--min-score` never overrides this — the process exits non-zero regardless.
+ */
+export function formatIncompleteLine(score: number, reason: string): string {
+  return (
+    `Run incomplete: ${reason}\n` +
+    `Score over executed tests: ${score} (not a verdict — exit code 1 regardless of --min-score)`
+  );
 }

--- a/src/runner/budget.ts
+++ b/src/runner/budget.ts
@@ -1,0 +1,182 @@
+/**
+ * Bounds a run by model calls, tokens and wall-clock time (design D1/D2, spec
+ * run-budget). Enforcement lives at the single choke point every model call
+ * already passes through (`createBrain`/`createPlanner` in `src/llm/brain.ts`) —
+ * the same shape as the run-wide secrets mask, and for the same reason: a limit
+ * checked at a call site instead of over the whole scope is the recurring defect
+ * in this codebase (secret leaks, then #15).
+ *
+ * Each limit is independently optional; an unconfigured one never binds, so a run
+ * with no budget or deadline configured behaves exactly as it does today.
+ */
+
+export type BudgetLimit = 'calls' | 'tokens' | 'duration';
+
+/** What a completed model call reports spending. Only the total is counted (D1). */
+export interface CallUsage {
+  totalTokens?: number;
+}
+
+export interface RunBudgetOptions {
+  maxCalls?: number;
+  maxTokens?: number;
+  maxDurationMs?: number;
+  /** Injectable clock, so deadline behaviour is testable without real wall-clock time. */
+  now?: () => number;
+}
+
+function describeLimit(limit: BudgetLimit, observed: number, configured: number): string {
+  switch (limit) {
+    case 'calls':
+      return `model call budget exhausted: reached the configured maximum of ${configured} call(s)`;
+    case 'tokens':
+      return (
+        `token budget exhausted: reached the configured maximum of ${configured} token(s) ` +
+        `(observed ${observed})`
+      );
+    case 'duration':
+      return (
+        `deadline exceeded: reached the configured maximum of ${(configured / 1000).toFixed(0)}s ` +
+        `(elapsed ${(observed / 1000).toFixed(1)}s)`
+      );
+  }
+}
+
+/**
+ * Raised when the next model call — or, in `runCommand`, the next test — could
+ * exceed a configured limit (design D2/D3). Distinct from a step failure: a caller
+ * catching this must end the run, not fail a test, since exhaustion says nothing
+ * about the application under test. Carries the limit and the observed count, so
+ * every surface that reports it (console, JUnit, HTML) can name both without
+ * recomputing them.
+ */
+export class BudgetExhaustedError extends Error {
+  readonly limit: BudgetLimit;
+  readonly observed: number;
+  readonly configured: number;
+
+  constructor(limit: BudgetLimit, observed: number, configured: number) {
+    super(describeLimit(limit, observed, configured));
+    this.name = 'BudgetExhaustedError';
+    this.limit = limit;
+    this.observed = observed;
+    this.configured = configured;
+  }
+}
+
+/**
+ * Counts model calls, tokens and elapsed wall-clock time against optional limits.
+ * `check()` is called before spending anything — a model call, or in `runCommand`,
+ * a test — so exhaustion always stops the *next* unit of work rather than being
+ * discovered mid-flight. Tokens are the one exception: they are known only after a
+ * call returns, so `check()` can only compare against what has already been spent,
+ * and the call in flight when the limit is crossed is allowed to finish (design
+ * risk, accepted and documented: overshoot bounded by one call).
+ */
+export class RunBudget {
+  private readonly maxCalls?: number;
+  private readonly maxTokens?: number;
+  private readonly maxDurationMs?: number;
+  private readonly now: () => number;
+  private readonly startedAt: number;
+  private calls = 0;
+  private tokens = 0;
+
+  constructor(options: RunBudgetOptions = {}) {
+    this.maxCalls = options.maxCalls;
+    this.maxTokens = options.maxTokens;
+    this.maxDurationMs = options.maxDurationMs;
+    this.now = options.now ?? Date.now;
+    this.startedAt = this.now();
+  }
+
+  /** Model calls recorded so far. */
+  get callCount(): number {
+    return this.calls;
+  }
+
+  /** Tokens recorded so far, summed across every completed call. */
+  get tokenCount(): number {
+    return this.tokens;
+  }
+
+  /**
+   * Throws {@link BudgetExhaustedError} when the next unit of work could exceed a
+   * configured limit. Called before spending anything, never after — so an
+   * over-budget call is never issued and then rejected (spec: "the call is not
+   * made").
+   */
+  check(): void {
+    if (this.maxCalls !== undefined && this.calls >= this.maxCalls) {
+      throw new BudgetExhaustedError('calls', this.calls, this.maxCalls);
+    }
+    if (this.maxTokens !== undefined && this.tokens >= this.maxTokens) {
+      throw new BudgetExhaustedError('tokens', this.tokens, this.maxTokens);
+    }
+    if (this.maxDurationMs !== undefined) {
+      const elapsed = this.now() - this.startedAt;
+      if (elapsed >= this.maxDurationMs) {
+        throw new BudgetExhaustedError('duration', elapsed, this.maxDurationMs);
+      }
+    }
+  }
+
+  /** Records what a completed model call spent. */
+  record(usage: CallUsage | undefined): void {
+    this.calls += 1;
+    if (usage?.totalTokens !== undefined) this.tokens += usage.totalTokens;
+  }
+}
+
+/** The step counts an estimate needs from a test — a subset of `TestFile`. */
+export interface StepCounts {
+  setup?: string[];
+  steps: string[];
+}
+
+/**
+ * Worst-case model-call ceiling for a selection (design D5, spec run-budget: "the
+ * ceiling the selection cannot exceed").
+ *
+ * Per step, `executor.ts` enforces two independent caps, `maxIterationsPerStep`
+ * (N) and `maxRetriesPerStep` (R), and a model call can spend against either or
+ * both at once:
+ *   - A malformed `nextAction` response is retried — `failedAttempts++` then
+ *     `continue` — *before* `iterations++` runs, so it costs one call against R
+ *     alone, never touching N.
+ *   - A successful `nextAction` always costs one call against N. If the action is
+ *     `assert`, `judge()` spends a second call in the same turn; a failing
+ *     judgment then also costs one unit of R, on top of the N unit already spent.
+ *
+ * So R-worth of calls can be spent two ways: standalone (1 call each, N
+ * untouched) or bundled onto a failing assert (2 calls each, N and R both spent
+ * for the price of one retry unit). Filling all N iteration slots with failing
+ * asserts alone (`2N` calls) never has enough retry budget left to also cash in
+ * standalone calls once `maxRetriesPerStep` is exhausted — that path is bounded
+ * by `min(N, R)` bundled iterations, not N of them, unless R ≥ N. Working the
+ * trade-off through (an LP over how many of the R retry units are bundled onto an
+ * iteration vs. spent standalone) tops out at exactly `N + R` calls, achieved by
+ * spending every iteration slot and every retry unit once each, never both on the
+ * same call except where a failing assert intentionally pays for one of each.
+ * `2N` (the previous formula) undercounts once R exceeds what standalone retries
+ * can absorb below N — DEF-001 measured 35 real calls against N=15, R=20 (its
+ * reported ceiling of 30 came from `2N` alone, ignoring R entirely). `N + R`
+ * matches that measurement exactly: 15 + 20 = 35.
+ *
+ * A forecast this is not — most steps finish in a handful of calls, long before
+ * either cap binds. This is the maximum a single step's loop cannot exceed no
+ * matter how the model behaves, and `maxRetriesPerStep` is read from config, not
+ * assumed, because it has no upper bound (`z.number().int().min(1)`) and a fixed
+ * assumption here would silently stop being a ceiling the moment a config raised it.
+ */
+export function estimateMaxModelCalls(
+  tests: StepCounts[],
+  maxIterationsPerStep: number,
+  maxRetriesPerStep: number,
+): number {
+  const totalSteps = tests.reduce(
+    (sum, test) => sum + (test.setup?.length ?? 0) + test.steps.length,
+    0,
+  );
+  return totalSteps * (maxIterationsPerStep + maxRetriesPerStep);
+}

--- a/src/runner/executor.ts
+++ b/src/runner/executor.ts
@@ -2,8 +2,14 @@ import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import type { AgentBrain } from '../llm/brain.js';
 import type { AgentAction } from '../llm/schemas.js';
+import { BudgetExhaustedError } from './budget.js';
 import type { TestFile } from './testfile.js';
 import { performAction, type PageLike } from './actions.js';
+
+/** Hard cap on LLM actions per step, when not overridden. Also the number the
+ * dry-run ceiling (design D5, `estimateMaxModelCalls`) is derived from, so the
+ * two never drift apart. */
+export const DEFAULT_MAX_ITERATIONS_PER_STEP = 15;
 
 export interface StepResult {
   step: string;
@@ -20,7 +26,12 @@ export interface TestResult {
   summary: string;
   priority: string;
   tags: string[];
-  status: 'passed' | 'failed';
+  /**
+   * `not-run` is a run stopped by its budget or deadline before this test executed
+   * (design D3, spec run-budget) — distinct from `failed`, since exhaustion says
+   * nothing about the application under test.
+   */
+  status: 'passed' | 'failed' | 'not-run';
   steps: StepResult[];
   /** Failing step text + reason, for summary reporting. */
   failedStep?: string;
@@ -84,7 +95,7 @@ export async function executeTest(page: PageLike, test: TestFile, options: Execu
     allowedOrigins,
     resolveValue,
     maxRetries = 3,
-    maxIterationsPerStep = 15,
+    maxIterationsPerStep = DEFAULT_MAX_ITERATIONS_PER_STEP,
     mask = (s: string) => s,
     snapshot = defaultSnapshot,
     onEvent = () => {},
@@ -147,6 +158,10 @@ export async function executeTest(page: PageLike, test: TestFile, options: Execu
             iterationsLeft: maxIterationsPerStep - iterations,
           });
         } catch (error) {
+          // A budget/deadline stop ends the run, not this attempt (design D3): it
+          // must not be spent from the retry budget or reported as a bad model
+          // response, so it bypasses this handler entirely.
+          if (error instanceof BudgetExhaustedError) throw error;
           // Malformed model output counts as a failed attempt (spec: structured output).
           failedAttempts++;
           lastResult = `error: ${error instanceof Error ? error.message : String(error)}`;
@@ -207,6 +222,11 @@ export async function executeTest(page: PageLike, test: TestFile, options: Execu
         }
       }
     } catch (error) {
+      // A budget/deadline stop is not a step failure (design D3, spec
+      // agentic-execution): let it propagate out of executeTest so the caller can
+      // record this test — and the rest of the run's selection — as not run,
+      // rather than manufacturing a defect that does not exist.
+      if (error instanceof BudgetExhaustedError) throw error;
       // Mask everything that reaches logs/reports, regardless of throw site.
       stepFailedReason = mask(error instanceof Error ? error.message : String(error));
     }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/auth.js';
 import type { AuthConfig } from '../src/config.js';
 import type { AgentBrain } from '../src/llm/brain.js';
+import { BudgetExhaustedError } from '../src/runner/budget.js';
 import { SecretsMask } from '../src/runner/env.js';
 
 const CAPTURED: StorageState = { cookies: [{ name: 'session', value: 'abc' }], origins: [] };
@@ -149,6 +150,21 @@ describe('authenticate: steps strategy', () => {
     );
 
     expect(session.storageState).toEqual(CAPTURED);
+  });
+
+  it('propagates a budget/deadline stop as itself, not as an AuthError (spec run-budget)', async () => {
+    // A budget stop during login is a budget stop, not a broken auth recipe: the
+    // run must end incomplete, not be reported as a configuration failure.
+    const brain: AgentBrain = {
+      nextAction: async () => {
+        throw new BudgetExhaustedError('calls', 1, 1);
+      },
+      judge: async () => ({ pass: true, reason: 'n/a' }),
+    };
+
+    await expect(
+      authenticate(options({ steps: ['sign in'], cache: false }, brain)),
+    ).rejects.toThrow(BudgetExhaustedError);
   });
 
   it('keeps a substituted password out of the error message', async () => {

--- a/tests/brain.test.ts
+++ b/tests/brain.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { LanguageModel } from 'ai';
 import {
   createBrain,
@@ -13,6 +13,7 @@ import {
   plannerSystemPrompt,
   plannerUserPrompt,
 } from '../src/llm/prompts.js';
+import { BudgetExhaustedError, RunBudget } from '../src/runner/budget.js';
 
 const fakeModel = { provider: 'test', modelId: 'test-model' } as unknown as LanguageModel;
 
@@ -65,6 +66,7 @@ describe('createBrain', () => {
     const brain = createBrain(
       fakeModel,
       stubGenerate({ action: 'click', target: { role: 'button', name: 'Save' }, reasoning: 'save form' }, captured),
+      new RunBudget(),
     );
     const action = await brain.nextAction({
       step: 'save the form',
@@ -79,17 +81,111 @@ describe('createBrain', () => {
   });
 
   it('nextAction throws MalformedModelOutputError on schema-invalid output', async () => {
-    const brain = createBrain(fakeModel, stubGenerate({ action: 'explode' }));
+    const brain = createBrain(fakeModel, stubGenerate({ action: 'explode' }), new RunBudget());
     await expect(
       brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 }),
     ).rejects.toThrow(MalformedModelOutputError);
   });
 
   it('judge returns the validated judgment', async () => {
-    const brain = createBrain(fakeModel, stubGenerate({ pass: false, reason: 'no discount line' }));
+    const brain = createBrain(
+      fakeModel,
+      stubGenerate({ pass: false, reason: 'no discount line' }),
+      new RunBudget(),
+    );
     const judgment = await brain.judge('discount applied', '- main: cart');
     expect(judgment.pass).toBe(false);
     expect(judgment.reason).toContain('no discount');
+  });
+});
+
+describe('createBrain budget enforcement (design D2)', () => {
+  it('counts a nextAction call against the budget', async () => {
+    const budget = new RunBudget({ maxCalls: 1 });
+    const brain = createBrain(
+      fakeModel,
+      stubGenerate({ action: 'done', reasoning: 'ok' }),
+      budget,
+    );
+    await brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 });
+    expect(budget.callCount).toBe(1);
+    await expect(
+      brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 }),
+    ).rejects.toThrow(BudgetExhaustedError);
+  });
+
+  it('counts a judge call against the budget', async () => {
+    const budget = new RunBudget({ maxCalls: 1 });
+    const brain = createBrain(fakeModel, stubGenerate({ pass: true, reason: 'ok' }), budget);
+    await brain.judge('expectation', 'snapshot');
+    expect(budget.callCount).toBe(1);
+  });
+
+  it('records tokens from the AI SDK usage the wrapper previously discarded', async () => {
+    const budget = new RunBudget({ maxTokens: 100 });
+    const generate: GenerateObjectFn = async () => ({
+      object: { action: 'done', reasoning: 'ok' },
+      usage: { totalTokens: 60 },
+    });
+    const brain = createBrain(fakeModel, generate, budget);
+    await brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 });
+    expect(budget.tokenCount).toBe(60);
+    await brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 });
+    expect(budget.tokenCount).toBe(120);
+    // The second call already crossed 100, so the third is never issued.
+    const generateSpy = vi.fn(generate);
+    const brain2 = createBrain(fakeModel, generateSpy, budget);
+    await expect(
+      brain2.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 }),
+    ).rejects.toThrow(BudgetExhaustedError);
+    expect(generateSpy).not.toHaveBeenCalled();
+  });
+
+  it('never issues a call that would exceed the budget (spec: not issued and rejected)', async () => {
+    const budget = new RunBudget({ maxCalls: 0 });
+    const generateSpy = vi.fn(stubGenerate({ action: 'done', reasoning: 'ok' }));
+    const brain = createBrain(fakeModel, generateSpy, budget);
+    await expect(
+      brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 }),
+    ).rejects.toThrow(BudgetExhaustedError);
+    expect(generateSpy).not.toHaveBeenCalled();
+  });
+
+  it('still records a call whose output later fails schema validation', async () => {
+    const budget = new RunBudget({ maxCalls: 5 });
+    const brain = createBrain(fakeModel, stubGenerate({ action: 'explode' }), budget);
+    await expect(
+      brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 }),
+    ).rejects.toThrow(MalformedModelOutputError);
+    expect(budget.callCount).toBe(1);
+  });
+
+  it('does not bind when the budget carries no configured limits (inert by default)', async () => {
+    const brain = createBrain(fakeModel, stubGenerate({ action: 'done', reasoning: 'ok' }), new RunBudget());
+    await expect(
+      brain.nextAction({ step: 'x', snapshot: '', retriesLeft: 3, iterationsLeft: 10 }),
+    ).resolves.toMatchObject({ action: 'done' });
+  });
+});
+
+describe('createPlanner budget enforcement (design D2)', () => {
+  it('counts a planTest call too — a budget that missed the planner would repeat #15', async () => {
+    const budget = new RunBudget({ maxCalls: 1 });
+    const planner = createPlanner(
+      fakeModel,
+      stubGenerate({
+        summary: 'a test',
+        steps: ['do a thing'],
+        priority: 'P1',
+        tags: [],
+      }),
+      budget,
+    );
+    await planner.planTest({ route: '/x', snapshot: '', changedFiles: [] });
+    expect(budget.callCount).toBe(1);
+    await expect(
+      planner.planTest({ route: '/x', snapshot: '', changedFiles: [] }),
+    ).rejects.toThrow(BudgetExhaustedError);
   });
 });
 
@@ -133,6 +229,7 @@ describe('createPlanner', () => {
         },
         captured,
       ),
+      new RunBudget(),
     );
 
     const draft = await planner.planTest({
@@ -149,7 +246,7 @@ describe('createPlanner', () => {
   });
 
   it('planTest throws MalformedModelOutputError on schema-invalid output', async () => {
-    const planner = createPlanner(fakeModel, stubGenerate({ summary: 'no steps', steps: [] }));
+    const planner = createPlanner(fakeModel, stubGenerate({ summary: 'no steps', steps: [] }), new RunBudget());
     await expect(
       planner.planTest({ route: '/cart', snapshot: '', changedFiles: [] }),
     ).rejects.toThrow(MalformedModelOutputError);

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentBrain } from '../src/llm/brain.js';
+import type { AgentAction, AssertJudgment } from '../src/llm/schemas.js';
+import {
+  BudgetExhaustedError,
+  estimateMaxModelCalls,
+  RunBudget,
+} from '../src/runner/budget.js';
+import { executeTest } from '../src/runner/executor.js';
+import type { PageLike } from '../src/runner/actions.js';
+import type { TestFile } from '../src/runner/testfile.js';
+
+describe('RunBudget', () => {
+  it('never binds when unconfigured', () => {
+    const budget = new RunBudget();
+    for (let i = 0; i < 1000; i++) {
+      expect(() => budget.check()).not.toThrow();
+      budget.record({ totalTokens: 1_000_000 });
+    }
+  });
+
+  it('exhausts the call limit independently of tokens and duration', () => {
+    const budget = new RunBudget({ maxCalls: 2 });
+    budget.check();
+    budget.record(undefined);
+    budget.check();
+    budget.record(undefined);
+    expect(() => budget.check()).toThrow(BudgetExhaustedError);
+  });
+
+  it('names the limit and the observed count for an exhausted call budget', () => {
+    const budget = new RunBudget({ maxCalls: 1 });
+    budget.record(undefined);
+    const error = getError(() => budget.check());
+    expect(error).toBeInstanceOf(BudgetExhaustedError);
+    expect(error.limit).toBe('calls');
+    expect(error.observed).toBe(1);
+    expect(error.configured).toBe(1);
+    expect(error.message).toContain('1 call');
+  });
+
+  it('exhausts the token limit independently of calls and duration', () => {
+    const budget = new RunBudget({ maxTokens: 100 });
+    budget.check();
+    budget.record({ totalTokens: 100 });
+    const error = getError(() => budget.check());
+    expect(error.limit).toBe('tokens');
+    expect(error.observed).toBe(100);
+    expect(error.configured).toBe(100);
+    expect(error.message).toContain('100 token');
+  });
+
+  it('exhausts the duration limit independently of calls and tokens', () => {
+    let now = 0;
+    const budget = new RunBudget({ maxDurationMs: 1000, now: () => now });
+    now = 500;
+    expect(() => budget.check()).not.toThrow();
+    now = 1000;
+    const error = getError(() => budget.check());
+    expect(error.limit).toBe('duration');
+    expect(error.message).toContain('deadline exceeded');
+  });
+
+  it('never issues a call that would exceed the budget: check() throws before record()', () => {
+    const budget = new RunBudget({ maxCalls: 1 });
+    budget.record(undefined);
+    expect(() => budget.check()).toThrow(BudgetExhaustedError);
+    // callCount is unchanged: the "call" that would have exceeded it was never made.
+    expect(budget.callCount).toBe(1);
+  });
+
+  it('accepts overshoot on tokens bounded by one call (design risk, documented)', () => {
+    const budget = new RunBudget({ maxTokens: 100 });
+    budget.check(); // under budget: allowed
+    budget.record({ totalTokens: 500 }); // the in-flight call overshoots by 400
+    expect(budget.tokenCount).toBe(500);
+    expect(() => budget.check()).toThrow(BudgetExhaustedError);
+  });
+});
+
+function getError(fn: () => void): BudgetExhaustedError {
+  try {
+    fn();
+  } catch (error) {
+    if (error instanceof BudgetExhaustedError) return error;
+    throw error;
+  }
+  throw new Error('expected fn to throw');
+}
+
+describe('estimateMaxModelCalls', () => {
+  it('is steps times (the iteration ceiling plus the retry budget)', () => {
+    // One test, 3 steps, N=15, R=3: 3 * (15 + 3) = 54.
+    const ceiling = estimateMaxModelCalls([{ steps: ['a', 'b', 'c'] }], 15, 3);
+    expect(ceiling).toBe(54);
+  });
+
+  it('counts setup steps alongside main steps', () => {
+    const ceiling = estimateMaxModelCalls([{ setup: ['sign in'], steps: ['a', 'b'] }], 10, 3);
+    // 3 total steps * (10 + 3) = 39.
+    expect(ceiling).toBe(39);
+  });
+
+  it('sums across every test in the selection', () => {
+    const ceiling = estimateMaxModelCalls(
+      [{ steps: ['a'] }, { steps: ['b', 'c'] }],
+      5,
+      2,
+    );
+    // 3 total steps * (5 + 2) = 21.
+    expect(ceiling).toBe(21);
+  });
+
+  it('is zero for an empty selection', () => {
+    expect(estimateMaxModelCalls([], 15, 3)).toBe(0);
+  });
+
+  it('grows with the retry budget, not just the iteration cap', () => {
+    // Same iteration cap, only the retry budget differs.
+    const low = estimateMaxModelCalls([{ steps: ['a'] }], 15, 1);
+    const high = estimateMaxModelCalls([{ steps: ['a'] }], 15, 20);
+    expect(high).toBeGreaterThan(low);
+    expect(high - low).toBe(19);
+  });
+});
+
+/**
+ * DEF-001 regression: a config with `max_retries_per_step` above the iteration
+ * cap is exactly the case the old `2 * maxIterationsPerStep` formula undercounted
+ * — QA measured 35 real calls against a reported ceiling of 30 (N=15, R=20; the
+ * old formula ignored R entirely). A test that only exercises default config
+ * would pass against that broken formula too, so this one deliberately sets
+ * R > N and drives the real executor loop adversarially (never `done`, always a
+ * failing `assert`, plus malformed responses) to spend as many calls as the loop
+ * allows, then checks the ceiling actually bounds what happened — not merely
+ * that it looks plausible.
+ */
+describe('estimateMaxModelCalls bounds the real executor (DEF-001 regression)', () => {
+  it('is >= the actual call count when retries exceed the iteration cap', async () => {
+    const N = 3; // maxIterationsPerStep
+    const R = 5; // maxRetries — deliberately above N, the case that broke the old formula
+
+    let nextActionCalls = 0;
+    let judgeCalls = 0;
+    const assertAction: AgentAction = { action: 'assert', reasoning: 'check', expectation: 'x' };
+    const failingJudgment: AssertJudgment = { pass: false, reason: 'not yet' };
+
+    // Worst-case schedule (see estimateMaxModelCalls's derivation): spend the
+    // retry budget that doesn't fit in the iteration cap (R - N) as standalone
+    // malformed responses first, then fail every remaining iteration's assert.
+    const adversarialBrain: AgentBrain = {
+      async nextAction() {
+        nextActionCalls++;
+        if (nextActionCalls <= R - N) {
+          throw new Error('malformed'); // costs a retry unit, no iteration slot
+        }
+        return assertAction; // costs an iteration slot
+      },
+      async judge() {
+        judgeCalls++;
+        return failingJudgment; // costs a retry unit too, on top of the iteration slot
+      },
+    };
+
+    const test: TestFile = {
+      path: '.blastproof/tests/def-001.yaml',
+      summary: 'DEF-001 regression',
+      steps: ['one step, worst case'],
+      priority: 'P1',
+      tags: [],
+    };
+
+    const fakePage = { goto: async () => {}, screenshot: async () => {} } as unknown as PageLike;
+
+    const result = await executeTest(fakePage, test, {
+      brain: adversarialBrain,
+      sessionDir: '/tmp',
+      baseUrl: 'http://localhost:4173',
+      maxRetries: R,
+      maxIterationsPerStep: N,
+      snapshot: async () => 'snapshot',
+    });
+
+    // The retry budget is exhausted deliberately: the step is expected to fail.
+    expect(result.status).toBe('failed');
+    const actualCalls = nextActionCalls + judgeCalls;
+    const ceiling = estimateMaxModelCalls([test], N, R);
+
+    expect(ceiling).toBeGreaterThanOrEqual(actualCalls);
+    // Tight, not just sufficient: this is exactly N + R for one step, matching
+    // the derivation and DEF-001's own measurement (15 + 20 = 35).
+    expect(actualCalls).toBe(N + R);
+    expect(ceiling).toBe(N + R);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -241,3 +241,66 @@ describe('auth recipe', () => {
     expect(config.auth).toBeUndefined();
   });
 });
+
+describe('budget section (spec run-budget)', () => {
+  it('leaves budget undefined when the section is absent — inert by default', async () => {
+    await writeConfig('base_url: http://localhost:3000\n');
+    const config = await loadConfig(dir, {});
+    expect(config.budget).toBeUndefined();
+  });
+
+  it('accepts all three limits', async () => {
+    await writeConfig(
+      'base_url: http://localhost:3000\nbudget:\n  max_llm_calls: 200\n  max_tokens: 500000\n  max_duration_s: 600\n',
+    );
+    const config = await loadConfig(dir, {});
+    expect(config.budget).toEqual({ max_llm_calls: 200, max_tokens: 500000, max_duration_s: 600 });
+  });
+
+  it('accepts each limit independently', async () => {
+    await writeConfig('base_url: http://localhost:3000\nbudget:\n  max_llm_calls: 50\n');
+    const config = await loadConfig(dir, {});
+    expect(config.budget?.max_llm_calls).toBe(50);
+    expect(config.budget?.max_tokens).toBeUndefined();
+    expect(config.budget?.max_duration_s).toBeUndefined();
+  });
+
+  it('rejects a non-positive limit, naming the field', async () => {
+    await writeConfig('base_url: http://localhost:3000\nbudget:\n  max_llm_calls: 0\n');
+    await expect(loadConfig(dir, {})).rejects.toThrow(/budget\.max_llm_calls/);
+  });
+
+  it('rejects a non-integer call count', async () => {
+    await writeConfig('base_url: http://localhost:3000\nbudget:\n  max_llm_calls: 1.5\n');
+    await expect(loadConfig(dir, {})).rejects.toThrow(/budget\.max_llm_calls/);
+  });
+
+  it('allows a fractional deadline', async () => {
+    await writeConfig('base_url: http://localhost:3000\nbudget:\n  max_duration_s: 90.5\n');
+    const config = await loadConfig(dir, {});
+    expect(config.budget?.max_duration_s).toBe(90.5);
+  });
+
+  it('overrides each field from its BLASTPROOF_MAX_* variable', async () => {
+    await writeConfig('base_url: http://localhost:3000\nbudget:\n  max_llm_calls: 999\n');
+    const config = await loadConfig(dir, {
+      BLASTPROOF_MAX_LLM_CALLS: '10',
+      BLASTPROOF_MAX_TOKENS: '20000',
+      BLASTPROOF_MAX_DURATION_S: '120',
+    });
+    expect(config.budget).toEqual({ max_llm_calls: 10, max_tokens: 20000, max_duration_s: 120 });
+  });
+
+  it('lets the environment win over the file (precedence: env > file)', async () => {
+    await writeConfig('base_url: http://localhost:3000\nbudget:\n  max_llm_calls: 999\n');
+    const config = await loadConfig(dir, { BLASTPROOF_MAX_LLM_CALLS: '5' });
+    expect(config.budget?.max_llm_calls).toBe(5);
+  });
+
+  it('rejects a non-numeric override, naming the variable', async () => {
+    await writeConfig('base_url: http://localhost:3000\n');
+    await expect(
+      loadConfig(dir, { BLASTPROOF_MAX_LLM_CALLS: 'lots' }),
+    ).rejects.toThrow(/BLASTPROOF_MAX_LLM_CALLS/);
+  });
+});

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { AgentBrain } from '../src/llm/brain.js';
 import type { AgentAction, AssertJudgment } from '../src/llm/schemas.js';
 import { performAction, resolveTarget, type LocatorLike, type PageLike } from '../src/runner/actions.js';
+import { BudgetExhaustedError } from '../src/runner/budget.js';
 import { executeTest, type ExecutorEvent } from '../src/runner/executor.js';
 import { trimSnapshot } from '../src/runner/snapshot.js';
 import type { TestFile } from '../src/runner/testfile.js';
@@ -361,6 +362,66 @@ describe('executeTest', () => {
     expect(serialized).toContain('***');
     // …but the real value reached the page
     expect(page.calls).toContain('fill role:textbox|Password=s3cret');
+  });
+
+  // Spec agentic-execution, scenario "Budget exhausted mid-step" (design D3): a
+  // budget/deadline stop ends the run, it does not fail the step or the test.
+  describe('budget exhaustion (design D3)', () => {
+    it('propagates BudgetExhaustedError from nextAction instead of failing the step', async () => {
+      const page = new FakePage();
+      const brain = scriptedBrain([new BudgetExhaustedError('calls', 5, 5)]);
+
+      await expect(
+        executeTest(page, makeTest(), {
+          brain,
+          sessionDir,
+          baseUrl: 'http://x.test',
+          snapshot: async () => 'snap',
+        }),
+      ).rejects.toThrow(BudgetExhaustedError);
+    });
+
+    it('propagates BudgetExhaustedError from judge instead of failing the step', async () => {
+      const page = new FakePage();
+      const brain: AgentBrain = {
+        nextAction: async () => ({ action: 'assert', reasoning: 'check', expectation: 'total is $80' }),
+        judge: async () => {
+          throw new BudgetExhaustedError('tokens', 1000, 1000);
+        },
+      };
+
+      await expect(
+        executeTest(page, makeTest(), {
+          brain,
+          sessionDir,
+          baseUrl: 'http://x.test',
+          snapshot: async () => 'snap',
+        }),
+      ).rejects.toThrow(BudgetExhaustedError);
+    });
+
+    it('does not spend it from the retry budget: a single exhaustion is never retried', async () => {
+      const page = new FakePage();
+      let calls = 0;
+      const brain: AgentBrain = {
+        nextAction: async () => {
+          calls++;
+          throw new BudgetExhaustedError('calls', 1, 1);
+        },
+        judge: async () => ({ pass: true, reason: 'n/a' }),
+      };
+
+      await expect(
+        executeTest(page, makeTest(), {
+          brain,
+          sessionDir,
+          baseUrl: 'http://x.test',
+          maxRetries: 3,
+          snapshot: async () => 'snap',
+        }),
+      ).rejects.toThrow(BudgetExhaustedError);
+      expect(calls).toBe(1);
+    });
   });
 });
 

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -38,6 +38,19 @@ function failed(summary: string, screenshot?: string): TestResult {
   };
 }
 
+function notRun(summary: string, reason: string): TestResult {
+  return {
+    file: '.blastproof/tests/never.yaml',
+    summary,
+    priority: 'P0',
+    tags: [],
+    status: 'not-run',
+    steps: [],
+    reason,
+    durationMs: 0,
+  };
+}
+
 const SKIPPED: SkippedCase[] = [{ path: '.blastproof/tests/legacy.yaml', summary: 'Legacy test' }];
 
 describe('escapeHtml', () => {
@@ -139,6 +152,51 @@ describe('renderHtml', () => {
     });
     const detail = html.slice(html.indexOf('<details'));
     expect(detail.indexOf('a failure')).toBeLessThan(detail.indexOf('a pass'));
+  });
+});
+
+describe('renderHtml: incomplete runs (spec run-budget)', () => {
+  it('shows a banner naming the stop when the run is incomplete', async () => {
+    const html = await renderHtml([passed('a')], [], {
+      score: 100,
+      durationMs: 1,
+      incomplete: 'model call budget exhausted: reached the configured maximum of 5 call(s)',
+    });
+    expect(html).toContain('Run stopped:');
+    expect(html).toContain('model call budget exhausted');
+  });
+
+  it('omits the banner on a complete run', async () => {
+    const html = await renderHtml([passed('a')], [], { score: 100, durationMs: 1 });
+    expect(html).not.toContain('Run stopped');
+  });
+
+  it('distinguishes a not-run test from a failed one', async () => {
+    const html = await renderHtml([failed('a failure'), notRun('never got here', 'stopped: budget exhausted')], [], {
+      score: 100,
+      durationMs: 1,
+      incomplete: 'stopped: budget exhausted',
+    });
+    expect(html).toContain('NOT RUN');
+    expect(html).toContain('never got here');
+    // The not-run test's own table row is tagged "skip", never "fail".
+    const rowStart = html.lastIndexOf('<tr>', html.indexOf('never got here'));
+    const rowEnd = html.indexOf('</tr>', rowStart);
+    const row = html.slice(rowStart, rowEnd);
+    expect(row).toContain('tag skip');
+    expect(row).not.toContain('tag fail');
+  });
+
+  it('puts not-run tests after failures but before passes, and counts them separately', async () => {
+    const html = await renderHtml(
+      [passed('a pass'), notRun('never got here', 'stopped'), failed('a failure')],
+      [],
+      { score: 100, durationMs: 1, incomplete: 'stopped' },
+    );
+    const detail = html.slice(html.indexOf('<details'));
+    expect(detail.indexOf('a failure')).toBeLessThan(detail.indexOf('never got here'));
+    expect(detail.indexOf('never got here')).toBeLessThan(detail.indexOf('a pass'));
+    expect(html).toContain('1 not run');
   });
 });
 

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -31,6 +31,19 @@ function failed(summary: string, failedStep: string, reason: string): TestResult
   };
 }
 
+function notRun(summary: string, reason: string): TestResult {
+  return {
+    file: '.blastproof/tests/never.yaml',
+    summary,
+    priority: 'P0',
+    tags: [],
+    status: 'not-run',
+    steps: [],
+    reason,
+    durationMs: 0,
+  };
+}
+
 const SKIPPED: SkippedCase[] = [
   { path: '.blastproof/tests/legacy.yaml', summary: 'Legacy test' },
 ];
@@ -107,6 +120,47 @@ describe('renderJUnit', () => {
     const result = { ...passed('x'), file: '/repo/.blastproof/tests/ok.yaml' };
     const xml = renderJUnit([result], [], { score: 100, durationMs: 1, cwd: '/repo' });
     expect(xml).toContain(`classname="${path.join('.blastproof', 'tests', 'ok.yaml')}"`);
+  });
+});
+
+describe('renderJUnit: incomplete runs (spec run-budget)', () => {
+  it('emits a not-run test as skipped, naming the limit in the message', () => {
+    const xml = renderJUnit(
+      [passed('one'), notRun('two', 'model call budget exhausted: reached the configured maximum of 5 call(s)')],
+      [],
+      { score: 100, durationMs: 10 },
+    );
+    expect(xml).toContain('name="two" time="0.000"');
+    expect(xml).toContain('<skipped message="model call budget exhausted');
+    expect(xml).not.toContain('<failure');
+  });
+
+  it('counts not-run tests in skipped, not in failures', () => {
+    const xml = renderJUnit([passed('one'), notRun('two', 'stopped')], [], {
+      score: 100,
+      durationMs: 10,
+    });
+    expect(xml).toContain('tests="2"');
+    expect(xml).toContain('failures="0"');
+    expect(xml).toContain('skipped="1"');
+  });
+
+  it('adds skipped and unrouted counts together', () => {
+    const xml = renderJUnit([notRun('two', 'stopped')], SKIPPED, { score: 100, durationMs: 10 });
+    expect(xml).toContain('skipped="2"');
+  });
+
+  it('records the run as incomplete, naming the reason, only when it is', () => {
+    const complete = renderJUnit([passed('x')], [], { score: 100, durationMs: 10 });
+    expect(complete).not.toContain('name="incomplete"');
+
+    const incomplete = renderJUnit([passed('x'), notRun('y', 'stopped')], [], {
+      score: 100,
+      durationMs: 10,
+      incomplete: 'model call budget exhausted: reached the configured maximum of 5 call(s)',
+    });
+    expect(incomplete).toContain('<property name="incomplete" value="true"/>');
+    expect(incomplete).toContain('<property name="incomplete_reason" value="model call budget exhausted');
   });
 });
 

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DiffError } from '../src/diff.js';
+import { BudgetExhaustedError } from '../src/runner/budget.js';
 
 const { launchMock, getChangedFilesMock, createPlannerMock, generateForRouteMock } = vi.hoisted(
   () => ({
@@ -229,6 +230,41 @@ describe('planCommand preview vs write', () => {
     await expect(readFile(path.join(testsDir(), 'cart.yaml'), 'utf8')).resolves.toContain(
       'apply a discount',
     );
+  });
+});
+
+describe('planCommand budget (spec run-budget: test planning counts against the budget)', () => {
+  it('wires the resolved budget (flag > config) into createPlanner', async () => {
+    await writeProject();
+
+    const code = await planCommand({ cwd: dir, routes: ['/cart'], maxLlmCalls: 1 });
+
+    expect(code).toBe(EXIT_OK);
+    expect(createPlannerMock).toHaveBeenCalled();
+    const budget = createPlannerMock.mock.calls.at(-1)?.[2];
+    expect(budget).toBeDefined();
+    budget.check(); // 0 calls recorded yet: must not throw
+    budget.record(undefined);
+    expect(() => budget.check()).toThrow(/model call budget exhausted/);
+  });
+
+  it('stops generating once the budget is exhausted, without misreporting it as a route failure', async () => {
+    await writeProject();
+    generateForRouteMock.mockImplementation(async (_page: unknown, options: { route: string }) => {
+      if (options.route === '/cart') throw new BudgetExhaustedError('calls', 1, 1);
+      return { ...DRAFT, routes: [options.route] };
+    });
+
+    const code = await planCommand({ cwd: dir, routes: ['/cart', '/settings'] });
+
+    expect(code).toBe(EXIT_FAILED);
+    // /settings was never attempted: the run stopped at /cart, it did not fail it.
+    expect(generateForRouteMock).toHaveBeenCalledTimes(1);
+    expect(out()).toContain('Stopped:');
+    expect(out()).toContain('model call budget exhausted');
+    expect(out()).not.toContain('Failed:');
+    expect(out()).toContain('Not attempted (run out of budget):');
+    expect(out()).toContain('/settings');
   });
 });
 

--- a/tests/run-budget.test.ts
+++ b/tests/run-budget.test.ts
@@ -1,0 +1,210 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BudgetExhaustedError } from '../src/runner/budget.js';
+
+const { launchMock, createBrainMock, executeTestMock } = vi.hoisted(() => ({
+  launchMock: vi.fn(),
+  createBrainMock: vi.fn(),
+  executeTestMock: vi.fn(),
+}));
+
+vi.mock('playwright', () => ({ chromium: { launch: launchMock } }));
+
+// A real RunBudget is exercised through createBrain in production; these tests
+// drive the same BudgetExhaustedError the wrapper would throw, so runCommand's
+// handling of it — not the wrapper itself (covered in brain.test.ts) — is what's
+// under test here.
+vi.mock('../src/runner/executor.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/runner/executor.js')>();
+  return { ...original, executeTest: executeTestMock };
+});
+
+vi.mock('../src/llm/brain.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/llm/brain.js')>();
+  return { ...original, createBrain: createBrainMock };
+});
+
+import { EXIT_FAILED, runCommand } from '../src/commands/run.js';
+
+const CONFIG = [
+  'base_url: http://localhost:4173',
+  'llm:',
+  '  provider: anthropic',
+  '  api_key_env: BLASTPROOF_BUDGET_TEST_KEY',
+  'budget:',
+  '  max_llm_calls: 5',
+  '',
+].join('\n');
+
+const TEST_A = 'summary: Test A\npriority: P0\nsteps:\n  - do a\n';
+const TEST_B = 'summary: Test B\npriority: P0\nsteps:\n  - do b\n';
+const TEST_C = 'summary: Test C\npriority: P0\nsteps:\n  - do c\n';
+
+let dir: string;
+let logs: string[];
+
+const out = (): string => logs.join('\n');
+
+function browserDouble(): unknown {
+  return {
+    newContext: async () => ({
+      newPage: async () => ({ setDefaultTimeout: () => {} }),
+      storageState: async () => ({ cookies: [], origins: [] }),
+      close: async () => {},
+    }),
+    close: async () => {},
+  };
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'blastproof-runbudget-'));
+  logs = [];
+  launchMock.mockReset();
+  createBrainMock.mockReset();
+  executeTestMock.mockReset();
+
+  launchMock.mockResolvedValue(browserDouble());
+  createBrainMock.mockReturnValue({ nextAction: vi.fn(), judge: vi.fn() });
+  process.env.BLASTPROOF_BUDGET_TEST_KEY = 'key';
+
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  delete process.env.BLASTPROOF_BUDGET_TEST_KEY;
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function writeProject(tests: Record<string, string>): Promise<void> {
+  await mkdir(path.join(dir, '.blastproof', 'tests'), { recursive: true });
+  await writeFile(path.join(dir, '.blastproof', 'config.yaml'), CONFIG);
+  for (const [name, content] of Object.entries(tests)) {
+    await writeFile(path.join(dir, '.blastproof', 'tests', name), content);
+  }
+}
+
+function passingResult(test: { path: string; summary: string; priority: string; tags: string[] }): {
+  file: string;
+  summary: string;
+  priority: string;
+  tags: string[];
+  status: 'passed';
+  steps: never[];
+  durationMs: number;
+} {
+  return {
+    file: test.path,
+    summary: test.summary,
+    priority: test.priority,
+    tags: test.tags,
+    status: 'passed',
+    steps: [],
+    durationMs: 10,
+  };
+}
+
+describe('runCommand budget exhaustion (design D3/D4, spec run-budget)', () => {
+  it('stops the run, marks the remaining tests not run, and exits 1 even though all executed tests passed', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B, 'c.yaml': TEST_C });
+    executeTestMock.mockImplementation(
+      async (_page: unknown, test: { path: string; summary: string; priority: string; tags: string[] }) => {
+        if (test.summary === 'Test B') {
+          throw new BudgetExhaustedError('calls', 5, 5);
+        }
+        return passingResult(test);
+      },
+    );
+
+    const code = await runCommand({ cwd: dir, tags: [] });
+
+    expect(code).toBe(EXIT_FAILED);
+    expect(out()).toContain('Run incomplete');
+    expect(out()).toContain('model call budget exhausted');
+    // Test A ran and passed; Test B was interrupted; Test C never started.
+    expect(out()).toContain('Test A');
+    expect(out()).toMatch(/NOT RUN\s+P0\s+Test B/);
+    expect(out()).toMatch(/NOT RUN\s+P0\s+Test C/);
+  });
+
+  it('does not let --min-score rescue an incomplete run', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B });
+    executeTestMock.mockImplementation(
+      async (_page: unknown, test: { path: string; summary: string; priority: string; tags: string[] }) => {
+        if (test.summary === 'Test B') throw new BudgetExhaustedError('calls', 5, 5);
+        return passingResult(test);
+      },
+    );
+
+    // Test A alone would score 100 and satisfy any threshold.
+    const code = await runCommand({ cwd: dir, tags: [], minScore: 1 });
+
+    expect(code).toBe(EXIT_FAILED);
+  });
+
+  it('excludes the not-run test from the score, rather than counting it as a failure', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B });
+    executeTestMock.mockImplementation(
+      async (_page: unknown, test: { path: string; summary: string; priority: string; tags: string[] }) => {
+        if (test.summary === 'Test B') throw new BudgetExhaustedError('calls', 5, 5);
+        return passingResult(test);
+      },
+    );
+
+    await runCommand({ cwd: dir, tags: [] });
+
+    // If Test B counted as a failure the score would be 0, not 100.
+    expect(out()).toContain('Score over executed tests: 100');
+  });
+
+  it('wires the resolved budget (flag > config) into createBrain for every test', async () => {
+    await writeProject({ 'a.yaml': TEST_A });
+    executeTestMock.mockImplementation(
+      async (_page: unknown, test: { path: string; summary: string; priority: string; tags: string[] }) =>
+        passingResult(test),
+    );
+
+    // Config says 5; the flag tightens it to 1.
+    await runCommand({ cwd: dir, tags: [], maxLlmCalls: 1 });
+
+    expect(createBrainMock).toHaveBeenCalled();
+    const budget = createBrainMock.mock.calls.at(-1)?.[2];
+    expect(budget).toBeDefined();
+    budget.check(); // 0 calls recorded yet: must not throw
+    budget.record(undefined);
+    expect(() => budget.check()).toThrow(/model call budget exhausted/);
+  });
+
+  it('marks every selected test not run when the budget is already exhausted during login', async () => {
+    const authConfig = [
+      'base_url: http://localhost:4173',
+      'llm:',
+      '  provider: anthropic',
+      '  api_key_env: BLASTPROOF_BUDGET_TEST_KEY',
+      'auth:',
+      '  steps:',
+      '    - sign in',
+      'budget:',
+      '  max_llm_calls: 5',
+      '',
+    ].join('\n');
+    await mkdir(path.join(dir, '.blastproof', 'tests'), { recursive: true });
+    await writeFile(path.join(dir, '.blastproof', 'config.yaml'), authConfig);
+    await writeFile(path.join(dir, '.blastproof', 'tests', 'a.yaml'), TEST_A);
+
+    executeTestMock.mockImplementation(async () => {
+      throw new BudgetExhaustedError('calls', 5, 5);
+    });
+
+    const code = await runCommand({ cwd: dir, tags: [] });
+
+    expect(code).toBe(EXIT_FAILED);
+    expect(out()).toContain('Run incomplete');
+    expect(out()).toMatch(/NOT RUN\s+P0\s+Test A/);
+  });
+});

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -16,7 +16,8 @@ vi.mock('../src/diff.js', async (importOriginal) => {
   return { ...original, getChangedFiles: getChangedFilesMock };
 });
 
-import { EXIT_FAILED, EXIT_OK, EXIT_USAGE, runCommand } from '../src/commands/run.js';
+import { EXIT_FAILED, EXIT_OK, EXIT_USAGE, resolveBudgetOptions, runCommand } from '../src/commands/run.js';
+import { loadConfig } from '../src/config.js';
 
 const CART_TEST = `summary: Cart discount
 priority: P0
@@ -162,6 +163,51 @@ describe('runCommand --dry-run', () => {
     // The routed-but-not-impacted login test is neither selected nor reported.
     expect(out()).not.toContain('Login succeeds');
     expect(out()).toContain('no browser launched, no LLM calls made');
+    // Spec run-budget: the ceiling for the selection, labelled a maximum (design
+    // D5) — CART_TEST has one step; default iteration cap 15 plus default retry
+    // budget 3 (config `max_retries_per_step`, not assumed): 1 * (15 + 3) = 18.
+    expect(out()).toContain('Worst case: up to 18 model call(s)');
+    expect(out()).toContain('a maximum, not a prediction');
+  });
+
+  it('reports zero worst-case calls for an empty selection', async () => {
+    await writeProject({ 'cart.yaml': CART_TEST });
+    getChangedFilesMock.mockResolvedValue(['docs/guide.md']);
+
+    const code = await runCommand({ cwd: dir, tags: [], impacted: true, dryRun: true });
+
+    expect(code).toBe(EXIT_OK);
+    expect(out()).toContain('Worst case: up to 0 model call(s)');
+  });
+
+  it('includes the login journey in the ceiling when auth.steps is configured (DEF-001 follow-up)', async () => {
+    // `authenticate()` runs auth.steps through the same executeTest loop and
+    // spends model calls (design D8) — a ceiling that omitted it would be
+    // exceedable by the first real run of this same selection.
+    const config = [
+      'base_url: http://localhost:4173',
+      'llm:',
+      '  provider: anthropic',
+      '  api_key_env: BLASTPROOF_TEST_MISSING_KEY',
+      'routes:',
+      '  "src/cart/**": ["/cart"]',
+      'auth:',
+      '  steps:',
+      '    - go to the login page',
+      '    - sign in with test credentials',
+      '',
+    ].join('\n');
+    await mkdir(path.join(dir, '.blastproof', 'tests'), { recursive: true });
+    await writeFile(path.join(dir, '.blastproof', 'config.yaml'), config);
+    await writeFile(path.join(dir, '.blastproof', 'tests', 'cart.yaml'), CART_TEST);
+    getChangedFilesMock.mockResolvedValue(['src/cart/discount.ts']);
+
+    const code = await runCommand({ cwd: dir, tags: [], impacted: true, dryRun: true });
+
+    expect(code).toBe(EXIT_OK);
+    // CART_TEST's 1 step plus auth's 2 steps = 3 * (15 + 3) = 54.
+    expect(out()).toContain('Worst case: up to 54 model call(s)');
+    expect(out()).toContain('including the login journey');
   });
 
   it('without --impacted, prints the tests that would run after filters', async () => {
@@ -382,6 +428,65 @@ describe('config precedence: flag > env > file', () => {
     expect(code).toBe(EXIT_USAGE);
     expect(errOut()).toContain('BLASTPROOF_LLM_PROVIDER');
     expect(launchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveBudgetOptions precedence: flag > env > file (spec run-budget)', () => {
+  it('is unbound when nothing is configured — inert by default', async () => {
+    await writeProject({ 'cart.yaml': CART_TEST });
+    const config = await loadConfig(dir);
+
+    const resolved = resolveBudgetOptions(config, { cwd: dir, tags: [] });
+
+    expect(resolved).toEqual({ maxCalls: undefined, maxTokens: undefined, maxDurationMs: undefined });
+  });
+
+  it('uses the file when nothing else is set', async () => {
+    await writeProject({ 'cart.yaml': CART_TEST });
+    await writeFile(
+      path.join(dir, '.blastproof', 'config.yaml'),
+      'base_url: http://localhost:4173\nbudget:\n  max_llm_calls: 500\n  max_duration_s: 60\n',
+    );
+    const config = await loadConfig(dir);
+
+    const resolved = resolveBudgetOptions(config, { cwd: dir, tags: [] });
+
+    expect(resolved.maxCalls).toBe(500);
+    expect(resolved.maxDurationMs).toBe(60_000);
+  });
+
+  it('lets the environment beat the file', async () => {
+    await writeProject({ 'cart.yaml': CART_TEST });
+    await writeFile(
+      path.join(dir, '.blastproof', 'config.yaml'),
+      'base_url: http://localhost:4173\nbudget:\n  max_llm_calls: 500\n',
+    );
+    const config = await loadConfig(dir, { BLASTPROOF_MAX_LLM_CALLS: '20' });
+
+    const resolved = resolveBudgetOptions(config, { cwd: dir, tags: [] });
+
+    expect(resolved.maxCalls).toBe(20);
+  });
+
+  it('lets the flag beat both the environment and the file', async () => {
+    await writeProject({ 'cart.yaml': CART_TEST });
+    await writeFile(
+      path.join(dir, '.blastproof', 'config.yaml'),
+      'base_url: http://localhost:4173\nbudget:\n  max_llm_calls: 500\n',
+    );
+    const config = await loadConfig(dir, { BLASTPROOF_MAX_LLM_CALLS: '20' });
+
+    const resolved = resolveBudgetOptions(config, { cwd: dir, tags: [], maxLlmCalls: 3 });
+
+    expect(resolved.maxCalls).toBe(3);
+  });
+
+  it('converts the seconds flag/config to milliseconds for the budget', () => {
+    const config = { budget: undefined } as unknown as Parameters<typeof resolveBudgetOptions>[0];
+
+    const resolved = resolveBudgetOptions(config, { cwd: dir, tags: [], maxDuration: 30 });
+
+    expect(resolved.maxDurationMs).toBe(30_000);
   });
 });
 

--- a/tests/score.test.ts
+++ b/tests/score.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { computeScore, formatScoreLine, WEIGHTS } from '../src/report/score.js';
+import { computeScore, formatIncompleteLine, formatScoreLine, WEIGHTS } from '../src/report/score.js';
 import type { TestResult } from '../src/runner/executor.js';
 
-function result(priority: string, status: 'passed' | 'failed'): TestResult {
+function result(priority: string, status: 'passed' | 'failed' | 'not-run'): TestResult {
   return {
     file: `.blastproof/tests/${priority}-${status}.yaml`,
     summary: `${priority} ${status}`,
@@ -61,6 +61,16 @@ describe('computeScore', () => {
     expect(WEIGHTS.P1).toBe(2);
     expect(computeScore([result('P9', 'passed')])).toBe(100);
   });
+
+  it('excludes not-run tests from the denominator, rather than counting them as failures (design D4)', () => {
+    // If not-run counted as a failure this would score 50 (1 of 2 weight units);
+    // excluded, it scores 100 — the one executed test's own result decides it.
+    expect(computeScore([result('P0', 'passed'), result('P0', 'not-run')])).toBe(100);
+  });
+
+  it('scores 100 when every test is not run (an empty-equivalent denominator)', () => {
+    expect(computeScore([result('P0', 'not-run'), result('P1', 'not-run')])).toBe(100);
+  });
 });
 
 describe('formatScoreLine', () => {
@@ -77,5 +87,15 @@ describe('formatScoreLine', () => {
     expect(formatScoreLine(60, results, 80)).toContain('min-score 80');
     expect(formatScoreLine(60, results, 80)).toContain('FAIL');
     expect(formatScoreLine(85, results, 80)).toContain('pass');
+  });
+});
+
+describe('formatIncompleteLine (spec run-budget, design D3/D4)', () => {
+  it('names the stop reason and states the score is not a verdict', () => {
+    const line = formatIncompleteLine(100, 'model call budget exhausted: reached the configured maximum of 5 call(s)');
+    expect(line).toContain('Run incomplete');
+    expect(line).toContain('model call budget exhausted');
+    expect(line).toContain('not a verdict');
+    expect(line).toContain('regardless of --min-score');
   });
 });

--- a/tests/test-command.test.ts
+++ b/tests/test-command.test.ts
@@ -3,15 +3,23 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DiffError } from '../src/diff.js';
+import { BudgetExhaustedError } from '../src/runner/budget.js';
 
-const { launchMock, getChangedFilesMock, createPlannerMock, generateForRouteMock, executeTestMock } =
-  vi.hoisted(() => ({
-    launchMock: vi.fn(),
-    getChangedFilesMock: vi.fn(),
-    createPlannerMock: vi.fn(),
-    generateForRouteMock: vi.fn(),
-    executeTestMock: vi.fn(),
-  }));
+const {
+  launchMock,
+  getChangedFilesMock,
+  createBrainMock,
+  createPlannerMock,
+  generateForRouteMock,
+  executeTestMock,
+} = vi.hoisted(() => ({
+  launchMock: vi.fn(),
+  getChangedFilesMock: vi.fn(),
+  createBrainMock: vi.fn(),
+  createPlannerMock: vi.fn(),
+  generateForRouteMock: vi.fn(),
+  executeTestMock: vi.fn(),
+}));
 
 vi.mock('playwright', () => ({ chromium: { launch: launchMock } }));
 
@@ -29,7 +37,7 @@ vi.mock('../src/diff.js', async (importOriginal) => {
 
 vi.mock('../src/llm/brain.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../src/llm/brain.js')>();
-  return { ...original, createPlanner: createPlannerMock };
+  return { ...original, createBrain: createBrainMock, createPlanner: createPlannerMock };
 });
 
 vi.mock('../src/planner.js', async (importOriginal) => {
@@ -77,11 +85,13 @@ beforeEach(async () => {
   errors = [];
   launchMock.mockReset();
   getChangedFilesMock.mockReset();
+  createBrainMock.mockReset();
   createPlannerMock.mockReset();
   generateForRouteMock.mockReset();
   executeTestMock.mockReset();
 
   launchMock.mockResolvedValue(fakeBrowser());
+  createBrainMock.mockReturnValue({ nextAction: vi.fn(), judge: vi.fn() });
   executeTestMock.mockImplementation(async (_page: unknown, test: { path: string; summary: string; priority: string; tags: string[] }) => ({
     file: test.path,
     summary: test.summary,
@@ -239,5 +249,45 @@ describe('testCommand', () => {
     await testCommand({ cwd: dir, base: 'develop' });
 
     expect(getChangedFilesMock).toHaveBeenCalledWith('develop', dir);
+  });
+});
+
+describe('testCommand budget (spec run-budget: one budget spans both phases)', () => {
+  it('hands the run phase and the plan phase the same budget instance, not one each', async () => {
+    await writeProject({ 'cart.yaml': CART_TEST });
+    // /cart is covered (run phase exercises it); /settings is not (plan phase drafts it).
+    getChangedFilesMock.mockResolvedValue(['src/cart/discount.ts', 'src/settings/flags.ts']);
+
+    const code = await testCommand({ cwd: dir, maxLlmCalls: 5 });
+
+    expect(code).toBe(EXIT_OK);
+    expect(createBrainMock).toHaveBeenCalled();
+    expect(createPlannerMock).toHaveBeenCalled();
+    const runPhaseBudget = createBrainMock.mock.calls.at(-1)?.[2];
+    const planPhaseBudget = createPlannerMock.mock.calls.at(-1)?.[2];
+    expect(runPhaseBudget).toBeDefined();
+    // Reference equality, not merely equal limits: a fresh budget with the same
+    // configured maximum would pass a looser check but still be two allowances.
+    expect(planPhaseBudget).toBe(runPhaseBudget);
+  });
+
+  it('does not grant the plan phase a fresh allowance once the run phase has spent the budget', async () => {
+    await writeProject({ 'cart.yaml': CART_TEST });
+    getChangedFilesMock.mockResolvedValue(['src/cart/discount.ts', 'src/settings/flags.ts']);
+    // Stands in for what the real createBrain wrapper does on every call: spend
+    // one unit of the shared budget before the test's outcome is even decided.
+    createBrainMock.mockImplementation((_model: unknown, _generate: unknown, budget: { record: (u: unknown) => void }) => {
+      budget?.record(undefined);
+      return { nextAction: vi.fn(), judge: vi.fn() };
+    });
+
+    const code = await testCommand({ cwd: dir, maxLlmCalls: 1 });
+
+    expect(code).toBe(EXIT_OK);
+    const planPhaseBudget = createPlannerMock.mock.calls.at(-1)?.[2] as { check: () => void };
+    expect(planPhaseBudget).toBeDefined();
+    // The one call the run phase spent already exhausted the shared allowance —
+    // a fresh budget handed to `plan` would not throw here.
+    expect(() => planPhaseBudget.check()).toThrow(/model call budget exhausted/);
   });
 });


### PR DESCRIPTION
Addresses the budget and deadline half of #2. **#2 stays open for worker parallelism**, which is deliberately out of scope — it is a change of a different kind (concurrency, browser context lifecycle, interleaved output, deterministic report ordering) and belongs in its own proposal.

## What now exists

A run carries an optional budget — maximum model calls, maximum tokens — and a deadline. Configurable in `budget:`, by `--max-llm-calls` / `--max-tokens` / `--max-duration`, or by `BLASTPROOF_MAX_*`, on `run`, `plan` and `test` alike. `test` composes two phases and shares one budget across both, rather than granting each its own allowance.

`--dry-run` now reports the ceiling a selection cannot exceed, so a limit can be chosen from evidence instead of guessed.

## Three decisions worth recording

**Enforcement wraps the one function every model call already passes through** (`createBrain`/`createPlanner`), not the loop in `runCommand`. The parameter is **required**, so a command that starts prompting cannot silently escape it — the compiler refuses. This mattered immediately: the first implementation left `plan` unbudgeted, which the spec's "agent action, assert judgment, or test planning" clause forbids. With the parameter optional, `tsc` could not have caught the very omission being fixed.

**Limits count calls and tokens, never currency.** A price table keyed by model and provider goes stale the day a provider reprices, is wrong for anyone behind a gateway, and fails in the way that matters least visibly: the cap quietly stops binding while still being trusted.

**Exhaustion ends the run; it never fails a test.** Running out of quota says nothing about the application under test, and a red test meaning "no credit left" is worse than useless in review. Unexecuted tests get a third state, `not-run`, excluded from the score denominator rather than counted as failures — counting them as failures would replace one lie with a quieter one. An incomplete run exits 1 unconditionally and `--min-score` cannot rescue it, because the tests that finished are the ones that came first, not the ones that mattered.

## Verified in CI, not only in unit tests

With `max_llm_calls=20` (run `30473778580`):

```
PASS     P1  App loads and shows the home page      3.5s
NOT RUN  P0  Promo code SAVE20 applies a 20% ...    0.0s
NOT RUN  P0  Completing checkout displays ...       0.0s
NOT RUN  P0  Login with valid credentials ...       0.0s
NOT RUN  P1  Order history lists past orders ...    0.0s
1 passed, 0 failed, 4 not run, 5 total
Run incomplete: model call budget exhausted: reached the configured maximum of 20 call(s)
Score over executed tests: 100 (not a verdict — exit code 1 regardless of --min-score)
exit code 1
```

The executed test passed, the score over executed tests is 100, and it still exits 1.

With no budget configured (run `30473914460`): `Score: 100 — min-score 80: pass`, 5 passed, exit 0. The default is genuinely inert — the outcome that would have been worst to get wrong, since a limit that accidentally binds would break every existing suite silently.

One defect was found and fixed during review (DEF-001): the dry-run ceiling was `steps × iterations × 2` and omitted the retry pool, so it undershot whenever `max_retries_per_step` exceeded the iteration cap — an estimate that undershoots is worse than none, because a budget gets sized from it. The bound is now `N + R` per step, verified against the real executor across seven `(N, R)` regimes.

## What remains here

Worker parallelism. It is a change of a different kind — concurrency, browser context lifecycle, interleaved console output, deterministic report ordering — and belongs in its own proposal rather than bolted onto this one.
