### PR TITLE
fix: the origin boundary constrains where the page is

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,9 @@ The key itself is never read from a `BLASTPROOF_*` variable — you name *which*
 
 The application under test is not trusted input: its page content reaches the model, so a page that controls its own accessible text can try to influence the agent. Two things constrain that.
 
-**The agent cannot leave your application.** `navigate` is bounded by `base_url`'s origin; an app spanning hosts declares them in `allowed_origins:`. This is enforced by comparison, not by asking the model nicely.
+**The agent cannot leave your application.** The boundary is `base_url`'s origin plus whatever `allowed_origins:` declares, and it constrains where the page **is**, not only where an action asked to go. A `navigate` outside it is refused before the request; a page that ends up outside it any other way — a redirect, a link to another host, a script setting the location — fails the step, and its content is never sent to the model. Enforced by comparison, not by asking the model nicely.
+
+If your application legitimately spans hosts (an identity provider, a hosted payment step), declare them. A suite that was quietly walking onto a foreign page will now fail and name the origin to add.
 
 **Your secrets stay out of prompts.** `{{env.*}}` placeholders survive intact and are substituted at the moment of typing. Every value your tests or auth recipe reference is redacted from everything else crossing into a prompt — page snapshots included — in literal and percent-encoded form. Redaction matches known values, so treat it as a strong default rather than a guarantee against a hostile app.
 

