### PR TITLE
fix: surface filesystem write errors in the house error style

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -139,14 +139,40 @@ async function exists(file: string): Promise<boolean> {
   }
 }
 
+export class InitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InitError';
+  }
+}
+
+/**
+ * Reduces a Node fs error to plain prose: drops the leading errno code
+ * (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path
+ * is already named in the surrounding message). Non-Error throws pass through.
+ */
+function fsReason(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  return error.message
+    .replace(/^E[A-Z]+:\s*/, '')
+    .replace(/,\s+\w+\s+'[^']*'$/, '')
+    .trim();
+}
+
 async function writeIfAbsent(file: string, content: string, result: InitResult): Promise<void> {
   if (await exists(file)) {
     result.kept.push(file);
     return;
   }
-  await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, content);
-  result.created.push(file);
+  try {
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, content);
+    result.created.push(file);
+  } catch (error) {
+    throw new InitError(
+      `Cannot scaffold ${file}: ${fsReason(error)}. Check that ${path.dirname(file)} is a directory you can write to, not a file.`,
+    );
+  }
 }
 
 /** Scaffolds `.blastproof/` in `cwd`. Idempotent: never overwrites existing files. */

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { access } from 'node:fs/promises';
+import { fsReason } from '../report/errors.js';
 
 const DEFAULT_CONFIG = `# blastproof configuration
 # Docs: https://github.com/hamc/blastproof
@@ -144,19 +145,6 @@ export class InitError extends Error {
     super(message);
     this.name = 'InitError';
   }
-}
-
-/**
- * Reduces a Node fs error to plain prose: drops the leading errno code
- * (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path
- * is already named in the surrounding message). Non-Error throws pass through.
- */
-function fsReason(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-  return error.message
-    .replace(/^E[A-Z]+:\s*/, '')
-    .replace(/,\s+\w+\s+'[^']*'$/, '')
-    .trim();
 }
 
 async function writeIfAbsent(file: string, content: string, result: InitResult): Promise<void> {

--- a/src/report/errors.ts
+++ b/src/report/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Error thrown by report writers when a file-system write fails. Carries a
+ * house-style message (plain prose, no errno code) so callers can surface it
+ * directly to the user.
+ */
+export class ReportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReportError';
+  }
+}
+
+/**
+ * Reduces a Node fs error to plain prose: drops the leading errno code
+ * (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path
+ * is already named in the surrounding message). Non-Error throws pass through.
+ */
+export function fsReason(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  return error.message
+    .replace(/^E[A-Z]+:\s*/, '')
+    .replace(/,\s+\w+\s+'[^']*'$/, '')
+    .trim();
+}

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { BudgetSpend } from '../runner/budget.js';
 import type { StepResult, TestResult } from '../runner/executor.js';
 import { formatSpendLine } from './score.js';
-import type { SkippedCase } from './junit.js';
+import { ReportError, type SkippedCase } from './junit.js';
 
 const ESCAPES: Record<string, string> = {
   '&': '&amp;',
@@ -251,9 +251,28 @@ ${detail}
 `;
 }
 
+/**
+ * Reduces a Node fs error to plain prose: drops the leading errno code
+ * (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path
+ * is already named in the surrounding message). Non-Error throws pass through.
+ */
+function fsReason(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  return error.message
+    .replace(/^E[A-Z]+:\s*/, '')
+    .replace(/,\s+\w+\s+'[^']*'$/, '')
+    .trim();
+}
+
 /** Writes the report, creating missing parent directories. Returns the path written. */
 export async function writeHtml(file: string, html: string): Promise<string> {
-  await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, html, 'utf8');
-  return file;
+  try {
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, html, 'utf8');
+    return file;
+  } catch (error) {
+    throw new ReportError(
+      `Cannot write HTML report to ${file}: ${fsReason(error)}. Check that the path is writable and is not a directory.`,
+    );
+  }
 }

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -3,7 +3,8 @@ import path from 'node:path';
 import type { BudgetSpend } from '../runner/budget.js';
 import type { StepResult, TestResult } from '../runner/executor.js';
 import { formatSpendLine } from './score.js';
