### PR TITLE
feat: tests can run several at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,22 @@ blastproof plan --base main --dry-run                 # affected routes no test 
 
 They report affected routes, files nobody has classified, and affected routes no test covers — a coverage-gap report with an exit code, useful even on a repo whose suite is Playwright or Cypress.
 
+## Running tests at once
+
+Tests run one at a time by default. Raise it when your tests can stand it:
+
+```yaml
+concurrency: 4
+```
+
+or `blastproof run --concurrency 4` for a single invocation. On this repository's own suite that takes a run from 156s to 68s — **2.3× faster, for the same 81 model calls.** Parallelism buys wall-clock, not spend.
+
+**The default is 1 on purpose, and raising it is your call to make.** Other test runners default to parallel because their tests are isolated by construction — separate processes, separate fixtures. These are journeys driven against **one running application**, so two tests can see each other's data. A suite is safe to parallelise when its tests do not write state that another test reads.
+
+The test in this repository's own suite that could not run beside itself is a good shape to recognise: it adds a note and then asserts *"one note on file"*. It writes shared server state, and it asserts on a global count. Either alone is a warning; together they mean the test's verdict depends on nothing else touching the application at that moment.
+
+Two practical notes. Four concurrent journeys are four times the traffic against whatever you pointed at — usually fine for a development instance, worth knowing for a shared one. And with several model calls in flight, a `budget:` limit can overshoot by up to the concurrency rather than by a single call, since the calls already sent are allowed to finish.
+
 ## Bounding a run
 
 Nothing stops a run by default. `budget:` puts a ceiling on `run`, `plan` and `test` alike — every model call any of them makes is counted:

--- a/openspec/changes/tests-in-parallel/design.md
+++ b/openspec/changes/tests-in-parallel/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`runCommand` runs tests in a plain `for` loop over `selected`, calling `runOne` and awaiting each one. `runOne` opens a fresh browser context, runs the test, closes the context. Nothing in it is shared with another test except the `Browser`, the `RunBudget`, the secrets mask and — when auth is configured — the captured session state, which is read-only.
+
+So the tests are already isolated *from each other inside the browser*. The loop is the only thing serialising them.
+
+Measured baseline, this repository's suite against the demo app: **7 tests, 156s, 85 model calls.** Wall-clock is dominated by waiting on the model and on page settling, neither of which uses local CPU.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Several tests in flight, bounded.
+- A log that stays readable when they are.
+- A report that does not change shape because of timing.
+
+**Non-Goals:**
+- Parallelising a journey's steps.
+- Promising isolation of the application under test. We cannot give it.
+
+## Decisions
+
+### D1 — The default is 1, and parallelism is opted into
+
+**Decision.** `concurrency` defaults to `1`. A run behaves exactly as it does today until someone sets it higher.
+
+**Why not follow the usual convention.** Vitest, Jest and Playwright all default to parallel, and it would be easy to argue we should too. They can, because their tests are isolated by construction: separate processes, separate fixtures, a database per worker if you set one up. Ours are plain-English journeys driven against **one running application**, and two tests that both write to it can see each other's data. This repository's own suite contains an example — the notes test asserts *"the heading shows one note on file"*, which is only true because nothing else is adding notes at that moment.
+
+A tool whose job is to gate merges must not, on upgrade, start producing failures that come from its own concurrency rather than from the code under review. Someone chasing that would be debugging our scheduler while believing they were debugging their application. The cost of the safe default is one line of configuration; the cost of the unsafe one is paid by whoever cannot reproduce a flake.
+
+**Why a fixed number rather than one derived from CPU count.** A default of "half your cores" makes a run behave differently on a laptop and on a CI runner, which for a gate means the budget overshoot (D3) and the interleaving both change with the machine. Concurrency here is bounded by network waiting, not by CPU, so cores are the wrong quantity anyway.
+
+### D2 — Buffer per test when concurrent, stream when not
+
+**Decision.** With `concurrency > 1`, each test's events are collected and printed as one contiguous block when that test finishes. With `concurrency === 1`, events print as they happen, exactly as today.
+
+**Why two paths rather than always buffering.** Always buffering would be simpler code and a worse tool. Watching steps arrive is how someone knows a run is progressing and where it is stuck, and taking that away from every existing user to serve an opt-in feature would be a regression paid by people who did not ask for anything. The condition is decided once, where the run's concurrency is known, not per event.
+
+**Why not interleave with a per-line prefix.** It keeps the live feedback, but a step transcript is only legible read consecutively — the action, its result, the judgment. Interleaved at the line level, four tests produce a log where no single narrative can be followed. Blocks preserve the thing that makes the output useful.
+
+### D3 — Overshoot is bounded by concurrency, and the spec says so
+
+**Decision.** `RunBudget` is unchanged. The documented bound on overshoot changes from "one call" to "as many calls as can be in flight".
+
+**Why not make the check atomic.** `check()` then `record()` is check-then-act, and with N calls in flight N can pass the check before any of them records. Reserving a call at check time would fix that for calls, but not for tokens, which are only known after the response arrives — so the honest bound would still be concurrency-dependent, and the machinery would buy a guarantee it cannot fully deliver.
+
+**Why this is acceptable.** The bound only weakens for a run that opted into concurrency, and it weakens by a known, configured amount: set 4, and the budget can overshoot by up to 4 calls instead of 1. Someone who needs the tighter bound has it by leaving the default alone. Stating it plainly in the spec is the whole of the work; pretending otherwise would be the failure.
+
+### D4 — Reported in selection order, never completion order
+
+**Decision.** Results are written into a slot reserved by the test's index in the selection and read back in that order for every surface: summary, JUnit, HTML.
+
+**Why.** A report whose row order depends on which test happened to finish first is a report that changes between runs of the same code. Diffing two reports is a real thing people do, and completion order makes it useless. This costs an indexed array.
+
+### D5 — A budget stop lets what is running finish
+
+**Decision.** When a `BudgetExhaustedError` stops the run, tests already in flight run to completion, no further tests start, and the rest are reported `not-run`.
+
+**Why not cancel in flight.** Cancelling a test mid-step means closing a browser context under an action, and the result would be a test that neither passed, failed, nor was cleanly not run — a fourth state to define and report for no benefit. Letting them finish costs at most one test's duration and keeps `not-run` meaning exactly what it means today: the run stopped before this test executed.
+
+## Risks / Trade-offs
+
+- **Tests that interfere.** Real, and it is why the default is 1. The README must say what makes a suite safe to parallelise rather than only offering the knob: tests that write to shared server state, or assert on global counts, are the ones that cannot.
+- **More load on the application under test.** Four concurrent journeys against a development instance is four times the traffic. Worth a sentence in the README; not something to solve here.
+- **Two output paths to keep working.** Mitigated by deciding once, at the top, rather than per event.
+- **Provider rate limits.** A user who hits one will see it as test failures. Nothing to do here beyond naming it, since the limit and its remedy belong to their account.
+
+## Migration Plan
+
+None. `concurrency` defaults to 1 and every existing run behaves identically, output included.
+
+## Open Questions
+
+None blocking. Noted: with concurrency above 1 the wall-clock deadline (`max_duration_s`) buys more work per second, so a deadline sized against serial runs becomes more generous rather than less. That is a change in what an existing setting achieves, but only for a run that opted in, and in the direction nobody complains about.