--- a/openspec/changes/contained-navigation/design.md
+++ b/openspec/changes/contained-navigation/design.md
@@ -1,0 +1,67 @@
+## Context
+
+`assertAllowedOrigin(url, ctx)` in `src/runner/actions.ts` builds the allowed set from `base_url` plus `allowed_origins:` and compares the URL it is handed. It is called from exactly one place: the `navigate` branch of `performAction` (`actions.ts:166`), immediately before `page.goto`.
+
+So the boundary holds for one action, against one input, at one moment: the URL the model asked for, before the request is made. Everything after that moment is unchecked.
+
+Measured against 0.7.0 with two local servers, `base_url` = `http://localhost:4197`, nothing declared in `allowed_origins:`:
+
+| what the step did | where the browser ended up | what blastproof reported |
+|---|---|---|
+| `navigate to /away` (`302` → `:4196`) | `http://localhost:4196/` | PASS |
+| `click the "Partner portal" link` (`href` to `:4196`) | `http://localhost:4196/` | PASS |
+
+`Score: 100` for both. In the redirect run the judge stated the foreign URL out loud — *"the snapshot shows the current URL is http://localhost:4196/"* — and the run still passed, because nothing was comparing it to anything.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The boundary constrains where the agent *is*.
+- No page outside the boundary reaches a prompt.
+- One place decides it, for every action, including actions not written yet.
+
+**Non-Goals:**
+- Preventing the HTTP request that a redirect implies. It has already happened when we find out.
+- Any new configuration. `allowed_origins:` is the escape hatch and already exists.
+
+## Decisions
+
+### D1 — Check where the page is, immediately before every snapshot
+
+**Decision.** In the executor's per-step loop, after the settle wait and **before** `takeSnapshot`, compare `page.url()`'s origin against the allowed set. Outside it, the step fails with a reason naming the origin, and no snapshot is taken.
+
+**Why at the snapshot and not after each action.** The snapshot is the single point where the page's content crosses into a prompt, and it is reached exactly once per iteration regardless of what the previous action was. Checking there covers every way a URL can change — `navigate`, a click on an anchor, a form submit, `location.href` from a script, a `meta refresh`, a redirect chain, and any action added to the vocabulary later — without anyone having to remember to add a call. Checking after each action instead would mean enumerating the actions that can navigate, which is the same enumeration mistake in a new place: the accessibility tree cannot tell you whether a button navigates.
+
+It also gives the strongest property available at the right moment: **the content of a page outside the boundary is never sent to the model.** The request has already gone out by then, but the run does not read the response into a prompt, does not keep acting on that page, and does not carry the application's session further into it.
+
+**Why not navigate back to `base_url` and continue.** Recovering silently would hide a real finding: an application that leaves its own origin is something the person running this needs to be told about, not something to paper over. Failing the step surfaces it with the origin named, and `allowed_origins:` is right there if the crossing is legitimate.
+
+**Why not fail the whole run.** Every other action failure fails its step, and each test starts from a fresh browser context, so the breach cannot leak into the next test. Making this one uniquely fatal would be inconsistent for no added protection.
+
+### D2 — `about:blank` is inside the boundary; everything else must match
+
+**Decision.** A URL of `about:blank` passes. Every other URL is compared by origin, and anything that is not in the allowed set fails, including non-HTTP schemes such as `file:`.
+
+**Why.** `about:blank` is the browser's own empty page: it carries no content and is what a fresh context shows before the first `goto`. Treating unknown schemes as allowed would be the same permissiveness that produced this defect — `file:///etc/passwd` has no origin to compare, and "no origin" must not mean "fine".
+
+### D3 — One comparison, exported, used by both checks
+
+**Decision.** The allowed-set construction and comparison move behind a single exported function in `src/runner/actions.ts`. The `navigate` branch keeps calling it before `page.goto`; the executor calls it before every snapshot.
+
+**Why keep the pre-navigation check at all.** It is strictly better when it applies: refusing to make the request is better than making it and objecting afterwards, and it produces a more useful message (the model is told the target is out of bounds and can choose differently, rather than the step ending). The new check is the floor, not a replacement.
+
+**Why not two copies of the comparison.** This change exists because a rule lived in one place while claiming to cover everything. Two implementations of the same rule that can drift apart would be a poor way to fix that.
+
+## Risks / Trade-offs
+
+- **An application that legitimately spans origins now fails instead of continuing.** Identity providers and hosted payment steps are the common shapes. The remedy already exists and the error names the origin to add. This is a behavioural change and belongs in the changelog in those words: a suite that was quietly testing a foreign page will now fail. That is the correct direction — it was never testing what it claimed to.
+- **The check runs on every iteration.** It is a string comparison against a small set, built once per action context; against a snapshot round trip over CDP the cost does not register.
+- **The request still happens.** A redirect to a hostile host still causes one request from the test browser, carrying whatever cookies that host was already entitled to. Nothing at this layer can prevent that; what changes is that the response never reaches the model and the run stops there. The proposal says so rather than implying more.
+
+## Migration Plan
+
+None. No configuration change, no test-file format change. Suites that stay inside their own origin see no difference. Suites that leave it were already broken and now say so.
+
+## Open Questions
+
+None blocking. One noted and deliberately left: `allowed_origins:` is currently all-or-nothing per origin, so declaring an identity provider allows the agent anywhere on that host. Narrowing it to path prefixes would be a separate change with its own reproduction, and no observed defect asks for it yet.