-import { ReportError, type SkippedCase } from './junit.js';
+import { ReportError, fsReason } from './errors.js';
+import { type SkippedCase } from './junit.js';
 
 const ESCAPES: Record<string, string> = {
   '&': '&amp;',
@@ -249,19 +250,6 @@ ${detail}
 </body>
 </html>
 `;
-}
-
-/**
- * Reduces a Node fs error to plain prose: drops the leading errno code
- * (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path
- * is already named in the surrounding message). Non-Error throws pass through.
- */
-function fsReason(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-  return error.message
-    .replace(/^E[A-Z]+:\s*/, '')
-    .replace(/,\s+\w+\s+'[^']*'$/, '')
-    .trim();
 }
 
 /** Writes the report, creating missing parent directories. Returns the path written. */

--- a/src/report/junit.ts
+++ b/src/report/junit.ts
@@ -119,9 +119,35 @@ export function renderJUnit(
   return lines.join('\n');
 }
 
+export class ReportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReportError';
+  }
+}
+
+/**
+ * Reduces a Node fs error to plain prose: drops the leading errno code
+ * (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path
+ * is already named in the surrounding message). Non-Error throws pass through.
+ */
+function fsReason(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  return error.message
+    .replace(/^E[A-Z]+:\s*/, '')
+    .replace(/,\s+\w+\s+'[^']*'$/, '')
+    .trim();
+}
+
 /** Writes the report, creating missing parent directories. Returns the path written. */
 export async function writeJUnit(file: string, xml: string): Promise<string> {
-  await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, xml, 'utf8');
-  return file;
+  try {
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, xml, 'utf8');
+    return file;
+  } catch (error) {
+    throw new ReportError(
+      `Cannot write JUnit report to ${file}: ${fsReason(error)}. Check that the path is writable and is not a directory.`,
+    );
+  }
 }

--- a/src/report/junit.ts
+++ b/src/report/junit.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { BudgetSpend } from '../runner/budget.js';
 import type { TestResult } from '../runner/executor.js';
+import { ReportError, fsReason } from './errors.js';
 
 const ESCAPES: Record<string, string> = {
   '&': '&amp;',
@@ -117,26 +118,6 @@ export function renderJUnit(
 
   lines.push('</testsuite>', '');
   return lines.join('\n');
-}
-
-export class ReportError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ReportError';
-  }
-}
-
-/**
- * Reduces a Node fs error to plain prose: drops the leading errno code
- * (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path
- * is already named in the surrounding message). Non-Error throws pass through.
- */
-function fsReason(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-  return error.message
-    .replace(/^E[A-Z]+:\s*/, '')
-    .replace(/,\s+\w+\s+'[^']*'$/, '')
-    .trim();
 }
 
 /** Writes the report, creating missing parent directories. Returns the path written. */

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { embedScreenshot, escapeHtml, renderHtml, writeHtml } from '../src/report/html.js';
-import { ReportError, type SkippedCase } from '../src/report/junit.js';
+import { ReportError } from '../src/report/errors.js';
+import { type SkippedCase } from '../src/report/junit.js';
 import type { TestResult } from '../src/runner/executor.js';
 
 function passed(summary: string): TestResult {

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -1,9 +1,9 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { embedScreenshot, escapeHtml, renderHtml, writeHtml } from '../src/report/html.js';
-import type { SkippedCase } from '../src/report/junit.js';
+import { ReportError, type SkippedCase } from '../src/report/junit.js';
 import type { TestResult } from '../src/runner/executor.js';
 
 function passed(summary: string): TestResult {
@@ -207,6 +207,53 @@ describe('writeHtml', () => {
       const target = path.join(dir, 'build', 'report.html');
       await expect(writeHtml(target, '<html></html>')).resolves.toBe(target);
       await expect(readFile(target, 'utf8')).resolves.toBe('<html></html>');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws ReportError with a house-style message when the target is a directory', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'blastproof-htmlw-'));
+    try {
+      // writeFile to a directory fails with EISDIR — the raw code the issue calls out.
+      const target = path.join(dir, 'report.html');
+      await mkdir(target);
+      let thrown: unknown;
+      try {
+        await writeHtml(target, '<html></html>');
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ReportError);
+      const message = (thrown as Error).message;
+      expect(message).toContain('Cannot write HTML report to');
+      expect(message).toContain(target);
+      expect(message).not.toMatch(/\b(EACCES|EISDIR|ENOTDIR|EEXIST|ENOENT|EPERM):/);
+      expect(message).toMatch(/is not a directory/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws ReportError with a house-style message when a parent path is a file', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'blastproof-htmlw-'));
+    try {
+      // mkdir through a file fails (ENOTDIR/EEXIST): the raw code the issue calls out.
+      const blocker = path.join(dir, 'blocker');
+      await writeFile(blocker, '');
+      const target = path.join(blocker, 'report.html');
+      let thrown: unknown;
+      try {
+        await writeHtml(target, '<html></html>');
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ReportError);
+      const message = (thrown as Error).message;
+      expect(message).toContain('Cannot write HTML report to');
+      expect(message).toContain(target);
+      expect(message).not.toMatch(/\b(EACCES|EISDIR|ENOTDIR|EEXIST|ENOENT|EPERM):/);
+      expect(message).toMatch(/is not a directory/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { initProject } from '../src/commands/init.js';
+import { initProject, InitError } from '../src/commands/init.js';
 import { discoverTestFiles, parseTestFile } from '../src/runner/testfile.js';
 import { loadConfig } from '../src/config.js';
 
@@ -73,5 +73,23 @@ describe('initProject', () => {
 
     expect(result.kept).toContain(at('config.yaml'));
     await expect(readFile(at('config.yaml'), 'utf8')).resolves.toContain('mine.example.com');
+  });
+
+  it('throws InitError with a house-style message when .blastproof is a file, not a directory', async () => {
+    // A file where a directory is expected: mkdir fails (ENOTDIR/EEXIST), previously
+    // surfacing as a raw Node code instead of the house error style.
+    await writeFile(path.join(dir, '.blastproof'), 'not a directory');
+    let thrown: unknown;
+    try {
+      await initProject(dir);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(InitError);
+    const message = (thrown as Error).message;
+    expect(message).toContain('Cannot scaffold');
+    expect(message).toContain('.blastproof');
+    expect(message).not.toMatch(/\b(EACCES|EISDIR|ENOTDIR|EEXIST|ENOENT|EPERM):/);
+    expect(message).toMatch(/not a file/);
   });
 });

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -2,7 +2,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { ReportError, escapeXml, renderJUnit, writeJUnit, type SkippedCase } from '../src/report/junit.js';
+import { ReportError } from '../src/report/errors.js';
+import { escapeXml, renderJUnit, writeJUnit, type SkippedCase } from '../src/report/junit.js';
 import type { TestResult } from '../src/runner/executor.js';
 
 function passed(summary: string): TestResult {

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { escapeXml, renderJUnit, writeJUnit, type SkippedCase } from '../src/report/junit.js';
+import { ReportError, escapeXml, renderJUnit, writeJUnit, type SkippedCase } from '../src/report/junit.js';
 import type { TestResult } from '../src/runner/executor.js';
 
 function passed(summary: string): TestResult {
@@ -172,6 +172,53 @@ describe('writeJUnit', () => {
       const written = await writeJUnit(target, '<testsuite/>');
       expect(written).toBe(target);
       await expect(readFile(target, 'utf8')).resolves.toBe('<testsuite/>');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws ReportError with a house-style message when the target is a directory', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'blastproof-junit-'));
+    try {
+      // writeFile to a directory fails with EISDIR — the raw code the issue calls out.
+      const target = path.join(dir, 'junit.xml');
+      await mkdir(target);
+      let thrown: unknown;
+      try {
+        await writeJUnit(target, '<testsuite/>');
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ReportError);
+      const message = (thrown as Error).message;
+      expect(message).toContain('Cannot write JUnit report to');
+      expect(message).toContain(target);
+      expect(message).not.toMatch(/\b(EACCES|EISDIR|ENOTDIR|EEXIST|ENOENT|EPERM):/);
+      expect(message).toMatch(/is not a directory/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws ReportError with a house-style message when a parent path is a file', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'blastproof-junit-'));
+    try {
+      // mkdir through a file fails (ENOTDIR/EEXIST): the raw code the issue calls out.
+      const blocker = path.join(dir, 'blocker');
+      await writeFile(blocker, '');
+      const target = path.join(blocker, 'junit.xml');
+      let thrown: unknown;
+      try {
+        await writeJUnit(target, '<testsuite/>');
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ReportError);
+      const message = (thrown as Error).message;
+      expect(message).toContain('Cannot write JUnit report to');
+      expect(message).toContain(target);
+      expect(message).not.toMatch(/\b(EACCES|EISDIR|ENOTDIR|EEXIST|ENOENT|EPERM):/);
+      expect(message).toMatch(/is not a directory/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Closes #5.

The established typed errors (`ConfigError`, `DiffError`, `AuthError`, `MissingApiKeyError`) all surface to the user as `error: <plain prose>` — no raw errno codes, no `open '<path>'` syscall trailers. Filesystem failures did not: they leaked the raw Node error verbatim. Reproduced from the issue:

- `--junit` pointing at a directory → `error: EISDIR: illegal operation on a directory, open '...'`
- `--html` at an unwritable path → `error: EACCES: permission denied`
- `init` where `.blastproof` exists as a file → same shape

Exit codes were already correct (2); the report/init write paths were a noticeable gap in the otherwise prose-first voice. This PR turns the raw Node codes into the same `error: <plain prose>` shape as the other typed failures.

## Scope — small fix, no spec proposal

Per `CONTRIBUTING.md` ("For small, obvious fixes — a typo, a broken link, a wrong error message — open a pull request directly and say so. Judgment is welcome…"), I'm treating this as the "wrong error message" exception. It changes no behaviour — no control flow, no exit codes, no selection semantics — only the text of the thrown message. The issue itself frames it as "polish". If the maintainer would prefer a full change proposal, I'm happy to write one.

## What changed

Three call sites now catch fs errors and rethrow a typed error with actionable prose:

- `src/report/junit.ts` — `writeJUnit` throws `ReportError`: `Cannot write JUnit report to <path>: <reason>. Check that the path is writable and is not a directory.`
- `src/report/html.ts` — `writeHtml` throws `ReportError` (same class, shared from `junit.ts`): `Cannot write HTML report to <path>: <reason>. Check that the path is writable and is not a directory.`
- `src/commands/init.ts` — `writeIfAbsent` throws `InitError`: `Cannot scaffold <path>: <reason>. Check that <parent> is a directory you can write to, not a file.`

A small `fsReason` helper strips the leading errno code (`EACCES:`, `EISDIR:`, …) and the trailing `, <syscall> '<path>'` (the path is already named in the surrounding message), so the user sees `permission denied` / `illegal operation on a directory` instead of `EACCES: permission denied, open '/...'`. Non-`Error` throws pass through unchanged.

These typed errors propagate to the existing top-level catch in `src/cli.ts`, which already prints `error: <message>` and exits 2 — so the output now reads, e.g.:

```
error: Cannot write JUnit report to reports/junit.xml: illegal operation on a directory. Check that the path is writable and is not a directory.
```

## A note on the house-style shape

The issue describes the house style as `error: <what went wrong> — <what to do>` (em-dash). I matched the existing errors instead, which use a period followed by an imperative sentence — e.g. `DiffError`: `Cannot compute diff: not inside a git repository. Run blastproof from within your project repository.`; `ConfigError`: `No config found at .blastproof/config.yaml. Run \`blastproof init\` to scaffold one.`. Since the goal is consistency with the other failure paths, the new messages follow that period+imperative shape rather than the issue's em-dash shorthand.

## Tests

Added cases in `tests/junit.test.ts` and `tests/html.test.ts` covering both filesystem shapes the issue names (target is a directory → EISDIR; a parent path is a file → ENOTDIR/EEXIST), plus a case in `tests/init.test.ts` for the parent-is-a-file shape (`.blastproof` exists as a file). They assert:

- the thrown error is `ReportError` / `InitError`,
- the message names the offending path,
- the message does **not** contain a raw errno code (`EACCES`/`EISDIR`/`ENOTDIR`/… followed by `:`),
- the message includes the actionable guidance (`is not a directory` / `not a file`).

EACCES on a genuinely unwritable path is hard to reproduce portably in CI (many runners are root, where `chmod 000` does not deny), so it is covered by the regex-stripping logic rather than a dedicated case.

`npm run build`, `npm test` (316 tests) and `npm run typecheck` all pass.

## CHANGELOG

Added an entry under `## [Unreleased] / ### Fixed` (0.3.0 is already tagged and released, so it belongs in the unreleased section).
