### PR TITLE
chore: let the compiler catch dead code

### DIFF
--- a/src/runner/testfile.ts
+++ b/src/runner/testfile.ts
@@ -42,7 +42,7 @@ export class TestFileError extends Error {
   }
 }
 
-function formatIssues(file: string, error: z.ZodError): string {
+function formatIssues(error: z.ZodError): string {
   return error.issues
     .map((issue) => `  - ${issue.path.join('.') || '(root)'}: ${issue.message}`)
     .join('\n');
@@ -68,7 +68,7 @@ export async function parseTestFile(filePath: string): Promise<TestFile> {
 
   const result = testFileSchema.safeParse(data ?? {});
   if (!result.success) {
-    throw new TestFileError(`Invalid test file ${filePath}:\n${formatIssues(filePath, result.error)}`);
+    throw new TestFileError(`Invalid test file ${filePath}:\n${formatIssues(result.error)}`);
   }
 
   return { path: filePath, ...result.data };

--- a/tests/containment.test.ts
+++ b/tests/containment.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ActionError, performAction, type PageLike } from '../src/runner/actions.js';
 import { executeTest } from '../src/runner/executor.js';
 import { SecretsMask, substituteEnv } from '../src/runner/env.js';

--- a/tests/run-budget.test.ts
+++ b/tests/run-budget.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/tests/run-preflight.test.ts
+++ b/tests/run-preflight.test.ts
@@ -37,7 +37,6 @@ let dir: string;
 let logs: string[];
 let errors: string[];
 
-const out = (): string => logs.join('\n');
 const errOut = (): string => errors.join('\n');
 
 function browserDouble(): unknown {

--- a/tests/test-command.test.ts
+++ b/tests/test-command.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DiffError } from '../src/diff.js';
-import { BudgetExhaustedError } from '../src/runner/budget.js';
 
 const {
   launchMock,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,12 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
+    // Dead code is caught by the compiler rather than by review (#7 asks for a
+    // linter, which is a wider question — see the note there for what these two
+    // do and do not cover). Turning them on cost five fixes: four unused
+    // imports in tests and one redundant parameter, none hiding a defect.
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Raised by an outside code review of 0.11.0, beside the missing linter (#7).

`noUnusedLocals` and `noUnusedParameters` were off, so unused imports and variables depended entirely on review.

## What it cost

**Five fixes, none hiding a defect.**

| where | what |
|---|---|
| `src/runner/testfile.ts` | `formatIssues(file, error)` never read `file` — the caller already names it in the message around the call, so nothing was lost |
| `tests/containment.test.ts` | unused `vi` |
| `tests/run-budget.test.ts` | unused `readFile` |
| `tests/run-preflight.test.ts` | `out()` helper — copied harness; preflight writes to stderr and these tests use `errOut()` |
| `tests/test-command.test.ts` | unused `BudgetExhaustedError` — left over from a budget test that checks sharing by reference, not exhaustion |

The last two were checked against the possibility that they signalled *missing coverage* rather than leftovers. Neither did.

**Twenty-eight product files and one dead parameter between them** is the number worth reading here: the absence of a linter had not let rubbish accumulate. This is about stopping accumulation, not clearing a backlog.

## This does not close #7

These two flags catch dead code. A linter is wanted for **floating promises** — an unawaited async call in something that drives a browser is exactly where that bites — and for consistency of patterns. Different things. Noted on the issue so nobody closes it thinking this covered it.

425 tests, build and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)