--- a/openspec/changes/contained-navigation/proposal.md
+++ b/openspec/changes/contained-navigation/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The origin boundary checks where the agent asks to go, never where it ends up. Both ways out were reproduced against 0.7.0, with a real model, using two local servers so that "another origin" is real:
+
+**A redirect.** `navigate to /away` targets the application's own origin, so the check passes. The server answers `302` to a foreign host and the browser follows. The judge's own words in the run log: *"the current URL is http://localhost:4196/"*.
+
+**A click.** `assertAllowedOrigin` is called in the `navigate` branch and nowhere else, so clicking a link to another origin is not checked at all. This is broader than #3 as filed, which only describes redirects.
+
+Both runs reported **`Score: 100`**. The tool drove the agent out of the application twice and called it a pass.
+
+What makes this more than untidy: once outside, that page's content goes into the next prompt, while the browser context still holds the application's session. `agent-containment`'s stated purpose is "so a page that can influence its own content cannot redirect an agent holding a live session" — which is precisely what happens. The prompt already tells the model that page text is content under test and never instructions; that defence assumes the page belongs to the application being tested.
+
+This is the third time the same underlying mistake has produced a defect here: a guarantee written at one call site instead of over the scope it claims to cover. It has previously produced a secret leak, a budget that missed `plan`, and a timeout that missed `auth`.
+
+## What Changes
+
+- The boundary is enforced on **where the page actually is**, not only on where an action asked to go. It is checked before every snapshot, so no action type can escape it — a redirect, a click on a foreign link, a form submit, a script setting `location`, or any action added later.
+- A page outside the boundary is never snapshotted into a prompt. The step fails, naming the origin.
+- The existing pre-navigation check stays. Refusing to go somewhere is still better than going and then objecting.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-containment`: the origin boundary constrains where the agent *is*, not only where it asked to go, and no page outside it reaches a prompt.
+
+## Non-goals
+
+- Not removing `allowed_origins:`. An application that legitimately spans hosts — an identity provider, a hosted payment step — declares them, exactly as it does today. That mechanism already exists; this change makes it load-bearing rather than advisory.
+- Not blocking the browser from following a redirect. By the time a cross-origin response arrives the request has already been made; what this change controls is what happens next, which is what actually protects the run.
+- Not failing the whole run. A containment breach fails its step, like any other action failure, and the next test starts from a fresh context.
+- Not the iframe gap (#21) or the action vocabulary (#22).
+
+## Impact
+
+- `src/runner/executor.ts` — one check before every snapshot; `src/auth.ts`'s login journey runs through the same loop and is covered by the same line.
+- `src/runner/actions.ts` — the origin comparison becomes reusable; the `navigate` branch keeps calling it.
+- **Behavioural change**: an application that redirects across hosts without declaring them in `allowed_origins:` now fails instead of silently continuing. That is the point, and it needs saying in the changelog.
+- No new npm dependency.

--- a/openspec/changes/contained-navigation/specs/agent-containment/spec.md
+++ b/openspec/changes/contained-navigation/specs/agent-containment/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Navigation is bounded by origin
+The executor SHALL reject a `navigate` action whose resolved URL falls outside the application's origin or a configured `allowed_origins:` entry, failing the step with a reason naming the rejected origin.
+
+The boundary SHALL additionally constrain where the page **is**, not only where an action asked to go. Before every snapshot, the executor SHALL compare the current URL against the same allowed set, and SHALL fail the step when it falls outside — however the page got there, including a server redirect, a link to another origin, a form submission, or a script setting the location. A page outside the boundary SHALL NOT be snapshotted, so its content never reaches a prompt.
+
+`about:blank` SHALL be treated as inside the boundary. Every other URL SHALL be compared by origin, and a URL with no comparable origin SHALL NOT be treated as allowed.
+
+#### Scenario: Relative path within the application
+- **WHEN** the agent navigates to `/cart` and `base_url` is `http://localhost:4173`
+- **THEN** navigation proceeds
+
+#### Scenario: Absolute URL to another origin rejected
+- **WHEN** the agent navigates to `https://elsewhere.example.com/x` and that origin is not allowed
+- **THEN** the step fails with a reason naming the rejected origin, and the browser does not go there
+
+#### Scenario: Declared additional origin
+- **WHEN** `allowed_origins:` lists `https://auth.example.com` and the agent navigates there
+- **THEN** navigation proceeds
+
+#### Scenario: The application's own origin needs no declaration
+- **WHEN** no `allowed_origins:` is configured
+- **THEN** navigation within the `base_url` origin still proceeds
+
+#### Scenario: A redirect carries the page outside the boundary
+- **WHEN** a navigation to the application's own origin is answered with a redirect to an origin that is not allowed
+- **THEN** the step fails naming that origin, and no snapshot of it is taken
+
+#### Scenario: A click carries the page outside the boundary
+- **WHEN** the agent clicks a link whose target is an origin that is not allowed
+- **THEN** the step fails naming that origin, however the navigation was triggered
+
+#### Scenario: The page outside the boundary is never read
+- **WHEN** the page is outside the boundary
+- **THEN** its content is not sent to the model in any prompt
+
+#### Scenario: A declared origin may be landed on
+- **WHEN** the page ends up on an origin listed in `allowed_origins:`
+- **THEN** the run continues normally
+
+#### Scenario: The empty page is inside the boundary
+- **WHEN** the current URL is `about:blank`
+- **THEN** the boundary does not fail the step
+
+#### Scenario: A URL with no comparable origin is not allowed
+- **WHEN** the page has moved to a `file:` URL
+- **THEN** the step fails, because the absence of an origin to compare is not permission

