### PR TITLE
feat: a run reports what it spent

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,16 @@ Each limit is optional; with none set, nothing binds. They count **calls and tok
 
 Exhausting a budget **stops the run; it does not fail a test.** Running out of quota says nothing about the code under review. Unreached tests are reported as `not run`, a third state excluded from the score entirely, and the process exits 1 unconditionally — `--min-score` cannot rescue it, because the tests that finished are whichever ran first, not a representative sample.
 
-`--dry-run` reports the ceiling before you spend anything.
+**Every run reports what it spent**, so you can size a limit from experience rather than guesswork:
+
+```
+Spent: 82 model call(s), 115407 token(s)
+Score: 100
+```
+
+The figures also land in the JUnit report as `llm_calls` and `llm_tokens`, beside `score`, so a pipeline can trend cost without scraping output. A run stopped by its own budget reports the spend too — that is the case where the number is least guessable. Where a provider reports no token usage, the line says so rather than showing zero.
+
+`--dry-run` reports the ceiling before you spend anything. Read it as a maximum and nothing more: for this repository's own suite it says 735 calls where a real run spends 82. Size a budget from what your runs actually report, not from the ceiling.
 
 ## Testing behind a login
 

--- a/openspec/changes/report-what-it-spent/design.md
+++ b/openspec/changes/report-what-it-spent/design.md
@@ -1,0 +1,62 @@
+## Context
+
+`RunBudget` already holds everything needed. `record(usage)` runs after every model call, incrementing `calls` and adding `usage.totalTokens` when it is present. `callCount` and `tokenCount` are already exposed. At the end of a run the object goes out of scope and the numbers go with it.
+
+`--dry-run` prints `estimateMaxModelCalls`, a worst case of `steps × (N + R + min(N, R))`. For the dogfood suite that is 735 calls. A real run of the same suite spends a small fraction of it. Both numbers are correct; only one of them is useful for sizing a budget, and it is the one we do not print.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A run says what it spent.
+- An interrupted run says it too.
+- A pipeline can read it without parsing stdout.
+
+**Non-Goals:**
+- Currency. Calls and tokens are what we know.
+- Per-test attribution, or an input/output split.
+
+## Decisions
+
+### D1 — Zero tokens and unknown tokens are different, and must read differently
+
+**Decision.** `RunBudget` additionally counts how many calls reported usage at all. The summary distinguishes three cases:
+
+- no call reported usage → the tokens figure is stated as unavailable, naming the provider as the reason
+- every call reported usage → the total, plainly
+- some did → the total, qualified by how many calls it covers
+
+**Why this is not over-engineering for a rare case.** `CallUsage.totalTokens` is optional because it genuinely is optional: local providers routinely omit it. `tokenCount` is initialised to `0` and only ever incremented by a defined value, so a run against such a provider ends with `tokens: 0` — indistinguishable from a run that made no calls. Printing `0 tokens` there is not a rounding error, it is a false statement about the thing someone is reading the line to learn. The partial case is unlikely but costs one comparison to be honest about, and this project has been bitten before by numbers that were technically derived and practically wrong.
+
+### D2 — The command that created the budget is the one that reports it
+
+**Decision.** `run` and `plan` report the spend only when they constructed their own `RunBudget`. When a composing caller handed one in (`options.budget`), that caller reports.
+
+**Why.** `test` deliberately creates one budget and passes it to both phases, because a budget that resets between phases is two allowances rather than one bound. Reporting at the point of use rather than the point of ownership would print the running total twice for a single allowance, with the second line silently including the first. Tying the report to ownership makes "reported once per allowance" true by construction rather than by remembering — the same reasoning that made the budget itself a single object rather than a check at each call site.
+
+### D3 — Report the spend before the score, and always
+
+**Decision.** The spend line is printed for every completed run, including a run stopped by its own budget or deadline, and it sits with the summary rather than being hidden behind a flag.
+
+**Why for an interrupted run especially.** A stop already prints which limit was hit and its configured value. What it does not print is the rest of the picture: a run stopped on tokens still spent calls, and someone deciding whether the limit was too tight needs both. This is the case where the number is least guessable and most needed.
+
+**Why not behind a `--report-usage` flag.** A number the tool already has, that costs one line, does not need opting into. Anyone who does not care skips a line; anyone who does would otherwise have to know the flag exists.
+
+### D4 — Against the limits, when there are limits
+
+**Decision.** When a limit is configured, the line names it: `142 of 500`. When none is, the bare figure.
+
+**Why.** The figure alone answers "what did this cost". The figure against the limit answers "how close am I", which is the question someone who has already configured a budget is asking. Printing `of unlimited` for the unconfigured case would be noise.
+
+## Risks / Trade-offs
+
+- **The token total is only as good as the provider's reporting.** We report what we were told, and say when we were told nothing. Nothing here reconciles against a provider's own billing, and the release notes should not imply it does.
+- **One more line of output on every run.** Accepted; it is one line, and the alternative is a flag nobody discovers.
+- **Two report surfaces gain a field.** JUnit and HTML both take the same numbers from the same object, so they cannot disagree with the console unless someone computes them separately, which is why the summary is produced by `RunBudget` itself rather than by each caller.
+
+## Migration Plan
+
+None. Output gains a line, JUnit gains two properties. Nothing existing changes shape, so a pipeline parsing the score property is unaffected.
+
+## Open Questions
+
+None blocking. Noted: `CallUsage` records only `totalTokens`, so an input/output split is not available to report even though most providers return one. Widening it is a separate change with its own reason to exist.