--- a/openspec/changes/tests-in-parallel/proposal.md
+++ b/openspec/changes/tests-in-parallel/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Tests run one after another. Every external evaluation has said so, and it is the most cited practical complaint about the tool.
+
+Measured on this repository's own suite, just now: **7 tests, 2 minutes 36 seconds, 85 model calls**. Almost all of that time is spent waiting — for a page to settle, for a model to answer — with one browser context open and one request in flight. A pull-request gate that takes two and a half minutes for seven tests does not stay a seven-test suite for long, and the wait is what stops people adding the eighth.
+
+Nothing about the design requires this. `runOne` already opens a fresh browser context per test and closes it afterwards, so tests are already isolated from each other inside the browser. The `for` loop around it is the only thing making them sequential.
+
+## What Changes
+
+- A run can execute several tests at once, bounded by a configured `concurrency:` and a `--concurrency` flag.
+- **The default stays 1.** Parallelism is opt-in, because the isolation that matters is not the browser's — it is the application's, and only the person who wrote the tests knows whether theirs can run at the same time.
+- With concurrency above 1, each test's output is buffered and printed as one block when it finishes, so a log with several tests in flight stays readable. At 1, output streams exactly as it does today.
+- Results are reported in selection order regardless of the order they finish in, so a report never changes shape because of timing.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli-run-command`: tests may run concurrently, and console output accounts for it.
+- `run-budget`: how far a budget can overshoot depends on how many calls can be in flight.
+
+## Non-goals
+
+- **Not parallelising a single test's steps.** A journey is ordered by definition.
+- Not a default above 1. See D1: the safe default is the one that cannot silently corrupt someone's run, and the cost of opting in is one line of config.
+- Not process-level parallelism or sharding across machines. One browser, several contexts, which is what the existing design already supports.
+- Not test-level isolation of the application under test. We cannot provide it and should not pretend to; what we can do is be explicit that it is the user's to reason about.
+
+## Impact
+
+- `src/commands/run.ts` — the sequential loop becomes a bounded pool; `printEvent` becomes a per-test sink.
+- `src/config.ts` — `concurrency:`, plus the `--concurrency` flag in `src/cli.ts`.
+- `src/runner/budget.ts` — unchanged in behaviour, but its documented overshoot bound now depends on concurrency.
+- `README.md` — when parallelism is safe, and when it is not.
+- No new npm dependency: a bounded pool is a dozen lines.

--- a/openspec/changes/tests-in-parallel/specs/cli-run-command/spec.md
+++ b/openspec/changes/tests-in-parallel/specs/cli-run-command/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Tests may run concurrently
+`run` SHALL support executing several tests at once, bounded by a configured maximum. The maximum SHALL be configurable in `.blastproof/config.yaml` as `concurrency:` and overridable per invocation with `--concurrency <n>`, the flag taking precedence over the file. A value below 1 SHALL be rejected with an explanatory error rather than clamped.
+
+The default SHALL be 1. Tests are journeys driven against one running application, and whether two of them can run at the same time is a property of the application and the tests, not of the runner — so concurrency is opted into by the person who knows, never assumed on their behalf.
+
+Results SHALL be reported in selection order on every surface, regardless of the order in which tests finish.
+
+#### Scenario: Concurrency is opted into
+- **WHEN** no `concurrency:` is configured and no flag is given
+- **THEN** tests run one at a time, as they do today
+
+#### Scenario: Several tests at once
+- **WHEN** `concurrency: 4` is configured and more than four tests are selected
+- **THEN** at most four run at the same time, and the rest start as earlier ones finish
+
+#### Scenario: The flag beats the file
+- **WHEN** the config declares a concurrency and `--concurrency` is given
+- **THEN** the flag's value is used
+
+#### Scenario: An invalid concurrency is refused
+- **WHEN** a concurrency below 1 is configured or passed
+- **THEN** the run fails with an explanatory error instead of silently choosing a value
+
+#### Scenario: Report order does not depend on timing
+- **WHEN** tests finish in a different order from the one they were selected in
+- **THEN** the summary and every written report list them in selection order
+
+### Requirement: Concurrent output stays readable
+When more than one test can be in flight, each test's console output SHALL be presented as one contiguous block, printed when that test finishes, so that a step transcript can be read consecutively. When tests run one at a time, output SHALL stream as each event occurs, unchanged.
+
+#### Scenario: Blocks, not interleaving
+- **WHEN** several tests run at once
+- **THEN** each test's header, steps and result appear together, not interleaved with another test's
+
+#### Scenario: Live output is preserved when serial
+- **WHEN** tests run one at a time
+- **THEN** events print as they happen, exactly as before

--- a/openspec/changes/tests-in-parallel/specs/run-budget/spec.md
+++ b/openspec/changes/tests-in-parallel/specs/run-budget/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: A run is bounded by model calls, tokens and wall-clock time
+A run SHALL carry a budget of a maximum number of model calls and a maximum number of tokens, and a deadline of a maximum wall-clock duration. Each SHALL be optional and independently configurable; an unconfigured limit SHALL NOT bound the run. Every model call made anywhere in the run — agent action, assert judgment, or test planning — SHALL count against the budget.
+
+A limit is checked before the next unit of work is spent, so how far a run can exceed one depends on how much work can be in flight when the limit is crossed. Running tests one at a time, that is a single call. Running several at once, it is bounded by the configured concurrency, and this SHALL be documented rather than presented as an exact bound.
+
+#### Scenario: Call budget exhausted
+- **WHEN** a run configured with a maximum of 200 model calls attempts the 201st
+- **THEN** the call is not made, the run stops, and the reason names the limit that was reached
+
+#### Scenario: Token budget exhausted
+- **WHEN** the tokens reported by completed calls reach the configured maximum
+- **THEN** the run stops before the next call and the reason names the limit that was reached
+
+#### Scenario: Deadline reached
+- **WHEN** the configured wall-clock duration elapses
+- **THEN** the run stops at the next check point and the reason names the elapsed limit
+
+#### Scenario: No budget configured
+- **WHEN** no budget or deadline is configured
+- **THEN** the run proceeds without any limit, as it does today
+
+#### Scenario: Overshoot grows with concurrency
+- **WHEN** a limit is crossed while several tests are in flight
+- **THEN** the calls already in flight complete, so the run may exceed the limit by up to the configured concurrency
+
+#### Scenario: A stop lets running tests finish
+- **WHEN** a budget or deadline stops a run with tests in flight
+- **THEN** those tests run to completion, no further test starts, and the remainder are reported as not run

--- a/openspec/changes/tests-in-parallel/tasks.md
+++ b/openspec/changes/tests-in-parallel/tasks.md
@@ -1,0 +1,47 @@
+## 1. Measure the baseline first
+
+- [x] 1.1 Time the dogfood suite serially and record wall-clock, calls and tokens, so the change is judged against a number rather than an impression.
+  - **7 tests, 156s (2m36), 85 model calls, 118676 tokens.**
+
+## 2. A bounded pool
+
+- [x] 2.1 A small `mapWithConcurrency`-style helper, in its own module and unit-tested independently of the browser: bounded in flight, results in input order, one rejection does not lose the others' results.
+- [x] 2.2 `runCommand`'s `for` loop becomes a call to it. `runOne` is untouched — it already opens and closes its own context.
+- [x] 2.3 Results are placed by the test's index in the selection, so every surface reports in selection order regardless of finishing order (design D4).
+- [x] 2.4 A budget stop lets in-flight tests finish, starts no more, and reports the rest `not-run` (design D5). `budget.check()` still runs before each test starts, not only inside the brain.
+
+## 3. Output that survives concurrency
+
+- [x] 3.1 `printEvent` becomes a per-test sink. With concurrency 1 it writes through immediately, exactly as today; above 1 it collects and the block is printed when the test finishes (design D2).
+- [x] 3.2 Decide which mode once, where the run's concurrency is known — not per event, and not by checking a global inside the printer.
+- [x] 3.3 The test's header line (`> summary [P0] (path)`) belongs to its block, not printed on start, or blocks will be separated from their headers.
+
+## 4. Configuration
+
+- [x] 4.1 `concurrency:` in the config schema, integer, minimum 1, **default 1** (design D1).
+- [x] 4.2 `--concurrency <n>` on `run`, overriding the file, matching how the budget flags already work.
+- [x] 4.3 Reject a value below 1 with the house error style rather than silently clamping.
+
+## 5. Tests
+
+- [x] 5.1 The pool runs no more than N at once, and returns results in input order.
+- [x] 5.2 A run with concurrency 1 produces byte-identical console output to today's.
+- [x] 5.3 With concurrency above 1, each test's events appear contiguously, not interleaved.
+- [x] 5.4 The summary, JUnit and HTML report in selection order even when completion order differs.
+- [x] 5.5 A budget stop with several tests in flight: those finish, the rest are `not-run`.
+- [x] 5.6 `--concurrency` beats the config file; an invalid value is rejected.
+
+## 6. Verification
+
+- [x] 6.1 Re-run the dogfood suite at concurrency 4 against a real model. Compare wall-clock with the 156s baseline and state the speedup honestly, including whether the token and call counts moved.
+
+  | | wall-clock | calls | tokens | result |
+  |---|---|---|---|---|
+  | serial | 156s | 85 | 118676 | 7/7 |
+  | concurrency 4 | **68s** | 81 | 114349 | 7/7 |
+
+  **2.3× faster.** Calls and tokens are unchanged within run-to-run noise, which is the expected result: parallelism buys wall-clock, not spend. The speedup is short of 4× because the login journey runs once before any test starts and is not parallelised, and because the pool drains at the end while the longest test finishes alone.
+- [x] 6.2 Confirmed: at the default the transcript still arrives step by step as it happens, byte-identical in shape to before.
+
+  **A first concurrent run failed, and it was worth chasing rather than re-running.** The notes test failed on the contained-recovery refusal. It was not interference between tests: the demo server had been up across several runs, each adding one note, so `Notes on file` was 2 where the test asserts 1. Restarted clean, 7/7. The finding is real but it is about *our own suite not being idempotent against a persistent application* — the same hazard as two tests interfering, separated in time rather than running at once. It belongs in the README as the concrete example, which is task 6.3.
+- [x] 6.3 README says what makes a suite unsafe to parallelise, using this repository's own notes test as the example — it both writes shared server state and asserts on a global count, which is exactly the combination that cannot be run beside itself.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,11 @@ program
   .option('--html [path]', 'write a self-contained HTML report (default: .blastproof/reports/<session>/report.html)')
   .option('--fail-on-unmapped', 'fail when a changed file matches no routes: or ignore: glob')
   .option(
+    '--concurrency <n>',
+    'run this many tests at once (overrides config; default 1 — see the README on when this is safe)',
+    parsePositiveInt('--concurrency'),
+  )
+  .option(
     '--max-llm-calls <n>',
     'stop the run after this many model calls, reported as incomplete (overrides config)',
     parsePositiveInt('--max-llm-calls'),
@@ -116,6 +121,7 @@ program
       junit?: string | boolean;
       html?: string | boolean;
       failOnUnmapped?: boolean;
+      concurrency?: number;
       maxLlmCalls?: number;
       maxTokens?: number;
       maxDuration?: number;
@@ -134,6 +140,7 @@ program
           junit: options.junit,
           html: options.html,
           failOnUnmapped: options.failOnUnmapped,
+          concurrency: options.concurrency,
           maxLlmCalls: options.maxLlmCalls,
           maxTokens: options.maxTokens,
           maxDuration: options.maxDuration,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -18,6 +18,7 @@ import {
   type RunBudgetOptions,
 } from '../runner/budget.js';
 import { MissingEnvError, SecretsMask, substituteEnv } from '../runner/env.js';
+import { runWithConcurrency } from '../runner/pool.js';
 import { describeAction } from '../runner/recovery.js';
 import {
   DEFAULT_MAX_ITERATIONS_PER_STEP,
@@ -50,6 +51,8 @@ export const EXIT_USAGE = 2;
  * `test` (which composes both) accept the same three.
  */
 export interface BudgetFlags {
+  /** Overrides config `concurrency` for this invocation (`--concurrency`). */
+  concurrency?: number;
   /** Overrides config `budget.max_llm_calls` for this invocation (`--max-llm-calls`). */
   maxLlmCalls?: number;
   /** Overrides config `budget.max_tokens` for this invocation (`--max-tokens`). */
@@ -179,19 +182,28 @@ function notRunResults(tests: TestFile[], reason: string): TestResult[] {
   }));
 }
 
-function printEvent(event: ExecutorEvent): void {
+/**
+ * Where a test's console lines go (design tests-in-parallel, D2). Serial runs
+ * hand in one that writes straight through, so output streams exactly as it
+ * always has; a concurrent run hands in one that collects, and the block is
+ * printed whole when the test finishes. Decided once, where the run's
+ * concurrency is known — never by the printer checking a global.
+ */
+export type LineSink = (line: string) => void;
+
+function printEvent(event: ExecutorEvent, write: LineSink = console.log): void {
   switch (event.type) {
     case 'step-start':
-      console.log(`  ${event.setup ? '(setup) ' : ''}step ${event.index + 1}/${event.total}: ${event.step}`);
+      write(`  ${event.setup ? '(setup) ' : ''}step ${event.index + 1}/${event.total}: ${event.step}`);
       break;
     case 'action': {
       const { action, result } = event;
-      console.log(`    -> ${describeAction(action)} :: ${result}`);
+      write(`    -> ${describeAction(action)} :: ${result}`);
       break;
     }
     case 'step-end':
       if (event.status === 'failed') {
-        console.log(`    X step failed: ${event.reason ?? 'unknown reason'}`);
+        write(`    X step failed: ${event.reason ?? 'unknown reason'}`);
       }
       break;
   }
@@ -253,6 +265,7 @@ async function runOne(
   session: AuthSession | undefined,
   runMask: SecretsMask,
   budget: RunBudget,
+  write: LineSink,
 ): Promise<TestResult> {
   const brain = createBrain(createModel(config.llm).model, undefined, budget);
 
@@ -294,7 +307,7 @@ async function runOne(
       timeoutMs: config.browser.timeout_ms,
       maxSnapshotLines: config.browser.max_snapshot_lines,
       mask: (text) => mask.mask(text),
-      onEvent: printEvent,
+      onEvent: (event) => printEvent(event, write),
     });
   } finally {
     await context.close();
@@ -650,26 +663,61 @@ export async function runCommand(options: RunOptions): Promise<number> {
       // to start, so every one of them is not run (design D3).
       results.push(...notRunResults(selected, incomplete.message));
     } else {
-      for (let i = 0; i < selected.length; i++) {
-        const test = selected[i]!;
-        console.log(`\n> ${test.summary} [${test.priority}] (${path.relative(options.cwd, test.path)})`);
+      const concurrency = options.concurrency ?? config.concurrency;
+      // Serial runs stream, concurrent runs buffer (design tests-in-parallel,
+      // D2). Decided once, here, where the concurrency is known — the printer
+      // never asks.
+      const streaming = concurrency === 1;
+
+      // Once any test has been stopped by the budget, no further test starts
+      // (design tests-in-parallel, D5). Held here rather than left to
+      // `budget.check()` to refuse the next one: that only holds while the
+      // budget itself agrees, which makes the guarantee a side effect of
+      // another component instead of a rule this loop enforces — the exact
+      // shape of defect this codebase keeps producing.
+      let stoppedBy: BudgetExhaustedError | undefined;
+
+      const outcomes = await runWithConcurrency(selected, concurrency, async (test, index) => {
+        if (stoppedBy) return { index, stopped: stoppedBy };
+        const lines: string[] = [];
+        // The header belongs to the block, not to the moment the test starts:
+        // printed on start, a concurrent run would separate every header from
+        // the transcript it introduces (design D2, task 3.3).
+        const header = `\n> ${test.summary} [${test.priority}] (${path.relative(options.cwd, test.path)})`;
+        const write: LineSink = streaming ? console.log : (line) => lines.push(line);
+        if (streaming) console.log(header);
+        else lines.push(header);
+
         try {
           // Checked here too, not only inside the brain (design run-budget task
           // 4.2): a deadline that has already passed must stop the *next test*
           // rather than launching a fresh context only to fail on its first call.
+          // This is also the whole of "no further test starts" once a budget has
+          // stopped the run (design tests-in-parallel, D5) — every test queued
+          // behind the stop short-circuits here without opening a context.
           budget.check();
-          results.push(await runOne(browser, test, config, sessionDir, session, runMask, budget));
+          const result = await runOne(browser, test, config, sessionDir, session, runMask, budget, write);
+          if (!streaming) for (const line of lines) console.log(line);
+          return { index, result };
         } catch (error) {
           if (error instanceof BudgetExhaustedError) {
-            incomplete = error;
-            // The test in progress, plus everything after it, never finished —
-            // recorded as not run rather than failed, and excluded from the
-            // score's denominator rather than counted against it (D3/D4).
-            results.push(...notRunResults(selected.slice(i), error.message));
-            break;
+            stoppedBy ??= error;
+            if (!streaming) for (const line of lines) console.log(line);
+            return { index, stopped: error };
           }
           throw error;
         }
+      });
+
+      for (const outcome of outcomes) {
+        if (outcome.result) {
+          results.push(outcome.result);
+          continue;
+        }
+        // Recorded as not run rather than failed, and excluded from the score's
+        // denominator rather than counted against it (D3/D4).
+        incomplete ??= outcome.stopped;
+        results.push(...notRunResults([selected[outcome.index]!], outcome.stopped!.message));
       }
     }
   } finally {

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,6 +104,13 @@ const configSchema = z.object({
   allowed_origins: z.array(z.string().url()).optional(),
   auth: authSchema.optional(),
   max_retries_per_step: z.number().int().min(1).default(3),
+  /**
+   * How many tests may run at once (design tests-in-parallel, D1). Defaults to
+   * 1 — tests are journeys driven against one running application, and whether
+   * two of them can run at the same time is a property of that application and
+   * those tests, not of the runner. Opted into by the person who knows.
+   */
+  concurrency: z.number().int().min(1, 'concurrency must be at least 1').default(1),
   budget: budgetSchema.optional(),
 });
 

--- a/src/runner/pool.ts
+++ b/src/runner/pool.ts
@@ -1,0 +1,48 @@
+/**
+ * Runs an ordered list of jobs with a bounded number in flight, returning their
+ * results in **input order** (design tests-in-parallel, D4).
+ *
+ * Input order, not completion order, is the point: a report whose rows depend on
+ * which test happened to finish first changes between runs of the same code, and
+ * people diff reports.
+ *
+ * Deliberately not a dependency. A bounded pool is this file; pulling in a
+ * library for it would add a supply-chain surface to a tool whose own pitch is
+ * that it gates other people's merges.
+ */
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  run: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (concurrency < 1) throw new RangeError(`concurrency must be at least 1, got ${concurrency}`);
+
+  const results = new Array<R>(items.length);
+  let next = 0;
+
+  // Each worker pulls the next index until there are none left, so a slow job
+  // holds up only itself — a fixed partition (worker i takes every nth item)
+  // would leave workers idle behind one long test.
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await run(items[index]!, index);
+    }
+  };
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < Math.min(concurrency, items.length); i++) {
+    workers.push(worker());
+  }
+
+  // `allSettled`, not `all`: `all` rejects on the first failure while the other
+  // workers keep running, which here would mean browser contexts left open with
+  // nobody awaiting them, and an unhandled rejection if a second worker failed
+  // too. Every worker is waited for, then the first failure is re-thrown — so a
+  // genuine error still ends the run, but not while work is still in flight.
+  const settled = await Promise.allSettled(workers);
+  const failure = settled.find((outcome) => outcome.status === 'rejected');
+  if (failure && failure.status === 'rejected') throw failure.reason;
+  return results;
+}

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { runWithConcurrency } from '../src/runner/pool.js';
+
+/** Resolves after `ms`, for ordering jobs deterministically without real waiting. */
+const after = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('runWithConcurrency', () => {
+  it('returns results in input order, not completion order', async () => {
+    // The whole point of the ordering rule: a report whose rows depend on which
+    // test finished first changes between runs of the same code.
+    const results = await runWithConcurrency([30, 10, 20], 3, async (ms, index) => {
+      await after(ms);
+      return index;
+    });
+
+    expect(results).toEqual([0, 1, 2]);
+  });
+
+  it('never exceeds the requested concurrency', async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await runWithConcurrency(Array.from({ length: 9 }, (_, i) => i), 3, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await after(5);
+      inFlight--;
+    });
+
+    expect(peak).toBe(3);
+  });
+
+  it('keeps every worker busy rather than partitioning the work', async () => {
+    // One slow job must hold up only itself. A fixed partition (worker i takes
+    // every nth item) would leave two workers idle behind this one.
+    const order: number[] = [];
+
+    await runWithConcurrency([50, 1, 1, 1], 2, async (ms, index) => {
+      await after(ms);
+      order.push(index);
+    });
+
+    expect(order[order.length - 1]).toBe(0);
+    expect(order).toHaveLength(4);
+  });
+
+  it('runs serially at a concurrency of 1', async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await runWithConcurrency([1, 2, 3], 1, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await after(1);
+      inFlight--;
+    });
+
+    expect(peak).toBe(1);
+  });
+
+  it('waits for work in flight before surfacing a failure', async () => {
+    // `Promise.all` would reject immediately and leave the other workers
+    // running with nobody awaiting them — here, browser contexts left open.
+    let finished = 0;
+
+    await expect(
+      runWithConcurrency([0, 1, 2, 3], 4, async (_item, index) => {
+        if (index === 0) throw new Error('boom');
+        await after(10);
+        finished++;
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(finished).toBe(3);
+  });
+
+  it('refuses a concurrency below 1 rather than choosing one', async () => {
+    await expect(runWithConcurrency([1], 0, async () => 1)).rejects.toThrow(/at least 1/);
+  });
+
+  it('handles an empty list', async () => {
+    expect(await runWithConcurrency([], 4, async () => 1)).toEqual([]);
+  });
+});

--- a/tests/run-budget.test.ts
+++ b/tests/run-budget.test.ts
@@ -265,3 +265,112 @@ describe('runCommand reports what it spent (#27)', () => {
     expect(out()).toContain('Spent:');
   });
 });
+
+describe('runCommand concurrency (#2)', () => {
+  it('runs tests one at a time by default, streaming their output', async () => {
+    // The default must not change what an existing user sees. Tests are
+    // journeys against one live application, and only the person who wrote
+    // them knows whether two can run at once (design tests-in-parallel, D1).
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B });
+    let inFlight = 0;
+    let peak = 0;
+    executeTestMock.mockImplementation(async (_page: unknown, test: never) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight--;
+      return passingResult(test);
+    });
+
+    await runCommand({ cwd: dir, tags: [] });
+
+    expect(peak).toBe(1);
+  });
+
+  it('runs several at once when asked, and reports in selection order', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B, 'c.yaml': TEST_C });
+    let peak = 0;
+    let inFlight = 0;
+    // B finishes last; the summary must still list A, B, C.
+    const delays: Record<string, number> = { 'Test A': 5, 'Test B': 40, 'Test C': 5 };
+    executeTestMock.mockImplementation(async (_page: unknown, test: never) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, delays[(test as { summary: string }).summary] ?? 5));
+      inFlight--;
+      return passingResult(test);
+    });
+
+    await runCommand({ cwd: dir, tags: [], concurrency: 3 });
+
+    expect(peak).toBe(3);
+    const summary = out().slice(out().indexOf('--- Summary'));
+    expect(summary.indexOf('Test A')).toBeLessThan(summary.indexOf('Test B'));
+    expect(summary.indexOf('Test B')).toBeLessThan(summary.indexOf('Test C'));
+  });
+
+  it('keeps each test\'s transcript contiguous when running concurrently', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B });
+    executeTestMock.mockImplementation(async (_page: unknown, test: never, options: never) => {
+      const { summary } = test as { summary: string };
+      const emit = (options as { onEvent: (e: unknown) => void }).onEvent;
+      emit({ type: 'step-start', index: 0, total: 1, step: `${summary} step one`, setup: false });
+      await new Promise((resolve) => setTimeout(resolve, summary === 'Test A' ? 30 : 1));
+      emit({ type: 'step-start', index: 1, total: 2, step: `${summary} step two`, setup: false });
+      return passingResult(test);
+    });
+
+    await runCommand({ cwd: dir, tags: [], concurrency: 2 });
+
+    // Contiguity, not ordering: B finishes first so its block prints first,
+    // which is fine. What must not happen is another test's line landing
+    // between two of A's.
+    const text = out();
+    const between = text.slice(
+      text.indexOf('Test A step one'),
+      text.indexOf('Test A step two'),
+    );
+    expect(between).not.toContain('Test B');
+    expect(text).toContain('Test A step two');
+  });
+
+  it('starts no further test once the budget has stopped the run', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B, 'c.yaml': TEST_C });
+    const started: string[] = [];
+    executeTestMock.mockImplementation(async (_page: unknown, test: never) => {
+      const { summary } = test as { summary: string };
+      started.push(summary);
+      if (summary === 'Test A') throw new BudgetExhaustedError('calls', 5, 5);
+      return passingResult(test);
+    });
+
+    await runCommand({ cwd: dir, tags: [] });
+
+    // Only the test that hit the limit ever ran; the guarantee is held by the
+    // loop, not inherited from the budget happening to refuse the next check.
+    expect(started).toEqual(['Test A']);
+    expect(out()).toMatch(/NOT RUN\s+P0\s+Test B/);
+    expect(out()).toMatch(/NOT RUN\s+P0\s+Test C/);
+  });
+
+  it('takes the flag over the configured value', async () => {
+    await writeProject({ 'a.yaml': TEST_A, 'b.yaml': TEST_B });
+    await writeFile(
+      path.join(dir, '.blastproof', 'config.yaml'),
+      `${CONFIG}concurrency: 1\n`,
+    );
+    let peak = 0;
+    let inFlight = 0;
+    executeTestMock.mockImplementation(async (_page: unknown, test: never) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight--;
+      return passingResult(test);
+    });
+
+    await runCommand({ cwd: dir, tags: [], concurrency: 2 });
+
+    expect(peak).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #2.

## Measured, before and after

| | wall-clock | calls | tokens | result |
|---|---|---|---|---|
| serial (today) | 156s | 85 | 118676 | 7/7 |
| `--concurrency 4` | **68s** | 81 | 114349 | 7/7 |

**2.3×.** Calls and tokens are unchanged within run-to-run noise, which is the expected result: parallelism buys wall-clock, not spend. It falls short of 4× because the login journey runs once before any test starts and because the pool drains at the end while the longest test finishes alone.

Nothing in the design required the wait. `runOne` already opens and closes its own browser context, so tests were already isolated inside the browser. The `for` loop around it was the only thing serialising them.

## The default stays 1, deliberately

Vitest, Jest and Playwright all default to parallel, and it would be easy to argue we should too. They can, because their tests are isolated by construction — separate processes, separate fixtures, a database per worker if you want one. Ours are plain-English journeys driven against **one running application**, and two tests that both write to it can see each other's data.

This repository's own suite contains the shape: the notes test adds a note and then asserts *"one note on file"*. It writes shared server state **and** asserts on a global count. That test cannot run beside itself.

A tool whose job is to gate merges must not, on upgrade, start producing failures that come from its own scheduler. Someone chasing that would be debugging our pool while believing they were debugging their application. The cost of the safe default is one line of config; the cost of the unsafe one is paid by whoever cannot reproduce a flake.

## Output

Above concurrency 1, each test's events are buffered and printed as one block when it finishes. A step transcript — the action, its result, the judgment — is only legible read consecutively, and interleaved at the line level four tests produce a log where no narrative can be followed.

At concurrency 1, output streams as it happens, exactly as before. Always buffering would have been simpler code and a worse tool: it would take live feedback away from every existing user to serve an opt-in feature.

Results are reported in selection order regardless of finishing order, on every surface. A report whose row order depends on which test finished first changes between runs of the same code, and people diff reports.

## An existing test caught a real bug

I had left "no further test starts after a budget stop" to `budget.check()` refusing the next one. That only holds while the budget itself agrees, which makes the guarantee a side effect of another component rather than a rule this loop enforces — the exact shape of defect this codebase keeps producing. A pre-existing test failed and named it. It is now explicit.

## Honest about what weakens

The budget's overshoot bound goes from "one call" to "as many as the configured concurrency", because calls already in flight are allowed to finish. Making the check atomic would fix it for calls but not for tokens, which are only known after a response arrives — so the honest bound stays concurrency-dependent either way. It is in the spec and the README, and it only weakens for a run that opted in.

## One false alarm worth recording

The first concurrent run failed a test, and it was worth chasing rather than re-running. It was **not** interference between tests: the demo server had been up across several runs, each adding one note, so the count was 2 where the test asserts 1. Restarted clean, 7/7. The finding is real but it is our own suite not being idempotent against a persistent application — the same hazard as two tests interfering, separated in time rather than running at once. It is now the README's worked example.

418 tests. New: a 40-line bounded pool with no dependency, unit-tested independently of the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