--- a/openspec/changes/contained-navigation/tasks.md
+++ b/openspec/changes/contained-navigation/tasks.md
@@ -1,0 +1,62 @@
+## 1. Reproduce both escapes first
+
+- [x] 1.1 Stand up two local origins so that "another origin" is real, not simulated: an application server and a second server representing anywhere else.
+- [x] 1.2 A test whose step navigates to a path on the application that answers `302` to the other origin.
+- [x] 1.3 A test whose step clicks a link whose `href` points at the other origin.
+- [x] 1.4 Run both with a real model and **confirm where the browser ended up**, not what the tool reported.
+- [x] 1.5 Report before continuing. Write no fix in this group.
+
+### Findings
+
+Both escaped, against 0.7.0, `anthropic/claude-haiku-4.5`, nothing in `allowed_origins:`:
+
+| step | ended up at | reported |
+|---|---|---|
+| `navigate to /away` (`302` → `:4196`) | `http://localhost:4196/` | PASS |
+| `click the "Partner portal" link` | `http://localhost:4196/` | PASS |
+
+`Score: 100` for both. The click case is wider than #3 as filed: `assertAllowedOrigin` is called only in the `navigate` branch, so a click across origins is not checked at all. In the redirect run the judge named the foreign URL in its own reason and the run still passed.
+
+### Fix verification
+
+Both escapes now fail with the boundary message, naming `http://localhost:4196`:
+
+```
+-> click link "Partner portal" :: ok: clicked role=link name="Partner portal"
+X step failed: The page left the application: http://localhost:4196/ is outside
+  http://localhost:4197. Add it to allowed_origins in .blastproof/config.yaml
+  if the app legitimately spans hosts.
+```
+
+## 2. One comparison, two callers
+
+- [x] 2.1 Extract the allowed-set construction and origin comparison in `src/runner/actions.ts` behind one exported function (design D3). No second implementation of the rule.
+- [x] 2.2 The `navigate` branch keeps calling it before `page.goto`, with the message it produces today unchanged.
+- [x] 2.3 `about:blank` passes; every other URL must match by origin, including non-HTTP schemes (design D2). "No origin to compare" must not mean "allowed".
+
+## 3. The boundary holds where the page is
+
+- [x] 3.1 In `src/runner/executor.ts`, after the settle wait and **before** `takeSnapshot`, fail the step when the current URL is outside the boundary (design D1).
+- [x] 3.2 No snapshot of an out-of-bounds page is taken, so its content never reaches a prompt. Assert this directly — it is the property that matters, not the failure itself.
+- [x] 3.3 The failure reason names the origin and points at `allowed_origins:`, consistent with the existing pre-navigation message.
+- [x] 3.4 One place decides this for every action. Do not enumerate the actions that can navigate — that is the same mistake this change exists to fix, moved somewhere new.
+- [x] 3.5 `src/auth.ts`'s login journey runs through the same loop; confirm it is covered by the same line and needs no separate check.
+  - Covered, and it showed immediately: seven `auth.test.ts` tests failed on a fake page returning `http://localhost/account` while `base_url` was `http://localhost:4173` — a different origin. Fixture artefact, not a product failure (a real page URL always carries the port, as the other fake in the same file already did). Fixed the fixture, not the check.
+
+## 4. Tests
+
+- [x] 4.1 A page that has moved to a foreign origin fails the step before any snapshot is taken.
+- [x] 4.2 The foreign page's content never reaches the brain — assert against the prompts the brain received, not only the step's status.
+- [x] 4.3 An origin listed in `allowed_origins:` passes the post-navigation check.
+- [x] 4.4 `about:blank` passes.
+- [x] 4.5 A `file:` URL fails.
+- [x] 4.6 The existing pre-navigation rejection still behaves exactly as before, message included.
+
+## 5. Verification against the reproduction
+
+- [x] 5.1 Re-run both reproductions from group 1 with a real model. Both must fail, naming `http://localhost:4196`.
+- [x] 5.2 Add the foreign origin to `allowed_origins:` and confirm both then pass — the escape hatch works, so a legitimately multi-origin application is not stranded.
+  - Declared, the boundary stops blocking: the click test passes, and the redirect test reaches the foreign origin repeatedly with no boundary error. So the hatch works and a multi-origin application is not stranded.
+  - The redirect test still fails, on something else and pre-existing: the judge will not accept a redirect as satisfying a step that names a path. *"The current URL is http://localhost:4196/ rather than http://localhost:4197/away."* Confirmed pre-existing from this change's own group 1 log, where the identical complaint appears against 0.7.0 (it happened to recover on the retry there). Filed separately rather than fixed here — it is the navigation analogue of "the action erases its own evidence" and deserves its own reproduction.
+- [x] 5.3 Dogfood suite unchanged.
+- [x] 5.4 The behavioural change is stated plainly where a user will meet it: a suite that was quietly testing a foreign page now fails. Written into the README's containment section. The changelog entry belongs to the release, not to this pull request (CONTRIBUTING).

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -66,20 +66,66 @@ export interface ActionContext {
   resolveValue?: (value: string) => string;
 }
 
