### PR TITLE
fix: generated drafts follow the rule the docs teach

### DIFF
--- a/openspec/changes/drafts-follow-the-rule/design.md
+++ b/openspec/changes/drafts-follow-the-rule/design.md
@@ -1,0 +1,90 @@
+## Context
+
+Two prompts describe what a good step looks like, and they disagree.
+
+`agentSystemPrompt` (the executor's) has been tightened three times by real defects, and since 0.7.0 it forbids inventing a value:
+
+> Never invent a value. A value you type must come from the step, from the page, or from an `{{env.*}}` placeholder.
+
+`plannerSystemPrompt` still says:
+
+> End with at least one step that verifies an observable outcome (visible text, a count, a state change).
+
+"At least one, at the end" was reasonable when it was written. It is not the rule any more. The README now opens its writing guidance with the stronger one and shows the measurement: Score 64 to Score 100 on two rewritten steps, same application, same suite, same version.
+
+Generated against this repository's demo app:
+
+```yaml
+steps:
+  - Navigate to the Support page
+  - Enter a subject in the Subject textbox
+  - Enter a message in the Message textbox
+```
+
+Every one bare, and two naming no value. The executor is then required to refuse to invent those values, so `plan` drafts a test that `run` is designed not to complete.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Drafts demonstrate the rule the documentation teaches.
+- A draft never depends on a value it does not supply.
+
+**Non-Goals:**
+- Machine-validating that a step "states an outcome".
+- Changing anything about how drafts are written or run.
+
+## Decisions
+
+### D1 — Teach the planner the rule the README teaches, in the same words
+
+**Decision.** Replace "end with at least one step that verifies an observable outcome" with the rule as the README states it: each step names what should be true once it has been carried out, and an action worth taking is worth saying the result of. Add that a step supplying a value must write the value.
+
+**Why the same words.** Two documents describing the same rule differently is how they drifted in the first place. The README's phrasing is the one that has been measured and the one a user reads before writing their own tests, so a draft that mirrors it is also a worked example of it.
+
+**Why the value clause belongs here.** The executor already refuses to invent values (0.7.0, `contained-recovery` D3), which means a draft that says "Enter a subject" is not merely fragile — it is unrunnable by design. The generator is where that can be prevented, and prevention is cheaper than a refusal at run time that the person then has to interpret.
+
+### D1b — "One action or check per step" had to change with it
+
+**Decision.** The planner's first rule becomes "one move per step — a single action together with what it should produce, or a single check. Never two unrelated actions in one step."
+
+**Why.** As written, "one action **or** check per step" contradicts the rule being added: the README's own worked example — *"submit the add-task form and verify the task appears in the list"* — is one action **and** one check. Adding the new rule beside the old one would have shipped two instructions that cannot both be followed, which is a worse failure than the one being fixed.
+
+**What this must not break.** `contained-recovery` D1 cited that phrase as evidence that a step needing two identical commits contradicts the documented format, and that argument holds under the new wording: one *move* still means one commit, and "never two unrelated actions in one step" says so more directly than the phrase it replaces.
+
+### D1c — The planner did not know where a run starts, and this change exposed it
+
+**Decision.** The planner is told that a run begins at the application's base URL rather than at the route being generated for, and that the draft must open with a step navigating there and stating what should be visible.
+
+**Why it surfaced now.** The old drafts opened with a bare `Navigate to the Support page`. Pushing the model toward outcome-carrying steps made it **drop the navigation entirely** — the first generated draft under the new prompt began with `Fill the Subject textbox with …`, and running it failed on the home page: *"there is no Subject textbox visible on this page"*.
+
+That was a regression this change introduced, caught by running a generated draft rather than by reading it. The underlying gap is older: the planner has never been told where execution starts, and it happened to emit a navigation only because it was listing actions naively. Removing the naive listing removed the accident that was covering the gap.
+
+**Consequence for the verification.** Reading drafts is not enough to judge a change to the generator. A draft has to be run.
+
+### D2 — Put the rule in the spec, not only in the prompt
+
+**Decision.** `test-generation` gains a requirement that a generated step states its own outcome and carries any value it needs.
+
+**Why.** Today the rule lives in one string in one file. That is exactly the shape that drifted from the README without anyone noticing for a release. A requirement with scenarios is what makes the next change to that prompt have something to be checked against.
+
+### D3 — No machine validation of drafts
+
+**Decision.** Nothing rejects a draft for failing the rule.
+
+**Why.** Whether a plain-English sentence "states an outcome" is not decidable by a parser. A heuristic — look for a verb like *verify*, require two clauses — would reject good drafts and pass bad ones, and would do it silently at generation time when there is nothing to fall back on. `plan` already prints drafts and requires `--write` to persist them, and the README already says drafts need review before they join a suite. That review is the check, and pretending to automate it would weaken it by implying it had been done.
+
+**What this means honestly.** This change improves the odds; it does not guarantee the output. The verification below is therefore a sample of real generations, not a proof.
+
+## Risks / Trade-offs
+
+- **The model may still emit a bare step.** Prompt guidance is the weakest lever available, and DEF-005 records this project reaching for it too readily. It is the right lever *here* only because the alternative — validating prose — is worse, and because a bad draft costs a review comment rather than a wrong verdict.
+- **Longer steps.** A step carrying its outcome and its value is a longer sentence, and the drafts will read less like a checklist. That is the shape that works.
+- **Verification is a sample.** Two routes generated before and after is evidence, not proof. Stated as such in the tasks rather than dressed up.
+
+## Migration Plan
+
+None. Drafts already written are untouched; only newly generated ones change shape.
+
+## Open Questions
+
+None blocking. Noted: `plan`'s provenance header could name the rule, so someone reviewing a draft is reminded what to check it against. Left out as a separate, smaller question about the header's content.

--- a/openspec/changes/drafts-follow-the-rule/proposal.md
+++ b/openspec/changes/drafts-follow-the-rule/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+`plan` generates drafts that break the rule the README calls load-bearing.
+
+The README, since 0.10.0, leads its "Writing tests" section with it: **every step says what it should produce**, with the measurement behind it — the same application and suite went from Score 64 to Score 100 on two rewritten steps. The planner's prompt teaches something weaker and older: *"End with at least one step that verifies an observable outcome."*
+
+An outside evaluation noticed the mismatch. Generating against this repository's own demo app confirms it, and it is worse than reported:
+
+```yaml
+summary: User submits a support ticket through the contact form
+steps:
+  - Navigate to the Support page
+  - Enter a subject in the Subject textbox
+  - Enter a message in the Message textbox
+```
+
+Three bare actions in a row. Two of them name no value at all — and the agent's own system prompt has forbidden inventing one since 0.7.0, because inventing values is how a run writes data nobody wrote a test for. So the planner produces steps the executor is then required to refuse.
+
+A tool that drafts the fragile shape and afterwards fails it is teaching the wrong lesson twice: once to the person reading the draft, and once to the agent asked to run it.
+
+## What Changes
+
+- The planner is told the rule the README teaches: a step names what should be true after it, and a step that supplies a value writes the value.
+- The rule is written into the `test-generation` spec, so it is a property of generation rather than advice living in one prompt string.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `test-generation`: a generated step states its own outcome and carries any value it needs.
+
+## Non-goals
+
+- **Not validating drafts against the rule in code.** Whether a plain-English step "states an outcome" is not decidable by a parser, and a check that guessed would reject good drafts and pass bad ones. Drafts are reviewed by a person before they join a suite; that review is the check.
+- Not changing what `plan` writes, where it writes it, or the provenance header.
+- Not touching the executor or the judge. This is about what gets generated, not how it runs.
+
+## Impact
+
+- `src/llm/prompts.ts` — `plannerSystemPrompt`.
+- `openspec/specs/test-generation` — the rule becomes a requirement.
+- No new npm dependency, no CLI surface change.

--- a/openspec/changes/drafts-follow-the-rule/specs/test-generation/spec.md
+++ b/openspec/changes/drafts-follow-the-rule/specs/test-generation/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: A generated step states its own outcome
+Every generated step SHALL name what should be true once it has been carried out, rather than naming an action alone. A step that supplies a value to the application SHALL write that value, because the executor refuses to invent one.
+
+This is the rule the documentation teaches for hand-written tests, and a draft is also a worked example of it: a step that names an action without an outcome asks the judge to decide whether something happened while looking at the state that succeeding produces, which is the shape behind three separate defects.
+
+Whether a plain-English step states an outcome SHALL NOT be validated mechanically. It is not decidable by a parser, and a heuristic would reject good drafts and accept bad ones silently at generation time. Drafts are printed for review and require an explicit flag to be written; that review is the check.
+
+#### Scenario: An action carries its outcome
+- **WHEN** a draft includes a step that submits a form
+- **THEN** that step also names what should be true afterwards, rather than naming the submission alone
+
+#### Scenario: A step that fills carries its value
+- **WHEN** a draft includes a step that enters text into a field
+- **THEN** the step names the value to enter, rather than leaving it for the agent to invent
+
+#### Scenario: Drafts are not rejected mechanically
+- **WHEN** a generated step does not obviously state an outcome
+- **THEN** generation still succeeds and the draft is printed for review, rather than being refused by a heuristic

--- a/openspec/changes/drafts-follow-the-rule/tasks.md
+++ b/openspec/changes/drafts-follow-the-rule/tasks.md
@@ -1,0 +1,58 @@
+## 1. Capture what it generates today
+
+- [x] 1.1 Generate against this repository's own demo app and record the drafts verbatim, so the change is judged against real output rather than an impression.
+
+### Findings
+
+```yaml
+summary: User submits a support ticket through the contact form
+steps:
+  - Navigate to the Support page
+  - Enter a subject in the Subject textbox
+  - Enter a message in the Message textbox
+```
+
+Three bare actions, two naming no value. The executor has refused to invent values since 0.7.0, so `plan` drafts a test `run` is designed not to complete. The `/cart` draft opened with `Navigate to the cart page`, also bare.
+
+## 2. The planner teaches the rule the README teaches
+
+- [x] 2.1 Replace "end with at least one step that verifies an observable outcome" with the rule as the README states it, in the same words (design D1).
+- [x] 2.2 A step that supplies a value must write the value, since the executor refuses to invent one.
+- [x] 2.4 The planner is told a run starts at `base_url`, not at the route, and must open by navigating there (design D1c — added after verification caught a regression this change introduced).
+- [x] 2.5 The first rule, "one action **or** check per step", contradicted the new one and was reworded to "one move per step" (design D1b). `contained-recovery` D1 cited the old phrasing; the argument survives, and reads more directly under the new one.
+- [x] 2.3 Do not add a validation pass over the generated prose (design D3, and say why in the spec).
+
+## 3. The rule lives in the spec
+
+- [x] 3.1 `test-generation` gains the requirement, with scenarios covering the outcome and the value.
+
+## 4. Tests
+
+- [x] 4.1 The planner prompt states the rule — pinned so the next edit to that string has something to fail against.
+- [x] 4.2 Existing planner tests unchanged: drafts still carry `routes:` set by code, placeholders for secrets, and a valid schema.
+
+## 5. Verification
+
+- [x] 5.1 Same two routes, same app, same model. `/support` went from
+
+  ```yaml
+  - Navigate to the Support page
+  - Enter a subject in the Subject textbox
+  - Enter a message in the Message textbox
+  ```
+
+  to
+
+  ```yaml
+  - Navigate to /support and verify the heading "Contact support" is shown
+  - Fill the Subject textbox with Defective product received
+  - Fill the Message textbox with I ordered item XYZ but it arrived broken and non-functional
+  - Click the Send message button and verify the confirmation message appears
+  ```
+
+  Values written, and the step that commits carries its outcome. Note honestly that the two `Fill` steps still state no outcome of their own — which is right: a fill does not erase its own evidence, and the README's own example does the same. The rule bites where it matters, on the commit.
+
+  **Two routes is a sample, not a proof.** Prompt guidance is the weakest lever available and nothing here guarantees the next generation.
+- [x] 5.2 Ran a generated draft, and it **failed the first time** — on the home page, because the draft had no navigation step. That regression was introduced by this change and is written up as design D1c. After telling the planner where a run starts, the regenerated draft passes: **1 passed, Score 100, 11 calls**, no refusal.
+
+  The lesson is the one worth keeping: reading a draft was not enough to judge a change to the generator.

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -152,11 +152,13 @@ export function plannerSystemPrompt(): string {
 You receive a YAML accessibility snapshot of the page (roles and accessible names, exactly what a user perceives) and the list of source files a pull request changed in the area this page covers.
 
 Rules:
-- Write steps a human tester could follow without looking at the code. One action or check per step.
+- Write steps a human tester could follow without looking at the code. One move per step — a single action together with what it should produce, or a single check. Never two unrelated actions in one step.
 - Refer to controls by the accessible name shown in the snapshot, spelled exactly. Never invent buttons, fields or links that are not in the snapshot.
 - Never write CSS selectors, XPath, IDs or any code — the runner resolves elements live from the accessibility tree.
 - Prefer the journey the changed files touch over a generic tour of the page. The changed files tell you which part of the page matters.
-- End with at least one step that verifies an observable outcome (visible text, a count, a state change).
+- **The test starts at the application's base URL, not at this route.** Begin with a step that navigates to the route and says what should be visible once it loads — "navigate to /support and verify the heading \"Contact support\" is shown". Without it the run opens the home page and every later step looks for controls that are not there.
+- **Every step says what it should produce.** Name what must be true once the step has been carried out, not the action alone: "submit the support form and verify the confirmation page shows the ticket number", never "submit the support form". A step that names an action without an outcome asks the runner to judge whether something happened while looking at the page that succeeding produces — a submitted form comes back empty, a redirect moves the URL — and that is the shape behind several real failures.
+- **A step that enters a value writes the value.** "fill the subject field with Order not received", never "enter a subject". The runner is forbidden from inventing values, so a step that does not supply one cannot be carried out.
 - If a step needs a credential or any secret, write it as a placeholder like {{env.TEST_PASSWORD}}. Never write a real or invented password, token or key.
 - Keep the whole test to a handful of steps: one journey, not an exhaustive suite.`;
 }

--- a/tests/planner.test.ts
+++ b/tests/planner.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../src/planner.js';
 import type { PageLike } from '../src/runner/actions.js';
 import { parseTestFile, type TestFile } from '../src/runner/testfile.js';
+import { plannerSystemPrompt } from '../src/llm/prompts.js';
 
 const DRAFT: GeneratedTest = {
   summary: 'Applying a discount updates the cart total',
@@ -268,5 +269,27 @@ describe('coveredRoutes', () => {
       { routes: [] },
     ] as TestFile[];
     expect([...coveredRoutes(tests)].sort()).toEqual(['/cart', '/checkout', '/login']);
+  });
+});
+
+describe('plannerSystemPrompt teaches the rule the docs teach', () => {
+  // The prompt said "end with at least one step that verifies an observable
+  // outcome" while the README led with the stronger rule, and drifted from it
+  // for a release. Pinned so the next edit has something to fail against.
+  const prompt = plannerSystemPrompt();
+
+  it('asks every step to state its outcome', () => {
+    expect(prompt).toMatch(/Every step says what it should produce/);
+    expect(prompt).not.toMatch(/at least one step that verifies/);
+  });
+
+  it('asks a step that enters a value to write the value', () => {
+    expect(prompt).toMatch(/A step that enters a value writes the value/);
+  });
+
+  it('does not tell the model one action OR check, which contradicts the above', () => {
+    // The README's own worked example is one action AND its check.
+    expect(prompt).not.toMatch(/One action or check per step/);
+    expect(prompt).toMatch(/One move per step/);
   });
 });


### PR DESCRIPTION
Found by an outside review of 0.10.0.

## The tool drafted the shape it documents as wrong

The README leads its writing guidance with the rule, and the measurement behind it: same application, same suite, same version, **Score 64 → 100 on two rewritten steps**.

The planner's prompt still taught the older, weaker version: *"End with at least one step that verifies an observable outcome."*

Generated against this repository's own demo app:

```yaml
steps:
  - Navigate to the Support page
  - Enter a subject in the Subject textbox
  - Enter a message in the Message textbox
```

Three bare actions, two naming no value at all. The executor has **refused to invent values since 0.7.0** — so `plan` was drafting a test `run` is designed not to complete.

## Three changes, and the third is the interesting one

**1.** Every step names what should be true once carried out; a step that supplies a value writes it.

**2.** "One action **or** check per step" contradicted that, since the README's own worked example is one action **and** its check. It becomes "one move per step — a single action together with what it should produce, or a single check. Never two unrelated actions in one step." `contained-recovery` D1 cited the old phrasing as evidence a step needing two identical commits contradicts our format; that argument survives and reads more directly now.

**3. The planner never knew where a run starts** — and this change exposed it.

Old drafts opened with a bare `Navigate to the Support page`. Pushing the model toward outcome-carrying steps made it **drop the navigation entirely**. The first draft under the new prompt began with `Fill the Subject textbox with …` and failed on the home page:

> there is no Subject textbox visible on this page to fill with the requested text

A regression I introduced. The underlying gap is older: the planner was never told that execution begins at `base_url` rather than at the route, and it emitted a navigation only because it was listing actions naively. Removing the naive listing removed the accident that was covering the gap.

## Before and after, same route and model

```yaml
# before
- Navigate to the Support page
- Enter a subject in the Subject textbox
- Enter a message in the Message textbox

# after
- Navigate to /support and verify the heading "Contact support" is shown
- Fill the Subject textbox with Defective product received
- Fill the Message textbox with I ordered item XYZ but it arrived broken and non-functional
- Click the Send message button and verify the confirmation message appears
```

The draft was then **run**: 1 passed, Score 100, 11 calls, no refusal.

Note honestly that the two `Fill` steps still state no outcome of their own, and that is right — a fill does not erase its own evidence, and the README's example does the same. The rule bites where it matters, on the step that commits.

## Deliberately not validated in code

Whether a plain-English step "states an outcome" is not decidable by a parser, and a heuristic — look for *verify*, require two clauses — would reject good drafts and accept bad ones silently at generation time. `plan` prints drafts and needs `--write` to persist them; that review is the check, and automating it badly would weaken it by implying it had been done.

**Two routes is a sample, not a proof.** Prompt guidance is the weakest lever available and nothing here guarantees the next generation. It is the right lever only because validating prose is worse, and because a bad draft costs a review comment rather than a wrong verdict.

## The lesson worth keeping

Reading the drafts would have shipped the missing navigation. Running one is what caught it.

425 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