--- a/openspec/changes/report-what-it-spent/proposal.md
+++ b/openspec/changes/report-what-it-spent/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+A run counts every model call and every token — that is how `budget:` enforces its limits — and then discards the totals. They exist in `RunBudget` when the run ends and nobody is told (#27).
+
+An external evaluator sizing what a pull-request gate would cost had to ask the provider instead:
+
+> Cost: roughly $0.11 / 126s for a realistic single `run --impacted` PR-gate invocation on Haiku via OpenRouter — tolerable. But a completed run never reports its own actual LLM-call/token consumption; I had to query OpenRouter directly.
+
+The only cost figure the tool volunteers today is `--dry-run`'s worst-case ceiling, which is deliberately a maximum and usually many times the real number. So the one number we offer is the one furthest from the truth. Someone sizing `max_llm_calls` from it sets it far too high; someone wanting to size it from experience cannot, because the tool never reports experience.
+
+It also makes the budget feature harder to adopt than it needs to be, and it would have made two findings in that evaluation visible immediately instead of requiring provider forensics.
+
+## What Changes
+
+- A finished run reports **what it actually spent**: model calls, and tokens, against the configured limits when any are set.
+- An interrupted run reports it too. That is the case where the number matters most, and it is the one a stop currently leaves unanswered.
+- The totals go into the JUnit properties beside `score`, so a pipeline can trend cost without scraping stdout, and into the HTML report.
+- Where a provider does not report token usage, that is said rather than shown as zero.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `run-budget`: what a run spent is reported, not only enforced.
+- `junit-report`: the spend is exposed as properties alongside the score.
+
+## Non-goals
+
+- **Not currency.** The same reasoning that keeps the budget denominated in calls and tokens applies to reporting them: a price table is wrong the day a provider reprices, and wrong for anyone behind a gateway. Calls and tokens are what we actually know.
+- Not per-test or per-step attribution. The budget is a run-wide count by design, and splitting it would mean threading counters through the executor for a number nobody has asked for yet.
+- Not input/output token split. `CallUsage` records the total only, and widening it is a separate question.
+- Not a cost forecast. `--dry-run`'s ceiling stays exactly what it is, a maximum; this reports the past, not the future.
+
+## Impact
+
+- `src/runner/budget.ts` — `RunBudget` gains a readable summary, including how many calls reported usage at all.
+- `src/commands/run.ts`, `src/commands/plan.ts`, `src/commands/test.ts` — the command that *owns* the budget reports it, so a composed `test` run reports once rather than once per phase.
+- `src/report/junit.ts`, `src/report/html.ts` — the totals as properties and in the summary block.
+- No new npm dependency.

--- a/openspec/changes/report-what-it-spent/specs/junit-report/spec.md
+++ b/openspec/changes/report-what-it-spent/specs/junit-report/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Score exposed as a property
+The XML SHALL expose the run score as a `property` named `score`, so a CI parser can read it without scraping console output.
+
+The XML SHALL likewise expose what the run spent: a property named `llm_calls`, and a property named `llm_tokens` when any completed call reported token usage. Both SHALL carry the same figures the summary states, taken from the same source, so the report and the console cannot disagree.
+
+#### Scenario: Score readable from the report
+- **WHEN** a run scores 75 and writes a JUnit report
+- **THEN** the XML contains a property named `score` with value 75
+
+#### Scenario: Spend readable from the report
+- **WHEN** a run spends model calls and writes a JUnit report
+- **THEN** the XML contains a property named `llm_calls` carrying the number of calls made
+
+#### Scenario: No token usage to expose
+- **WHEN** no completed call reported token usage
+- **THEN** no `llm_tokens` property is emitted, rather than one carrying zero

--- a/openspec/changes/report-what-it-spent/specs/run-budget/spec.md
+++ b/openspec/changes/report-what-it-spent/specs/run-budget/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: A run reports what it spent
+A run SHALL report the model calls and tokens it actually spent, for a completed run and for one stopped by its own budget or deadline alike. Where a limit is configured, the report SHALL name the spend against that limit; where none is, it SHALL report the figure alone.
+
+The token figure SHALL distinguish "no tokens were reported" from "no tokens were spent". Where no completed call reported usage, the report SHALL say the figure is unavailable rather than showing zero; where only some calls reported it, the report SHALL say how many calls the figure covers.
+
+The spend SHALL be reported once per budget. The command that constructed the budget is the one that reports it, so a composed run sharing one allowance across phases reports one total rather than one per phase.
+
+#### Scenario: A completed run reports its spend
+- **WHEN** a run finishes
+- **THEN** the summary states the model calls and the tokens it spent
+
+#### Scenario: An interrupted run reports its spend too
+- **WHEN** a run is stopped by its budget or deadline
+- **THEN** the summary states what was spent as well as which limit stopped it
+
+#### Scenario: Reported against a configured limit
+- **WHEN** a maximum number of calls is configured
+- **THEN** the spend is reported against that maximum
+
+#### Scenario: A provider that reports no usage
+- **WHEN** no completed call reported token usage
+- **THEN** the token figure is reported as unavailable, not as zero
+
+#### Scenario: Only some calls reported usage
+- **WHEN** some completed calls reported token usage and others did not
+- **THEN** the reported total says how many calls it covers
+
+#### Scenario: One allowance, one report
+- **WHEN** one budget is shared across the phases of a composed run
+- **THEN** the spend is reported once, by the command that created the budget

--- a/openspec/changes/report-what-it-spent/tasks.md
+++ b/openspec/changes/report-what-it-spent/tasks.md
@@ -1,0 +1,44 @@
+## 1. Confirm the numbers are there and discarded
+
+- [x] 1.1 Run the dogfood suite and confirm the tool reports no spend today, while `--dry-run` reports a worst case many times larger. Record both numbers.
+- [x] 1.2 Confirm what the provider actually reports for `totalTokens` on a real run, so D1's three cases are grounded rather than assumed.
+
+### Findings
+
+- The tool reports no spend today. `--dry-run` for the dogfood suite reports a worst case of **735 model calls**.
+- A single test plus the login journey spends **13 calls**, against a `--dry-run` ceiling of **105** for the same selection. The only figure the tool volunteers is 8× the real one.
+- OpenRouter returns full usage, `totalTokens` included, on every call. So D1's "every call reported" is the normal case and the other two are the defensive ones — which is the right way round, since the honest failure is silent.
+
+## 2. `RunBudget` can describe itself
+
+- [x] 2.1 Count how many calls reported usage at all, alongside calls and tokens.
+- [x] 2.2 A single method returns the spend — calls, tokens, how many calls the token figure covers, and the configured limits — so every surface takes the same numbers from the same object and cannot disagree (design D1).
+- [x] 2.3 Formatting lives with the other summary lines in `src/report/score.ts`, not in the console command, so JUnit and HTML are not tempted to recompute it.
+
+## 3. The owner reports
+
+- [x] 3.1 `run` and `plan` report only when they constructed their own budget; when a caller handed one in, that caller reports (design D2).
+- [x] 3.2 `test` reports once, after both phases, for the one allowance it created.
+- [x] 3.3 Do not implement this as "print at the end of `runCommand`" with a flag threaded in to suppress it. Ownership is the rule; a suppression flag is the same rule written where it can be forgotten.
+
+## 4. Every surface
+
+- [x] 4.1 The console summary, for a completed run and for one stopped by its budget or deadline (design D3).
+- [x] 4.2 JUnit properties beside `score`.
+- [x] 4.3 The HTML report's summary block.
+
+## 5. Tests
+
+- [x] 5.1 A run reports the calls and tokens it spent.
+- [x] 5.2 A provider that reports no usage produces "unavailable", never `0 tokens`.
+- [x] 5.3 A run where only some calls reported usage says what the figure covers.
+- [x] 5.4 With limits configured, the spend is reported against them.
+- [x] 5.5 A run stopped by its budget still reports what it spent.
+- [x] 5.6 A composed `test` run reports the spend once, not once per phase.
+- [x] 5.7 JUnit carries the properties; the existing `score` property is unchanged.
+
+## 6. Verification
+
+- [x] 6.1 Real dogfood run: `Spent: 82 model call(s), 115407 token(s)` for 7 passing tests; JUnit carried `llm_calls=82` and `llm_tokens=115407` beside `score=100`. The `--dry-run` ceiling is unchanged at 735.
+- [x] 6.2 With `--max-llm-calls 8`: `Spent: 8 of 8 model call(s), 12105 token(s)` printed above `Run incomplete: model call budget exhausted`. Both facts, in that order.
+- [x] 6.3 **735 ceiling against 82 actual, a ratio of 9:1.** Anyone sizing `max_llm_calls` from the only number the tool used to offer would set it about nine times too high. That ratio is the whole argument for this change, and it is now measured rather than asserted.

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -15,6 +15,7 @@ import {
 } from '../planner.js';
 import { printPreflightFailures, runPreflight } from '../preflight.js';
 import type { PageLike } from '../runner/actions.js';
+import { formatSpendLine } from '../report/score.js';
 import { BudgetExhaustedError, RunBudget } from '../runner/budget.js';
 import type { ExecutorEvent } from '../runner/executor.js';
 import {
@@ -352,6 +353,10 @@ export async function planCommand(options: PlanOptions): Promise<number> {
       for (const route of notAttempted) console.log(`  ${route}`);
     }
   }
+  // Reported only when this command constructed the budget (design
+  // report-what-it-spent, D2): when `test` handed one in, `test` reports the
+  // single allowance once, after both phases.
+  if (options.budget === undefined) console.log(formatSpendLine(budget.spend()));
   console.log('---------------------------------------------------------------');
 
   return incomplete || failed.length > 0 ? EXIT_FAILED : EXIT_OK;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,9 +8,15 @@ import { createModel, MissingApiKeyError } from '../llm/provider.js';
 import { printPreflightFailures, runPreflight } from '../preflight.js';
 import { renderHtml, writeHtml } from '../report/html.js';
 import { renderJUnit, writeJUnit, type SkippedCase } from '../report/junit.js';
-import { computeScore, formatIncompleteLine, formatScoreLine } from '../report/score.js';
+import { computeScore, formatIncompleteLine, formatScoreLine, formatSpendLine } from '../report/score.js';
 import type { PageLike } from '../runner/actions.js';
-import { BudgetExhaustedError, estimateMaxModelCalls, RunBudget, type RunBudgetOptions } from '../runner/budget.js';
+import {
+  BudgetExhaustedError,
+  estimateMaxModelCalls,
+  RunBudget,
+  type BudgetSpend,
+  type RunBudgetOptions,
+} from '../runner/budget.js';
 import { MissingEnvError, SecretsMask, substituteEnv } from '../runner/env.js';
 import { describeAction } from '../runner/recovery.js';
 import {
@@ -341,8 +347,16 @@ async function finalize(
   durationMs: number,
   impact?: ImpactResult,
   incomplete?: BudgetExhaustedError,
+  spend?: BudgetSpend,
 ): Promise<number> {
   if (results.length > 0) printSummary(results);
+
+  // Before the score, so the verdict stays the last thing printed. Reported for
+  // an interrupted run too (design report-what-it-spent, D3): a stop already
+  // says which limit was hit, and what it does not say is the rest of the
+  // picture — a run stopped on tokens still spent calls, and someone deciding
+  // whether the limit was too tight needs both.
+  if (spend) console.log(formatSpendLine(spend));
 
   const score = computeScore(results);
   console.log(
@@ -359,6 +373,7 @@ async function finalize(
       durationMs,
       cwd: options.cwd,
       incomplete: incomplete?.message,
+      spend,
     });
     await writeJUnit(target, xml);
     console.log(`JUnit report: ${path.relative(options.cwd, target)}`);
@@ -375,6 +390,7 @@ async function finalize(
       minScore: options.minScore,
       cwd: options.cwd,
       incomplete: incomplete?.message,
+      spend,
     });
     await writeHtml(target, html);
     console.log(`HTML report: ${path.relative(options.cwd, target)}`);
@@ -668,5 +684,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
     Date.now() - startedAt,
     impact,
     incomplete,
+    // The command that constructed the budget is the one that reports it
+    // (design report-what-it-spent, D2). `test` hands one budget to both of its
+    // phases deliberately, so reporting at the point of use rather than the
+    // point of ownership would print the running total twice for a single
+    // allowance, the second line silently including the first.
+    options.budget === undefined ? budget.spend() : undefined,
   );
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,4 +1,5 @@
 import { ConfigError, loadConfig, type BlastproofConfig } from '../config.js';
+import { formatSpendLine } from '../report/score.js';
 import { RunBudget } from '../runner/budget.js';
 import { planCommand } from './plan.js';
 import {
@@ -86,6 +87,10 @@ export async function testCommand(options: TestOptions): Promise<number> {
   });
   if (planCode === EXIT_USAGE) return EXIT_USAGE;
 
+  // The one allowance both phases shared, reported once by the command that
+  // created it (design report-what-it-spent, D2). Neither phase reports it
+  // itself: each checks whether it owns its budget, and here neither does.
+  console.log(`\n${formatSpendLine(budget.spend())}`);
   console.log(
     '\nDrafts are not executed and do not affect the score — review them before ' +
       'they join the suite.',

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -1,6 +1,8 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import type { BudgetSpend } from '../runner/budget.js';
 import type { StepResult, TestResult } from '../runner/executor.js';
+import { formatSpendLine } from './score.js';
 import type { SkippedCase } from './junit.js';
 
 const ESCAPES: Record<string, string> = {
@@ -44,6 +46,12 @@ export interface HtmlMeta {
   generatedAt?: Date;
   /** The reason the run's budget or deadline stopped it, when it did (spec run-budget). */
   incomplete?: string;
+  /**
+   * What the run spent, when this report's caller owns the budget (design
+   * report-what-it-spent). Rendered from `formatSpendLine`, the same text the
+   * console prints, rather than recomposed here.
+   */
+  spend?: BudgetSpend;
 }
 
 const STYLES = `
@@ -215,7 +223,9 @@ export async function renderHtml(
 <body>
 <main>
   <h1>blastproof report</h1>
-  <p class="sub">${escapeHtml(generatedAt)} · ${seconds(meta.durationMs)}</p>
+  <p class="sub">${escapeHtml(generatedAt)} · ${seconds(meta.durationMs)}${
+    meta.spend ? ` · ${escapeHtml(formatSpendLine(meta.spend))}` : ''
+  }</p>
 
 ${banner}  <section class="score">
     <b>${meta.score}</b>

--- a/src/report/junit.ts
+++ b/src/report/junit.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import type { BudgetSpend } from '../runner/budget.js';
 import type { TestResult } from '../runner/executor.js';
 
 const ESCAPES: Record<string, string> = {
@@ -31,6 +32,12 @@ export interface JUnitMeta {
   cwd?: string;
   /** The reason the run's budget or deadline stopped it, when it did (spec run-budget). */
   incomplete?: string;
+  /**
+   * What the run spent, when this report's caller owns the budget (design
+   * report-what-it-spent). Taken from the same `RunBudget` the summary line
+   * uses, so the report and the console cannot disagree about what a run cost.
+   */
+  spend?: BudgetSpend;
 }
 
 function seconds(ms: number): string {
@@ -61,6 +68,13 @@ export function renderJUnit(
     `<testsuite name="blastproof" tests="${results.length + skipped.length}" failures="${failures}" skipped="${skipped.length + notRun.length}" time="${seconds(meta.durationMs)}">`,
     '  <properties>',
     `    <property name="score" value="${meta.score}"/>`,
+    ...(meta.spend ? [`    <property name="llm_calls" value="${meta.spend.calls}"/>`] : []),
+    // Omitted rather than emitted as zero when no call reported usage: a
+    // property carrying 0 would be read by a pipeline as "this run spent no
+    // tokens", which is a different claim from "the provider did not say".
+    ...(meta.spend && meta.spend.callsWithUsage > 0
+      ? [`    <property name="llm_tokens" value="${meta.spend.tokens}"/>`]
+      : []),
     ...(meta.incomplete !== undefined
       ? [
           '    <property name="incomplete" value="true"/>',

--- a/src/report/score.ts
+++ b/src/report/score.ts
@@ -1,3 +1,4 @@
+import type { BudgetSpend } from '../runner/budget.js';
 import type { TestResult } from '../runner/executor.js';
 
 /** Priority weights: a failing P0 costs three times a failing P2 (design D1). */
@@ -58,4 +59,41 @@ export function formatIncompleteLine(score: number, reason: string): string {
     `Run incomplete: ${reason}\n` +
     `Score over executed tests: ${score} (not a verdict — exit code 1 regardless of --min-score)`
   );
+}
+
+/**
+ * The summary line stating what a run actually spent (design
+ * report-what-it-spent, D1/D4).
+ *
+ * Lives here, with the other summary lines, rather than in the console command:
+ * the JUnit and HTML reports take the same figures from the same
+ * {@link BudgetSpend}, and formatting it where only the console can see it is
+ * how three surfaces start disagreeing about what a run cost.
+ *
+ * Deliberately not currency. The same reasoning that keeps the budget itself
+ * denominated in calls and tokens applies to reporting them: a price table is
+ * wrong the day a provider reprices, and wrong for anyone behind a gateway.
+ * Digits are plain, not locale-grouped, so the line is identical everywhere it
+ * is read or asserted on.
+ */
+export function formatSpendLine(spend: BudgetSpend): string {
+  const calls =
+    spend.maxCalls === undefined
+      ? `${spend.calls} model call(s)`
+      : `${spend.calls} of ${spend.maxCalls} model call(s)`;
+
+  // Zero tokens counted and zero tokens reported are different facts, and only
+  // one of them is about the run (design D1).
+  if (spend.callsWithUsage === 0) {
+    return `Spent: ${calls}; token usage not reported by the provider`;
+  }
+  const tokens =
+    spend.maxTokens === undefined
+      ? `${spend.tokens} token(s)`
+      : `${spend.tokens} of ${spend.maxTokens} token(s)`;
+  const coverage =
+    spend.callsWithUsage < spend.calls
+      ? ` (tokens reported by ${spend.callsWithUsage} of ${spend.calls} call(s))`
+      : '';
+  return `Spent: ${calls}, ${tokens}${coverage}`;
 }

--- a/src/runner/budget.ts
+++ b/src/runner/budget.ts
@@ -81,6 +81,7 @@ export class RunBudget {
   private readonly startedAt: number;
   private calls = 0;
   private tokens = 0;
+  private callsWithUsage = 0;
 
   constructor(options: RunBudgetOptions = {}) {
     this.maxCalls = options.maxCalls;
@@ -124,8 +125,46 @@ export class RunBudget {
   /** Records what a completed model call spent. */
   record(usage: CallUsage | undefined): void {
     this.calls += 1;
-    if (usage?.totalTokens !== undefined) this.tokens += usage.totalTokens;
+    if (usage?.totalTokens !== undefined) {
+      this.tokens += usage.totalTokens;
+      this.callsWithUsage += 1;
+    }
   }
+
+  /**
+   * What this budget has been spent on, for every surface that reports it
+   * (design report-what-it-spent, D1). One method rather than four getters read
+   * separately: the console, the JUnit report and the HTML report take the same
+   * numbers from the same object, so they cannot disagree about what a run cost.
+   */
+  spend(): BudgetSpend {
+    return {
+      calls: this.calls,
+      maxCalls: this.maxCalls,
+      tokens: this.tokens,
+      callsWithUsage: this.callsWithUsage,
+      maxTokens: this.maxTokens,
+    };
+  }
+}
+
+/**
+ * What a run actually spent, for reporting (design report-what-it-spent, D1).
+ *
+ * `callsWithUsage` is what separates "no tokens were reported" from "no tokens
+ * were spent". `tokenCount` starts at zero and is only ever incremented by a
+ * value the provider supplied, so a run against a provider that reports no
+ * usage ends indistinguishable from one that made no calls at all. Printing
+ * `0 tokens` there is not a rounding error — it is a false statement about the
+ * one thing someone is reading the line to learn.
+ */
+export interface BudgetSpend {
+  calls: number;
+  maxCalls?: number;
+  tokens: number;
+  /** How many completed calls reported token usage; 0 means the figure is unavailable. */
+  callsWithUsage: number;
+  maxTokens?: number;
 }
 
 /** The step counts an estimate needs from a test — a subset of `TestFile`. */

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -9,6 +9,7 @@ import {
 import { executeTest } from '../src/runner/executor.js';
 import type { PageLike } from '../src/runner/actions.js';
 import type { TestFile } from '../src/runner/testfile.js';
+import { formatSpendLine } from '../src/report/score.js';
 
 describe('RunBudget', () => {
   it('never binds when unconfigured', () => {
@@ -210,5 +211,74 @@ describe('estimateMaxModelCalls bounds the real executor (DEF-001 regression)', 
     // = 11, which is 3 + 5 + min(3, 5).
     expect(actualCalls).toBe(N + R + Math.min(N, R));
     expect(ceiling).toBe(N + R + Math.min(N, R));
+  });
+});
+
+// --- what a run spent ---------------------------------------------------------
+//
+// The counts existed and were discarded (#27). An evaluator sizing a PR gate had
+// to ask the provider what a run cost, because the only figure blastproof
+// volunteered was `--dry-run`'s worst case — measured at 105 against 13 calls
+// actually spent for the same selection.
+
+describe('RunBudget.spend', () => {
+  it('reports the calls and tokens spent', () => {
+    const budget = new RunBudget();
+    budget.record({ totalTokens: 1539 });
+    budget.record({ totalTokens: 1525 });
+
+    expect(budget.spend()).toEqual({
+      calls: 2,
+      tokens: 3064,
+      callsWithUsage: 2,
+      maxCalls: undefined,
+      maxTokens: undefined,
+    });
+    expect(formatSpendLine(budget.spend())).toBe('Spent: 2 model call(s), 3064 token(s)');
+  });
+
+  it('says token usage is unavailable rather than showing zero', () => {
+    // A local provider that reports no usage leaves `tokens` at 0, which is
+    // indistinguishable from a run that spent nothing. Printing "0 tokens" there
+    // is a false statement about the one thing the line exists to report.
+    const budget = new RunBudget();
+    budget.record(undefined);
+    budget.record({});
+
+    expect(budget.spend().callsWithUsage).toBe(0);
+    expect(formatSpendLine(budget.spend())).toBe(
+      'Spent: 2 model call(s); token usage not reported by the provider',
+    );
+  });
+
+  it('says how many calls a partial token figure covers', () => {
+    const budget = new RunBudget();
+    budget.record({ totalTokens: 100 });
+    budget.record(undefined);
+    budget.record({ totalTokens: 50 });
+
+    expect(formatSpendLine(budget.spend())).toBe(
+      'Spent: 3 model call(s), 150 token(s) (tokens reported by 2 of 3 call(s))',
+    );
+  });
+
+  it('reports against the configured limits when there are any', () => {
+    const budget = new RunBudget({ maxCalls: 500, maxTokens: 200_000 });
+    budget.record({ totalTokens: 1539 });
+
+    expect(formatSpendLine(budget.spend())).toBe(
+      'Spent: 1 of 500 model call(s), 1539 of 200000 token(s)',
+    );
+  });
+
+  it('still reports what was spent after the budget stopped the run', () => {
+    // The case where the number is least guessable and most needed: a stop says
+    // which limit was hit, not what the rest of the picture was.
+    const budget = new RunBudget({ maxCalls: 2 });
+    budget.record({ totalTokens: 900 });
+    budget.record({ totalTokens: 800 });
+    expect(() => budget.check()).toThrow(BudgetExhaustedError);
+
+    expect(formatSpendLine(budget.spend())).toBe('Spent: 2 of 2 model call(s), 1700 token(s)');
   });
 });

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -177,3 +177,34 @@ describe('writeJUnit', () => {
     }
   });
 });
+
+describe('JUnit spend properties', () => {
+  const meta = { score: 100, durationMs: 1000 };
+
+  it('carries the calls and tokens a run spent, beside the score', () => {
+    const xml = renderJUnit([], [], {
+      ...meta,
+      spend: { calls: 13, tokens: 18382, callsWithUsage: 13 },
+    });
+    expect(xml).toContain('<property name="score" value="100"/>');
+    expect(xml).toContain('<property name="llm_calls" value="13"/>');
+    expect(xml).toContain('<property name="llm_tokens" value="18382"/>');
+  });
+
+  it('omits the token property rather than writing zero when nothing was reported', () => {
+    // A property carrying 0 reads to a pipeline as "this run spent no tokens",
+    // which is a different claim from "the provider did not say".
+    const xml = renderJUnit([], [], {
+      ...meta,
+      spend: { calls: 4, tokens: 0, callsWithUsage: 0 },
+    });
+    expect(xml).toContain('<property name="llm_calls" value="4"/>');
+    expect(xml).not.toContain('llm_tokens');
+  });
+
+  it('emits neither when there is no spend to report', () => {
+    const xml = renderJUnit([], [], meta);
+    expect(xml).toContain('<property name="score" value="100"/>');
+    expect(xml).not.toContain('llm_calls');
+  });
+});

--- a/tests/run-budget.test.ts
+++ b/tests/run-budget.test.ts
@@ -2,7 +2,10 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { BudgetExhaustedError } from '../src/runner/budget.js';
+import { BudgetExhaustedError, RunBudget } from '../src/runner/budget.js';
+
+/** The slice of `RunBudget` these tests drive through the mocked `createBrain`. */
+type RunBudgetLike = { record(usage: { totalTokens?: number } | undefined): void };
 
 const { launchMock, createBrainMock, executeTestMock } = vi.hoisted(() => ({
   launchMock: vi.fn(),
@@ -210,5 +213,55 @@ describe('runCommand budget exhaustion (design D3/D4, spec run-budget)', () => {
     expect(code).toBe(EXIT_FAILED);
     expect(out()).toContain('Run incomplete');
     expect(out()).toMatch(/NOT RUN\s+P0\s+Test A/);
+  });
+});
+
+describe('runCommand reports what it spent (#27)', () => {
+  it('prints the spend for a run that owns its budget', async () => {
+    await writeProject({ 'a.yaml': TEST_A });
+    executeTestMock.mockImplementation(async (_page, test) => passingResult(test));
+    createBrainMock.mockImplementation((_model: unknown, _mask: unknown, budget: RunBudgetLike) => {
+      budget.record({ totalTokens: 1200 });
+      budget.record({ totalTokens: 800 });
+      return { nextAction: vi.fn(), judge: vi.fn() };
+    });
+
+    await runCommand({ cwd: dir, tags: [] });
+
+    expect(out()).toContain('Spent: 2 of 5 model call(s), 2000 token(s)');
+  });
+
+  it('does not print the spend when a composing caller owns the budget', async () => {
+    // `test` hands one budget to both phases on purpose. Reporting at the point
+    // of use rather than the point of ownership would print the running total
+    // twice, the second line silently including the first.
+    await writeProject({ 'a.yaml': TEST_A });
+    executeTestMock.mockImplementation(async (_page, test) => passingResult(test));
+    const shared = new RunBudget();
+    createBrainMock.mockImplementation((_model: unknown, _mask: unknown, budget: RunBudgetLike) => {
+      budget.record({ totalTokens: 1200 });
+      return { nextAction: vi.fn(), judge: vi.fn() };
+    });
+
+    await runCommand({ cwd: dir, tags: [], budget: shared });
+
+    expect(out()).not.toContain('Spent:');
+    expect(shared.spend().calls).toBe(1);
+  });
+
+  it('reports the spend of a run its budget stopped', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B });
+    createBrainMock.mockImplementation((_model: unknown, _mask: unknown, budget: RunBudgetLike) => {
+      budget.record({ totalTokens: 900 });
+      return { nextAction: vi.fn(), judge: vi.fn() };
+    });
+    executeTestMock
+      .mockImplementationOnce(async (_page: unknown, test: never) => passingResult(test))
+      .mockRejectedValueOnce(new BudgetExhaustedError('calls', 5, 5));
+
+    await runCommand({ cwd: dir, tags: [] });
+
+    expect(out()).toContain('Run incomplete');
+    expect(out()).toContain('Spent:');
   });
 });


### PR DESCRIPTION
Closes #27.

## The gap

Every model call and every token was already counted — that is how `budget:` enforces its limits — and then thrown away when the run ended.

So the only cost figure blastproof volunteered was `--dry-run`'s worst case, which is deliberately a maximum. Measured on this repository's own suite:

| | |
|---|---|
| `--dry-run` ceiling | **735 model calls** |
| what a real run spends | **82 model calls, 115,407 tokens** |

**A ratio of 9:1.** Anyone sizing `max_llm_calls` from the one number available would set it about nine times too high, and anyone wanting to size it from experience could not, because the tool never reported experience. The evaluator who raised this had to ask OpenRouter directly to price a PR gate.

## What it looks like now

```
7 passed, 0 failed, 7 total
Spent: 82 model call(s), 115407 token(s)
Score: 100
```

Stopped by its own budget — the case where the number is least guessable, because a stop says which limit was hit and nothing about the rest of the picture:

```
Spent: 8 of 8 model call(s), 12105 token(s)
Run incomplete: model call budget exhausted: reached the configured maximum of 8 call(s)
```

And in the JUnit report, beside `score`, so a pipeline can trend cost without scraping stdout:

```xml
<property name="score" value="100"/>
<property name="llm_calls" value="82"/>
<property name="llm_tokens" value="115407"/>
```

## Two decisions worth reading

**Zero tokens counted and zero tokens reported are different facts.** `tokenCount` starts at zero and is only ever incremented by a value the provider supplied, so a run against a provider that reports no usage would end at `0 tokens` — indistinguishable from a run that spent nothing. That is not a rounding error, it is a false statement about the one thing the line exists to report. The number of calls that reported usage is tracked, the line says the figure is unavailable, and the JUnit property is omitted rather than written as zero. I confirmed OpenRouter reports full usage on every call, so this is the defensive path, not the common one — which is the right way round, since that failure would be silent.

**The command that constructed the budget is the one that reports it.** `test` deliberately hands a single budget to both its phases, because a budget that resets between phases is two allowances rather than one bound. Reporting at the point of use would print the running total twice, the second line silently including the first. Tying it to ownership makes "once per allowance" true by construction. Pinned by a test: replacing the ownership check with an unconditional report fails it.

## Deliberately not

**Currency.** The same reasoning that keeps the budget denominated in calls and tokens applies to reporting them — a price table is wrong the day a provider reprices, and wrong for anyone behind a gateway. Also no per-test attribution and no input/output split; `CallUsage` records the total only, and widening it is a separate question.

The `--dry-run` ceiling is unchanged. The README now says plainly to read it as a maximum and size budgets from what runs actually report, with the 735-against-82 figure named.

406 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