+/** The URL a fresh browser context shows before anything is loaded (design contained-navigation, D2). */
+const BLANK_PAGE = 'about:blank';
+
+/**
+ * The origins the agent may be on: the application's own, plus whatever the
+ * configuration declares. One construction, used by both checks (design
+ * contained-navigation, D3) — this defect existed because the rule lived at one
+ * call site while claiming to cover everything, and two copies of it that can
+ * drift apart would be a poor way to fix that.
+ */
+export function allowedOriginsFor(baseUrl: string, allowedOrigins: string[] | undefined): Set<string> {
+  const allowed = new Set<string>([new URL(baseUrl).origin]);
+  for (const origin of allowedOrigins ?? []) {
+    allowed.add(new URL(origin).origin);
+  }
+  return allowed;
+}
+
+/**
+ * Whether `url` is inside the boundary.
+ *
+ * `about:blank` is inside it: the browser's own empty page carries no content
+ * and is what a fresh context shows before the first `goto`. Everything else is
+ * compared by origin, and a URL with no comparable origin — `file:`, `data:` —
+ * is **not** allowed. Treating "no origin" as "fine" would be the same
+ * permissiveness that produced this defect (design D2).
+ */
+export function isOriginAllowed(url: string, allowed: ReadonlySet<string>): boolean {
+  if (url === BLANK_PAGE) return true;
+  let origin: string;
+  try {
+    origin = new URL(url).origin;
+  } catch {
+    return false;
+  }
+  if (origin === 'null') return false;
+  return allowed.has(origin);
+}
+
+/** Describes the boundary the way both failure messages name it. */
+export function describeBoundary(allowed: ReadonlySet<string>): string {
+  return [...allowed].join(' or ');
+}
+
 /**
  * The one containment that does not depend on the model cooperating: an absolute
  * URL ignores the base entirely (`new URL('https://x/y', base)` is `https://x/y`),
  * so a page that can influence the agent could otherwise send it anywhere while it
  * holds a live session. Compared, not argued with (design D1).
+ *
+ * Refusing to make the request is strictly better than making it and objecting
+ * afterwards, so this stays even though the executor now also checks where the
+ * page ended up: the model is told its target is out of bounds and can choose
+ * differently, rather than the step simply ending.
  */
 function assertAllowedOrigin(url: URL, ctx: ActionContext): void {
-  const allowed = new Set<string>([new URL(ctx.baseUrl).origin]);
-  for (const origin of ctx.allowedOrigins ?? []) {
-    allowed.add(new URL(origin).origin);
-  }
-  if (!allowed.has(url.origin)) {
+  const allowed = allowedOriginsFor(ctx.baseUrl, ctx.allowedOrigins);
+  if (!isOriginAllowed(url.toString(), allowed)) {
     throw new ActionError(
-      `Refusing to navigate outside the application: ${url.origin} is not ${[...allowed].join(' or ')}. ` +
+      `Refusing to navigate outside the application: ${url.origin} is not ${describeBoundary(allowed)}. ` +
         'Add it to allowed_origins in .blastproof/config.yaml if the app legitimately spans hosts.',
     );
   }

--- a/src/runner/executor.ts
+++ b/src/runner/executor.ts
@@ -4,7 +4,13 @@ import type { AgentBrain } from '../llm/brain.js';
 import type { AgentAction } from '../llm/schemas.js';
 import { BudgetExhaustedError } from './budget.js';
 import type { TestFile } from './testfile.js';
-import { performAction, type PageLike } from './actions.js';
+import {
+  allowedOriginsFor,
+  describeBoundary,
+  isOriginAllowed,
+  performAction,
+  type PageLike,
+} from './actions.js';
 import { StepRecovery, describeAction } from './recovery.js';
 
 /** Hard cap on LLM actions per step, when not overridden. Also the number the
@@ -209,6 +215,9 @@ export async function executeTest(page: PageLike, test: TestFile, options: Execu
   };
 
   let failure: { step: string; reason: string } | undefined;
+  // Built once for the test: the same allowed set `performAction` compares a
+  // navigate target against, so the two checks cannot drift (design D3).
+  const boundary = allowedOriginsFor(baseUrl, allowedOrigins);
 
   // Every test starts from the configured base_url (spec: browser lifecycle).
   await page.goto(new URL(baseUrl).toString());
@@ -237,6 +246,25 @@ export async function executeTest(page: PageLike, test: TestFile, options: Execu
         // before every snapshot, unconditionally — see `waitForSettled` for
         // why this cannot be applied only to actions believed to navigate.
         await waitForSettled(page);
+        // The boundary constrains where the page IS, not only where an action
+        // asked to go (design contained-navigation, D1). Checked here, at the
+        // one point the page's content crosses into a prompt, because that
+        // covers every way a URL can change — a redirect, a click on a foreign
+        // link, a form submit, a script setting `location`, an action added to
+        // the vocabulary later — without anyone having to remember to add a
+        // call. Enumerating the actions that can navigate would be the same
+        // mistake this exists to fix, moved somewhere new: the accessibility
+        // tree cannot tell you whether a button navigates.
+        //
+        // Before `takeSnapshot`, never after: the request has already gone out
+        // by the time we find out, so the property still available — and the
+        // one that matters — is that the response never reaches the model.
+        if (!isOriginAllowed(page.url(), boundary)) {
+          throw new StepFailure(
+            `The page left the application: ${page.url()} is outside ${describeBoundary(boundary)}. ` +
+              'Add it to allowed_origins in .blastproof/config.yaml if the app legitimately spans hosts.',
+          );
+        }
         const snap = await takeSnapshot(page);
 
         let action: AgentAction;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -31,7 +31,10 @@ function fakeBrowser(overrides: { fail?: boolean } = {}): {
         async newPage() {
           return {
             goto: async () => undefined,
-            url: () => 'http://localhost/account',
+            // Port included, as a real page URL always is: the executor now
+            // compares this against the boundary before every snapshot, and
+            // `http://localhost` is a different origin from `http://localhost:4173`.
+            url: () => 'http://localhost:4173/account',
             waitForLoadState: async () => {},
             getByRole: () => ({}) as never,
             getByLabel: () => ({}) as never,

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -6,7 +6,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { AgentBrain } from '../src/llm/brain.js';
 import type { AgentIterationInput } from '../src/llm/prompts.js';
 import type { AgentAction, AssertJudgment } from '../src/llm/schemas.js';
-import { performAction, resolveTarget, type LocatorLike, type PageLike } from '../src/runner/actions.js';
+import {
+  allowedOriginsFor,
+  isOriginAllowed,
+  performAction,
+  resolveTarget,
+  type LocatorLike,
+  type PageLike,
+} from '../src/runner/actions.js';
 import { BudgetExhaustedError } from '../src/runner/budget.js';
 import { executeTest, SETTLE_TIMEOUT_MS, type ExecutorEvent, type ExecutorOptions } from '../src/runner/executor.js';
 import { describeAction, StepRecovery } from '../src/runner/recovery.js';
@@ -1328,5 +1335,110 @@ describe('StepRecovery commit keys', () => {
     for (const key of ['Tab', 'Escape', 'ArrowDown']) {
       expect(perform({ action: 'press', value: key, reasoning: 'move' })).toBeUndefined();
     }
+  });
+});
+
+// --- the boundary holds where the page is -------------------------------------
+//
+// `assertAllowedOrigin` checked the URL a `navigate` asked for and nothing else,
+// so a 302 to another host, or a click on a foreign link, carried the agent out
+// of the application and the run reported PASS (#3). Both were reproduced with a
+// real model against two local origins before this was written.
+
+describe('executeTest origin boundary', () => {
+  function brainRecording(script: AgentAction[]): AgentBrain & { snapshots: string[] } {
+    let calls = 0;
+    const snapshots: string[] = [];
+    return {
+      snapshots,
+      async nextAction(input: AgentIterationInput): Promise<AgentAction> {
+        snapshots.push(input.snapshot);
+        const next = script[calls++];
+        if (!next) throw new Error('script exhausted');
+        return next;
+      },
+      async judge(): Promise<AssertJudgment> {
+        return { pass: true, reason: 'fine' };
+      },
+    };
+  }
+
+  /** A page that lands somewhere else the moment it is asked to go anywhere. */
+  class RedirectingPage extends FakePage {
+    constructor(private readonly landsAt: string) {
+      super();
+    }
+    override async goto(url: string): Promise<void> {
+      this.calls.push(`goto ${url}`);
+      this.currentUrl = this.landsAt;
+    }
+  }
+
+  it('fails the step when a redirect has carried the page off the allowed origin', async () => {
+    const page = new RedirectingPage('http://elsewhere.test/landing');
+    const brain = brainRecording([{ action: 'done', reasoning: 'never reached' }]);
+
+    const result = await executeTest(page, makeTest(), baseOptions(brain, { baseUrl: 'http://app.test' }));
+
+    expect(result.status).toBe('failed');
+    expect(result.reason).toContain('http://elsewhere.test');
+    expect(result.reason).toContain('allowed_origins');
+  });
+
+  it('never sends the content of an out-of-bounds page to the model', async () => {
+    // The property that matters. The request has already happened by the time we
+    // find out; what this change controls is that the response is not read into
+    // a prompt while the context still holds the application's session.
+    const page = new RedirectingPage('http://elsewhere.test/landing');
+    const brain = brainRecording([{ action: 'done', reasoning: 'never reached' }]);
+
+    await executeTest(
+      page,
+      makeTest(),
+      baseOptions(brain, {
+        baseUrl: 'http://app.test',
+        snapshot: async () => 'url: http://elsewhere.test/landing\n- heading "Outside the application"',
+      }),
+    );
+
+    expect(brain.snapshots).toHaveLength(0);
+  });
+
+  it('allows an origin the configuration declares', async () => {
+    const page = new RedirectingPage('https://auth.example.com/sso');
+    const brain = brainRecording([{ action: 'done', reasoning: 'signed in' }]);
+
+    const result = await executeTest(
+      page,
+      makeTest(),
+      baseOptions(brain, { baseUrl: 'http://app.test', allowedOrigins: ['https://auth.example.com'] }),
+    );
+
+    expect(result.status).toBe('passed');
+  });
+
+  it('treats about:blank as inside the boundary', () => {
+    const allowed = allowedOriginsFor('http://app.test', undefined);
+    expect(isOriginAllowed('about:blank', allowed)).toBe(true);
+  });
+
+  it('does not treat a URL with no comparable origin as allowed', () => {
+    // "No origin to compare" must not mean "fine" — that permissiveness is what
+    // produced this defect in the first place.
+    const allowed = allowedOriginsFor('http://app.test', undefined);
+    expect(isOriginAllowed('file:///etc/passwd', allowed)).toBe(false);
+    expect(isOriginAllowed('not a url at all', allowed)).toBe(false);
+  });
+
+  it('still refuses a navigate action to a foreign origin, with the same message', async () => {
+    const page = new FakePage();
+    await expect(
+      performAction(
+        page,
+        { action: 'navigate', value: 'https://elsewhere.example.com/x', reasoning: 'go' },
+        { baseUrl: 'http://app.test' },
+      ),
+    ).rejects.toThrow(/Refusing to navigate outside the application: https:\/\/elsewhere\.example\.com/);
+    expect(page.calls.filter((c) => c.startsWith('goto'))).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #3.

## The hole

`assertAllowedOrigin` checked the URL a `navigate` asked for, before the request, and nothing after. Two ways out, both reproduced against 0.7.0 with a real model and two local servers so "another origin" is real:

| step | ended up at | reported |
|---|---|---|
| `navigate to /away` (`302` → `:4196`) | `http://localhost:4196/` | **PASS** |
| `click the "Partner portal" link` | `http://localhost:4196/` | **PASS** |

`Score: 100` for both. The tool drove the agent out of the application twice and called it a pass.

The click case is **wider than #3 as filed**. The check was called in the `navigate` branch and nowhere else, so a link to another origin was never checked at all. The issue only describes redirects.

In the redirect run the judge said the foreign URL out loud — *"the snapshot shows the current URL is http://localhost:4196/"* — and the run still passed, because nothing was comparing it to anything.

## Why it matters beyond tidiness

`agent-containment`'s stated purpose is "so a page that can influence its own content cannot redirect an agent holding a live session". That is exactly what happened, and afterwards the foreign page's content went into the next prompt while the context still held the application's session. The system prompt telling the model that page text is data and not instruction assumes the page belongs to the application under test.

Third time the same underlying mistake has produced a defect here: a guarantee written at one call site instead of over the scope it claims to cover. It previously produced a secret leak, a budget that missed `plan`, and a timeout that missed `auth`.

## The fix

The boundary is checked **before every snapshot**, against where the page actually is.

That point is chosen deliberately. It is reached once per iteration regardless of what the previous action was, so it covers a redirect, a click, a form submit, a script setting `location`, and any action added to the vocabulary later, without anyone having to remember to add a call. Enumerating the actions that can navigate would be the same mistake moved somewhere new — the accessibility tree cannot tell you whether a button navigates.

It is also the one point where a page's content crosses into a prompt, which gives the strongest property still available: **the content of a page outside the boundary is never sent to the model.** The request has already gone out by the time we find out. What this controls is that the response is not read into a prompt and the run does not keep acting there.

The pre-navigation check stays. Refusing to make the request is better than making it and objecting afterwards, and it gives the model a message it can act on.

## Verified both directions

Blocked:
```
-> click link "Partner portal" :: ok: clicked role=link name="Partner portal"
X step failed: The page left the application: http://localhost:4196/ is outside
  http://localhost:4197. Add it to allowed_origins in .blastproof/config.yaml
  if the app legitimately spans hosts.
```

Unblocked by declaring it: with `http://localhost:4196` in `allowed_origins:`, the boundary stops firing and the same runs reach it freely. A legitimately multi-origin application is not stranded.

Dogfood 7/7, Score 100. 395 unit tests. Removing the check fails exactly the two tests that pin it.

## Behavioural change

An application that redirects across hosts without declaring them now **fails** instead of silently continuing. That is the point, and the README says so in those words. A suite that was quietly testing a foreign page was never testing what it claimed to.

## Two things found on the way

**Seven auth tests failed** on a fake page returning `http://localhost/account` while `base_url` was `http://localhost:4173`. Different origin. Fixture artefact, not the product — a real page URL always carries the port, as the sibling fake in the same file already did. Fixed the fixture, not the check.

**#35**, filed separately: a step naming a path fails when that path redirects, because the judge compares the URL against the path the step named. Pre-existing, confirmed from this change's own group 1 log on 0.7.0. It becomes newly relevant here — anyone who declares a cross-origin redirect is by definition testing an app that redirects, and lands on it immediately. Not fixed here; it deserves its own reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
