### PR TITLE
docs: split the operational reference out of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ git diff → impact mapping → test generation → agentic execution → report
 
 100% local. MIT. Bring your own LLM key.
 
+▶ **[Watch the introduction](https://www.youtube.com/shorts/miqN5FzMF_k)** — what it does, in a minute.
+
+**Documentation:** [Configuration](./docs/configuration.md) · [Testing behind a login](./docs/auth.md) · [Running in CI](./docs/ci.md) · [Contributing](./CONTRIBUTING.md) · [Architecture](./AGENTS.md)
+
 ## Quick start
 
 ```bash
@@ -44,21 +48,44 @@ blastproof run
 
 Before `run`, `plan` or `test` do anything, they check what they are about to spend — the browser can launch, the model provider is reachable, `base_url` responds — and report every unmet one together, so a stopped app or a missing browser is never a wall you hit one crash at a time. A missing system library names the exact install command and says it needs root; nothing is installed on your behalf. Silent when everything is fine, and skipped entirely by `--dry-run`, which needs none of it.
 
+Provider options, budgets and browser tuning: [Configuration](./docs/configuration.md).
+
 ## Does this fit your application?
 
-**Your markup must be accessible — a hard requirement.** Elements are found by role, label or visible text from the accessibility tree. That is what removes selectors and survives redesigns; the cost is that an interface the accessibility tree cannot describe cannot be driven at all, and there is deliberately no CSS or XPath fallback. Icon-only buttons without accessible names, `div`-based controls and ARIA-less dropdowns simply cannot be targeted. Run an accessibility checker first — the result predicts how well this will work better than anything else.
+Three questions. The first one decides most cases.
 
-**Windows is untested.** Development and CI run on Linux and macOS. Nothing is known to be broken and reports are welcome (#8).
+### 1. Is your markup accessible?
 
-**Not supported yet:** `iframe` content (so hosted payment widgets like Stripe Elements are invisible — an embedded checkout cannot be driven end to end), hover, scroll-to, drag and drop, file upload, multiple tabs, native `alert`/`confirm` dialogs. Page snapshots are capped at 200 lines by default, so very dense pages are truncated — raise it with `browser.max_snapshot_lines` if your pages need more; truncation is always marked in the snapshot so the model is never misled into thinking it saw the whole page.
+**A hard requirement, not a preference.** blastproof finds elements the way a screen reader does — by role, by label, by visible text. That is what removes selectors and survives redesigns. The cost is that there is deliberately no CSS or XPath fallback, so anything the accessibility tree cannot describe cannot be driven at all.
 
-**Point it at disposable data.** Within a step, an action that commits — a click, or pressing Enter — is never performed twice: the runner refuses the repeat and tells the agent it already did that. This closes the case that used to produce duplicate records, where a submit answered by a redirect came back to a reset form and the agent, seeing no evidence of its own work, submitted again. It is not a guarantee of zero duplicate writes: an agent that reaches the same effect by a genuinely different route — another control with the same effect — is not caught. Use a seeded database, a staging environment you can reset, or a throwaway account; do not gate on a run against production data.
+| works | cannot be driven |
+| --- | --- |
+| `<button>Add to cart</button>` | a `<div>` with a click handler |
+| `<label for="email">` + `<input>` | an input with no label |
+| `<button aria-label="Delete note">` | an icon-only button with no name |
+| `<select>` with `<option>`s | an ARIA-less custom dropdown |
 
-`browser.timeout_ms` bounds every wait — resolving a target element from the accessibility tree, and navigation — not only the click or fill performed afterwards. Raise it for an application that is merely slow to hydrate; the trade-off is that a genuinely missing element then takes longer to fail. It never changes how many self-healing retries a step gets — waiting and retrying are deliberately separate.
+**Run an accessibility checker on your app before installing anything.** The result predicts how well this will work better than anything else you could measure — and the fixes it suggests are worth making regardless of whether you adopt this tool.
 
-Writing each step so it states its own outcome helps here as well as everywhere else: `submit the form, then verify the confirmation shows the reference number` gives the agent something to check, where `click the submit button` leaves it to invent an expectation — and a poor invented expectation is what turns one submission into three.
+### 2. Does your journey need anything on this list?
 
-**This is now load-bearing, not just advisable.** The judge decides whether a step's own outcome holds, using the model's expectation only as the claim offered in support of it — a step that never says what its outcome is gives the judge nothing to anchor on beyond whatever the model happened to check that turn. `verify the confirmation shows the reference number` gives the judge a real question; `verify it worked` does not, and may now fail where a looser judge previously let a true-but-unrelated claim pass it.
+Not supported yet:
+
+- **`iframe` content** — a hosted payment widget is invisible, so an embedded checkout cannot be driven end to end
+- **hover, scroll-to, drag and drop, file upload**
+- **multiple tabs**, and native `alert` / `confirm` dialogs
+
+**Windows is untested.** Development and CI run on Linux and macOS. Nothing is known to be broken and reports are welcome ([#8](https://github.com/hamc/blastproof/issues/8)).
+
+If a critical journey needs one of these, that journey stays with your existing test suite. The two can coexist — nothing here replaces what you already have.
+
+### 3. Can you point it at data you can throw away?
+
+**Use a seeded database, a staging environment you can reset, or a throwaway account. Do not gate on a run against production data.**
+
+Within a step, an action that commits — a click, or pressing Enter — is never performed twice: the runner refuses the repeat and tells the agent it already did that. This closes the case that used to produce duplicate records, where a submit answered by a redirect came back to a reset form and the agent, seeing no evidence of its own work, submitted again.
+
+It is **not** a guarantee of zero duplicate writes. An agent that reaches the same effect by a genuinely different route — another control that does the same thing — is not caught.
 
 ## Writing tests
 
@@ -118,41 +145,13 @@ Common flags — `blastproof <command> --help` has the full list:
 | `--min-score <n>` | Gate on a weighted score instead of all-must-pass |
 | `--fail-on-unmapped` | Fail when a changed file matches no `routes:` or `ignore:` glob |
 | `--junit [path]` · `--html [path]` | Write reports |
+| `--concurrency <n>` | Run tests at once — [when that is safe](./docs/configuration.md#concurrency--running-tests-at-once) |
 | `--write` | `plan` only — persist drafts instead of previewing |
-| `--max-llm-calls` · `--max-tokens` · `--max-duration` | Bound what a run may spend |
+| `--max-llm-calls` · `--max-tokens` · `--max-duration` | [Bound what a run may spend](./docs/configuration.md#budget--bounding-what-a-run-spends) |
 
 Exit codes: **0** pass, **1** the gate failed, **2** usage or config error.
 
 **Generated drafts are never executed and never affect the score.** An unreviewed model-written test in the merge path fails in two directions: a hallucinated expectation blocks a correct PR, and a credulous one waves a broken change through while looking like coverage. `plan` makes the gap visible with a draft to review; it does not make an uncovered route safe.
-
-## In CI
-
-```yaml
-name: blastproof
-on: pull_request
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0          # required — the diff needs a merge-base
-
-      - run: npm start &          # however your app boots
-
-      - uses: hamc/blastproof@v0.11.0
-        with:
-          version: '0.6.0'        # pin both when this gates merges
-          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          base: ${{ github.event.pull_request.base.ref }}
-          min-score: '80'
-          fail-on-unmapped: 'true'
-```
-
-A non-zero exit blocks the merge. The action outputs `score` (0–100, empty when no report was produced) for later steps. Full input list: [`action.yml`](./action.yml).
-
-`fetch-depth: 0` is not optional — the default checkout is shallow and has no merge-base. The action detects this and fails immediately rather than letting it surface as a git error mid-run.
 
 ## Impact mapping
 
@@ -182,6 +181,8 @@ blastproof run --min-score 80    # one failing P2 is tolerated
 
 `--min-score` **replaces** the all-must-pass rule rather than adding to it. Only executed tests count: filtered and unrouted tests are neither numerator nor denominator, and a run that executed nothing scores 100, so a docs-only PR is never blocked. JUnit carries the score as a `<property name="score">`, and unrouted tests appear as `<skipped/>` so the coverage gap shows up in CI rather than vanishing.
 
+Wiring this into a pipeline, with the gating patterns worth knowing: [Running in CI](./docs/ci.md).
+
 ## Without a browser or a key
 
 Half of blastproof is deterministic and free. These need no model, no browser and no network:
@@ -194,103 +195,6 @@ blastproof plan --base main --dry-run                 # affected routes no test 
 ```
 
 They report affected routes, files nobody has classified, and affected routes no test covers — a coverage-gap report with an exit code, useful even on a repo whose suite is Playwright or Cypress.
-
-## Running tests at once
-
-Tests run one at a time by default. Raise it when your tests can stand it:
-
-```yaml
-concurrency: 4
-```
-
-or `blastproof run --concurrency 4` for a single invocation. On this repository's own suite that takes a run from 156s to 68s — **2.3× faster, for the same 81 model calls.** Parallelism buys wall-clock, not spend.
-
-**The default is 1 on purpose, and raising it is your call to make.** Other test runners default to parallel because their tests are isolated by construction — separate processes, separate fixtures. These are journeys driven against **one running application**, so two tests can see each other's data. A suite is safe to parallelise when its tests do not write state that another test reads.
-
-The test in this repository's own suite that could not run beside itself is a good shape to recognise: it adds a note and then asserts *"one note on file"*. It writes shared server state, and it asserts on a global count. Either alone is a warning; together they mean the test's verdict depends on nothing else touching the application at that moment.
-
-Two practical notes. Four concurrent journeys are four times the traffic against whatever you pointed at — usually fine for a development instance, worth knowing for a shared one. And with several model calls in flight, a `budget:` limit can overshoot by up to the concurrency rather than by a single call, since the calls already sent are allowed to finish.
-
-## Bounding a run
-
-Nothing stops a run by default. `budget:` puts a ceiling on `run`, `plan` and `test` alike — every model call any of them makes is counted:
-
-```yaml
-budget:
-  max_llm_calls: 500
-  max_tokens: 2000000
-  max_duration_s: 900
-```
-
-Each limit is optional; with none set, nothing binds. They count **calls and tokens, not currency** — a price table keyed by model and provider goes stale the day a provider reprices, and a limit that quietly stops meaning what it says is worse than none, because it is trusted.
-
-Exhausting a budget **stops the run; it does not fail a test.** Running out of quota says nothing about the code under review. Unreached tests are reported as `not run`, a third state excluded from the score entirely, and the process exits 1 unconditionally — `--min-score` cannot rescue it, because the tests that finished are whichever ran first, not a representative sample.
-
-**Every run reports what it spent**, so you can size a limit from experience rather than guesswork:
-
-```
-Spent: 82 model call(s), 115407 token(s)
-Score: 100
-```
-
-The figures also land in the JUnit report as `llm_calls` and `llm_tokens`, beside `score`, so a pipeline can trend cost without scraping output. A run stopped by its own budget reports the spend too — that is the case where the number is least guessable. Where a provider reports no token usage, the line says so rather than showing zero.
-
-`--dry-run` reports the ceiling before you spend anything. Read it as a maximum and nothing more: for this repository's own suite it says 735 calls where a real run spends 82. Size a budget from what your runs actually report, not from the ceiling.
-
-For an order of magnitude, this repository's own suite — 7 tests, 31 steps, an authenticated demo shop, `anthropic/claude-haiku-4.5` — spends **about 82 model calls and 115k tokens**, taking 156s serially or 68s at `--concurrency 4`. That is a number you can reproduce (`node examples/demo-app/serve.mjs 4173` and `blastproof run`), not a forecast for your suite: cost scales with steps, page density and how often the agent has to retry. Run yours once and read the `Spent:` line.
-
-## Testing behind a login
-
-Declare a recipe once; blastproof signs in one time per run and reuses that session for every test and for `plan`. Pick exactly one strategy:
-
-```yaml
-# 1) A plain-English journey — form login, or anything a person can click through
-auth:
-  steps:
-    - navigate to /login
-    - fill the email field with {{env.TEST_EMAIL}}
-    - fill the password field with {{env.TEST_PASSWORD}}
-    - submit the login form
-  verify: a signed-in indicator is visible    # optional, strongly recommended
-
-# 2) A session captured by hand — for SSO, MFA or magic links
-auth:
-  storage_state: .blastproof/auth.json
-
-# 3) Static values — for token-based apps
-auth:
-  headers:
-    Authorization: "Bearer {{env.API_TOKEN}}"
-```
-
-**`verify` is worth the extra call.** Without it a wrong password surfaces as every test failing on a login wall — N failures, none naming the cause. Authentication failure exits 2 and never reports as failing tests, because a login you cannot complete says nothing about the code under review.
-
-**A captured session is a credential** — the file holds live cookies. `init` git-ignores it; never commit one.
-
-## LLM providers (BYOK)
-
-**Anthropic** (`ANTHROPIC_API_KEY`), **OpenAI** (`OPENAI_API_KEY`), or **Ollama** (local, no key). Any setting can be overridden from the environment, with precedence **CLI flag > environment > file**:
-
-| variable | overrides |
-| --- | --- |
-| `BLASTPROOF_BASE_URL` | `base_url` — the app under test |
-| `BLASTPROOF_LLM_PROVIDER` | `anthropic` \| `openai` \| `ollama` |
-| `BLASTPROOF_LLM_MODEL` | the model name |
-| `BLASTPROOF_LLM_BASE_URL` | the provider endpoint — *not* the app |
-| `BLASTPROOF_LLM_API_KEY_ENV` | the **name** of the variable holding your key |
-| `BLASTPROOF_MAX_LLM_CALLS` · `BLASTPROOF_MAX_TOKENS` · `BLASTPROOF_MAX_DURATION_S` | the budget fields |
-
-So an OpenAI-compatible gateway needs no file edit:
-
-```bash
-export BLASTPROOF_LLM_PROVIDER=openai
-export BLASTPROOF_LLM_MODEL=anthropic/claude-haiku-4.5
-export BLASTPROOF_LLM_BASE_URL=https://openrouter.ai/api/v1
-export BLASTPROOF_LLM_API_KEY_ENV=OPENROUTER_API_KEY
-blastproof run --impacted --min-score 80
-```
-
-The key itself is never read from a `BLASTPROOF_*` variable — you name *which* variable holds it, so errors can keep naming the one you chose.
 
 ## Trust boundaries
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,130 @@
+# Testing behind a login
+
+Most journeys worth testing are behind a sign-in. Declare a recipe once in
+`.blastproof/config.yaml`; blastproof signs in **one time per run** and reuses
+that session for every test and for `plan`.
+
+Pick exactly one of the three strategies below. They are alternatives, not
+layers — declaring two is a configuration error rather than a fallback chain,
+because a silent fallback would hide which one actually authenticated you.
+
+## 1. A plain-English journey
+
+For a form login, or anything a person can click through.
+
+```yaml
+auth:
+  steps:
+    - navigate to /login
+    - fill the email field with {{env.TEST_EMAIL}}
+    - fill the password field with {{env.TEST_PASSWORD}}
+    - submit the login form
+  verify: a signed-in indicator is visible
+```
+
+The steps are ordinary blastproof steps, driven by the same agent against the
+same accessibility tree — so the same authoring rule applies: **say what each
+step should produce**. A login form that redirects on success is exactly the
+shape that erases its own evidence.
+
+### `verify` is worth the extra model call
+
+It is optional and strongly recommended.
+
+Without it, a wrong password surfaces as *every test failing on a login wall* —
+N failures, none of which names the cause. You spend a full run and a full
+budget to learn that a secret was mistyped.
+
+With it, authentication failure **exits 2 and reports no failing tests at all**,
+because a login you could not complete says nothing about the code under review.
+That distinction is the same one behind `not run`: never report a verdict about
+an application you did not actually exercise.
+
+## 2. A session captured by hand
+
+For SSO, MFA, magic links — anything that cannot be scripted as a journey.
+
+```yaml
+auth:
+  storage_state: .blastproof/auth.json
+```
+
+The file is a Playwright storage state: cookies plus local storage, captured
+from a browser where you signed in yourself.
+
+To produce one:
+
+```bash
+npx playwright open --save-storage=.blastproof/auth.json http://localhost:4173
+```
+
+Sign in in the window that opens, complete whatever second factor applies, then
+close it. The file is written on close.
+
+**A captured session is a credential.** The file holds live cookies, and anyone
+holding it is signed in as you. `blastproof init` adds it to `.gitignore`;
+never commit one, and treat it in CI exactly as you would a password — a secret
+written to disk at job start, not a file in the repository.
+
+Sessions expire. When a suite that worked yesterday fails everywhere on a login
+wall today, recapture before debugging anything else.
+
+## 3. Static values
+
+For token-based applications with no interactive login at all.
+
+```yaml
+auth:
+  headers:
+    Authorization: "Bearer {{env.API_TOKEN}}"
+```
+
+Headers are sent with every request the browser makes for the duration of the
+run.
+
+## Secrets
+
+Everywhere above, `{{env.VAR}}` is the only way to reference a credential.
+
+**The placeholder is what the model sees.** It survives intact through every
+prompt and is substituted at the moment of typing — the real value exists
+between the substitution and the keystroke, and never enters a page snapshot, a
+step record, a log line or a report.
+
+Every value your tests or auth recipe reference is redacted from everything else
+crossing into a prompt, in both literal and percent-encoded form. Redaction
+matches known values, so treat it as a strong default rather than a guarantee
+against a deliberately hostile application.
+
+In output, a redacted value appears as `***`. The judge is told explicitly that
+a field holding `***` is filled rather than empty, so a redacted password does
+not cause a step to fail for being unverifiable.
+
+## Running a test signed out
+
+A login test must not run inside an already-authenticated session — it would
+pass without proving anything.
+
+```yaml
+summary: Signing in with valid credentials reaches the dashboard
+priority: P0
+auth: false
+routes: ["/login"]
+steps:
+  - navigate to /login
+  - fill the email field with {{env.TEST_EMAIL}}
+  - fill the password field with {{env.TEST_PASSWORD}}
+  - submit the login form and verify the dashboard heading is shown
+```
+
+`auth: false` on a test opts it out of the run's session entirely.
+
+## What is not supported
+
+Authentication that requires reading a code from an email inbox, an SMS, or an
+authenticator app cannot be automated here — use strategy 2 and capture the
+session by hand.
+
+An identity provider on a different host needs that host declared in
+`allowed_origins:`, or the agent will refuse to follow the redirect. See
+[Trust boundaries](../README.md#trust-boundaries).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,187 @@
+# Running in CI
+
+blastproof is built for the pull request: read the diff, run what the diff can
+break, score it, and exit non-zero when the score is not good enough.
+
+- [GitHub Actions](#github-actions)
+- [`fetch-depth: 0` is not optional](#fetch-depth-0-is-not-optional)
+- [Pinning](#pinning)
+- [Other CI systems](#other-ci-systems)
+- [Reports](#reports)
+- [Gating patterns](#gating-patterns)
+- [The half that needs no key](#the-half-that-needs-no-key)
+
+## GitHub Actions
+
+```yaml
+name: blastproof
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # required — the diff needs a merge-base
+
+      - run: npm start &          # however your app boots
+
+      - uses: hamc/blastproof@v0.11.0
+        with:
+          version: '0.11.0'       # pin both when this gates merges
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          base: ${{ github.event.pull_request.base.ref }}
+          min-score: '80'
+          fail-on-unmapped: 'true'
+```
+
+A non-zero exit blocks the merge. The full input list is in
+[`action.yml`](../action.yml).
+
+### Outputs
+
+| output | |
+| --- | --- |
+| `score` | 0–100, empty when no report was produced |
+
+Empty rather than zero is deliberate: a run that produced no report has no
+score, and a downstream step comparing against `0` would read "everything
+failed" from "nothing ran".
+
+```yaml
+      - id: bp
+        uses: hamc/blastproof@v0.11.0
+        with:
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - if: steps.bp.outputs.score != ''
+        run: echo "scored ${{ steps.bp.outputs.score }}"
+```
+
+## `fetch-depth: 0` is not optional
+
+`actions/checkout` is shallow by default, and a shallow clone has no merge-base
+— so there is no diff to map to routes.
+
+The action detects this and **fails immediately with a message naming the
+fix**, rather than letting it surface as an opaque git error somewhere in the
+middle of a run. This is covered by the repository's own `Action self-test`
+workflow, which asserts that a shallow checkout is rejected.
+
+## Pinning
+
+Two versions are in play, and they are independent:
+
+- the **action** ref (`hamc/blastproof@v0.11.0`) — the wrapper
+- the **`version`** input — which blastproof release the wrapper installs from
+  npm, defaulting to `latest`
+
+Pin both when the result gates merges. `latest` means a release published on a
+Tuesday can change how your Wednesday pull requests are judged, which is exactly
+the kind of surprise a merge gate should not produce.
+
+Published releases carry npm provenance, so a pinned version is attestable back
+to the commit and workflow that built it.
+
+## Other CI systems
+
+There is no wrapper for GitLab, CircleCI or Jenkins, and none is needed — it is
+an npm package with an exit code.
+
+```bash
+npm install -g blastproof@0.11.0
+npx playwright install --with-deps chromium
+
+npm start &
+# wait for the app however your setup does it
+
+blastproof run \
+  --impacted --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" \
+  --min-score 80 \
+  --fail-on-unmapped \
+  --junit results.xml
+```
+
+Make sure the clone is deep enough to have a merge-base. On GitLab that means
+setting `GIT_DEPTH: 0`; most systems have an equivalent.
+
+Exit codes: **0** pass, **1** the gate failed, **2** usage or configuration
+error. A `2` is worth surfacing differently from a `1` in your pipeline —
+one means the application under review has a problem, the other means the
+pipeline does.
+
+## Reports
+
+```bash
+blastproof run --junit results.xml --html report.html
+```
+
+**JUnit** is what CI systems parse into a test summary. Beyond the usual cases
+it carries:
+
+| | |
+| --- | --- |
+| `<property name="score">` | the weighted score |
+| `<property name="llm_calls">` · `llm_tokens` | what the run spent |
+| `<skipped/>` on unrouted tests | tests `--impacted` could not select |
+
+Unrouted tests appear as skipped rather than being omitted entirely, so the
+coverage gap shows up in the CI summary instead of vanishing silently.
+
+**HTML** is the one to attach as an artifact when a run fails. It carries the
+per-step trace and links the failure screenshot.
+
+```yaml
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blastproof-report
+          path: |
+            report.html
+            .blastproof/reports/
+```
+
+`if: always()` matters — the run you most want the report from is the one that
+just failed the job.
+
+## Gating patterns
+
+**Strict.** Any failure blocks. The default, and the right starting point.
+
+```bash
+blastproof run --impacted --base main
+```
+
+**Weighted.** Tolerate a low-priority failure, never a critical one. With P0
+weighing 3 and P2 weighing 1, `--min-score 80` on a suite of mixed priorities
+lets one P2 through and stops any P0.
+
+```bash
+blastproof run --impacted --base main --min-score 80
+```
+
+**Coverage as well as correctness.** `--fail-on-unmapped` is additive rather
+than part of the score: a run can meet `--min-score` and still be blocked here,
+because *"the tests I ran passed"* and *"something changed that nobody
+classified"* are different claims about a pull request.
+
+```bash
+blastproof run --impacted --base main --min-score 80 --fail-on-unmapped
+```
+
+## The half that needs no key
+
+Worth its own job, because it costs nothing and answers a question no other
+check does:
+
+```yaml
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - run: npx blastproof run --impacted --base main --fail-on-unmapped --dry-run
+```
+
+No browser, no API key, no network. It reports which routes the diff affects,
+which changed files nobody has classified, and which affected routes no test
+covers — a coverage-gap gate that is useful even on a repository whose suite is
+Playwright or Cypress and which never runs an agentic test at all.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,304 @@
+# Configuration
+
+Everything blastproof reads from `.blastproof/config.yaml`, and every environment
+variable that overrides it.
+
+`blastproof init` scaffolds this file with comments. Nothing here is required
+except `base_url` — each section below says what happens when you leave it out.
+
+- [Precedence](#precedence)
+- [`base_url`](#base_url)
+- [`llm` — provider, model, key](#llm--provider-model-key)
+- [`browser` — waiting and snapshots](#browser--waiting-and-snapshots)
+- [`concurrency` — running tests at once](#concurrency--running-tests-at-once)
+- [`budget` — bounding what a run spends](#budget--bounding-what-a-run-spends)
+- [`max_retries_per_step`](#max_retries_per_step)
+- [`routes` and `ignore`](#routes-and-ignore)
+- [`allowed_origins`](#allowed_origins)
+- [`auth`](#auth)
+
+## Precedence
+
+**CLI flag > environment variable > config file.**
+
+The rule is the same everywhere, so a CI job can override one setting without a
+file edit, and a single invocation can override the CI job.
+
+| variable | overrides |
+| --- | --- |
+| `BLASTPROOF_BASE_URL` | `base_url` — the app under test |
+| `BLASTPROOF_LLM_PROVIDER` | `anthropic` \| `openai` \| `ollama` |
+| `BLASTPROOF_LLM_MODEL` | the model name |
+| `BLASTPROOF_LLM_BASE_URL` | the provider endpoint — *not* the app |
+| `BLASTPROOF_LLM_API_KEY_ENV` | the **name** of the variable holding your key |
+| `BLASTPROOF_MAX_LLM_CALLS` | `budget.max_llm_calls` |
+| `BLASTPROOF_MAX_TOKENS` | `budget.max_tokens` |
+| `BLASTPROOF_MAX_DURATION_S` | `budget.max_duration_s` |
+
+## `base_url`
+
+The root of the application under test. Every relative `navigate` path resolves
+against it, every test starts there, and its origin is the security boundary the
+agent may not leave.
+
+```yaml
+base_url: http://localhost:4173
+```
+
+`--url` overrides it for one invocation, which is how you point a run at a pull
+request preview deployment without touching the file.
+
+## `llm` — provider, model, key
+
+Three providers are supported directly. You bring the key; nothing is proxied
+through anyone.
+
+```yaml
+llm:
+  provider: anthropic          # anthropic | openai | ollama
+  model: claude-haiku-4-5      # optional — each provider has a default
+  api_key_env: ANTHROPIC_API_KEY
+```
+
+| provider | key variable | default model | notes |
+| --- | --- | --- | --- |
+| `anthropic` | `ANTHROPIC_API_KEY` | `claude-haiku-4-5` | |
+| `openai` | `OPENAI_API_KEY` | `gpt-4o-mini` | |
+| `ollama` | none | `qwen2.5` | local, set `base_url` to your endpoint |
+
+**`api_key_env` names the variable, it does not hold the key.** This is
+deliberate: the key never appears in a file that could be committed, and error
+messages can keep naming the variable *you* chose rather than a generic one.
+
+### OpenAI-compatible gateways
+
+`provider: openai` plus a `base_url` reaches anything speaking the OpenAI API —
+OpenRouter, Together, a self-hosted gateway, vLLM. No file edit needed:
+
+```bash
+export BLASTPROOF_LLM_PROVIDER=openai
+export BLASTPROOF_LLM_MODEL=anthropic/claude-haiku-4.5
+export BLASTPROOF_LLM_BASE_URL=https://openrouter.ai/api/v1
+export BLASTPROOF_LLM_API_KEY_ENV=OPENROUTER_API_KEY
+blastproof run --impacted --min-score 80
+```
+
+### Ollama, for a run that leaves the machine
+
+```yaml
+llm:
+  provider: ollama
+  model: qwen2.5
+  base_url: http://localhost:11434/v1
+```
+
+No key, no network beyond your own host. Smaller local models are more likely to
+return malformed actions, which a step spends from its retry budget — expect more
+retries than a hosted model, and prefer tests whose steps state their outcomes
+plainly.
+
+## `browser` — waiting and snapshots
+
+```yaml
+browser:
+  headless: true
+  timeout_ms: 30000
+  max_snapshot_lines: 200
+```
+
+### `timeout_ms`
+
+Bounds **every** wait: resolving a target element from the accessibility tree,
+and navigation — not only the click or fill performed afterwards. That is one
+knob rather than two on purpose; the earlier behaviour, where it bounded only
+the action, meant a slow-hydrating page failed while the configured limit was
+never reached.
+
+Raise it for an application that is merely slow to start rendering. The
+trade-off is direct: a genuinely missing element then takes correspondingly
+longer to fail.
+
+It never changes how many self-healing retries a step gets. **Waiting and
+retrying are deliberately separate** — one is about a slow application, the other
+about a wrong guess, and a single knob for both would make each unfixable
+without breaking the other.
+
+Note that this is not the same as the internal 2-second settle wait taken before
+every page snapshot. That one is fixed and short by design: `networkidle` is the
+load state most likely never to arrive at all on a page holding a websocket or a
+poll, and tying it to a 30-second limit would let one such page cost 30 seconds
+on *every* step.
+
+### `max_snapshot_lines`
+
+Caps how much of the accessibility tree is sent to the model per snapshot.
+Dense pages are truncated at 200 lines by default.
+
+**Truncation is always marked in the snapshot**, so the model is never misled
+into believing it saw the whole page. Raise this if your pages are genuinely
+large; the cost is tokens on every call of every step, which is the single
+largest lever on what a run spends.
+
+### `headless`
+
+`false` opens a visible browser, which is the fastest way to understand why a
+step is failing. Not useful in CI.
+
+## `concurrency` — running tests at once
+
+Tests run one at a time by default.
+
+```yaml
+concurrency: 4
+```
+
+or `blastproof run --concurrency 4` for a single invocation.
+
+On this repository's own suite that takes a run from 156s to 68s — **2.3×
+faster, for the same 82 model calls.** Parallelism buys wall-clock time, not
+spend.
+
+### Why the default is 1, and why raising it is your decision
+
+Other test runners default to parallel because their tests are isolated by
+construction: separate processes, separate fixtures, separate databases. These
+are journeys driven against **one running application**, so two tests can see
+each other's data.
+
+A suite is safe to parallelise when its tests do not write state that another
+test reads.
+
+### The shape that cannot run beside itself
+
+The test in this repository's own suite that fails under concurrency is worth
+recognising, because the pattern is common. It adds a note, then asserts *"one
+note on file"*.
+
+It **writes shared server state**, and it **asserts on a global count**. Either
+alone is a warning. Together they mean the test's verdict depends on nothing
+else touching the application at that moment — which is exactly what concurrency
+removes.
+
+Rewriting such a test to assert on its own note rather than the total makes it
+safe to parallelise, and is a better test regardless.
+
+### Two practical consequences
+
+Four concurrent journeys are **four times the traffic** against whatever you
+pointed at. Usually fine for a development instance; worth knowing before you
+aim it at something shared.
+
+With several model calls in flight, a `budget:` limit can **overshoot by up to
+the concurrency** rather than by a single call, because calls already sent are
+allowed to finish rather than being torn down mid-flight.
+
+## `budget` — bounding what a run spends
+
+Nothing stops a run by default. `budget:` puts a ceiling on `run`, `plan` and
+`test` alike — every model call any of them makes is counted, with no exceptions.
+
+```yaml
+budget:
+  max_llm_calls: 500
+  max_tokens: 2000000
+  max_duration_s: 900
+```
+
+Each limit is optional; with none set, nothing binds.
+
+### Calls and tokens, not currency
+
+A price table keyed by model and provider goes stale the day a provider
+reprices, and is wrong from the start for anyone behind a gateway. A limit that
+quietly stops meaning what it says is worse than no limit at all, **because it
+is trusted**.
+
+### Exhaustion stops the run; it does not fail a test
+
+Running out of quota says nothing about the code under review.
+
+Unreached tests are reported as `not run` — a third state, excluded from the
+score entirely rather than counted as failures. The process exits 1
+unconditionally, and `--min-score` cannot rescue it: the tests that finished are
+whichever happened to run first, not a representative sample of the suite.
+
+### Sizing a limit from evidence
+
+Every run reports what it spent:
+
+```
+Spent: 82 model call(s), 115407 token(s)
+Score: 100
+```
+
+The same figures land in the JUnit report as `llm_calls` and `llm_tokens`,
+beside `score`, so a pipeline can trend cost without scraping console output. A
+run stopped by its own budget reports its spend too — the case where the number
+is least guessable. Where a provider reports no token usage at all, the line
+says so rather than showing a misleading zero.
+
+`--dry-run` reports the **ceiling** before you spend anything. Read it as a
+maximum and nothing more: for this repository's own suite it says 735 calls
+where a real run spends 82. Size a budget from what your runs actually report.
+
+### An order of magnitude
+
+This repository's own suite — 7 tests, 31 steps, an authenticated demo shop,
+`anthropic/claude-haiku-4.5` — spends about **82 model calls and 115k tokens**,
+taking 156s serially or 68s at `--concurrency 4`.
+
+That is reproducible rather than forecast:
+
+```bash
+node examples/demo-app/serve.mjs 4173 &
+blastproof run
+```
+
+Your figures will differ. Cost scales with the number of steps, how dense your
+pages are, and how often the agent has to retry. Run yours once and read the
+`Spent:` line.
+
+## `max_retries_per_step`
+
+How many failed attempts a single step tolerates before failing. Default 3.
+
+A failed attempt is a malformed model response, a browser error, an element that
+could not be resolved, a refused repeat action, or an assertion the judge
+rejected against a settled page. Raising this makes a flaky step more likely to
+recover and a genuinely broken one slower to report.
+
+Separate from the hard ceiling of 15 model actions per step, which exists to stop
+a step that is making progress in a loop rather than failing.
+
+## `routes` and `ignore`
+
+The impact map — which changed files can affect which pages.
+
+```yaml
+routes:
+  "src/cart/**": ["/cart", "/checkout"]
+ignore:
+  - "**/*.md"
+```
+
+Explained in full in the README under
+[Impact mapping](../README.md#impact-mapping), since it is the part most worth
+reading before deciding whether the tool fits.
+
+## `allowed_origins`
+
+Extra origins the agent may reach beyond `base_url`'s own — an identity
+provider, a hosted payment step.
+
+```yaml
+allowed_origins:
+  - https://login.example.com
+```
+
+The boundary and why it is enforced by comparison rather than instruction is
+covered in the README under
+[Trust boundaries](../README.md#trust-boundaries).
+
+## `auth`
+
+Signing in once per run. See [Testing behind a login](./auth.md).

--- a/tests/docs-links.test.ts
+++ b/tests/docs-links.test.ts
@@ -1,0 +1,123 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Splitting the README into `docs/` bought scanability and paid for it in
+ * surfaces that can disagree — the exact class behind #30 and behind three
+ * documentation defects outside readers found in a single week. A moved
+ * heading or a renamed file breaks a link silently: nothing fails, and the
+ * reader simply lands nowhere. This is the cheap guard, in the shape of
+ * `action-manifest.test.ts`: assert the links resolve, in CI, before a merge.
+ */
+
+/** Markdown files that are part of the published documentation surface. */
+const DOC_ROOTS = ['README.md', 'CONTRIBUTING.md', 'AGENTS.md'];
+
+/**
+ * GitHub's heading-anchor algorithm, reduced to what our headings actually use:
+ * strip inline code fences and any other HTML, lowercase, drop every character
+ * that is not alphanumeric, space, hyphen or underscore, then hyphenate spaces.
+ * An em dash therefore vanishes and leaves the doubled hyphen GitHub produces
+ * (`## \`budget\` — bounding` → `budget--bounding`).
+ */
+function slug(heading: string): string {
+  return heading
+    .replace(/`/g, '')
+    .replace(/<[^>]*>/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s/g, '-');
+}
+
+function headingsOf(markdown: string): Set<string> {
+  const anchors = new Set<string>();
+  for (const line of markdown.split('\n')) {
+    const match = /^#{1,6}\s+(.*)$/.exec(line);
+    if (match?.[1]) anchors.add(slug(match[1]));
+  }
+  return anchors;
+}
+
+/** Relative markdown links, ignoring absolute URLs, images and bare anchors. */
+function linksOf(markdown: string): { target: string; anchor?: string }[] {
+  const links: { target: string; anchor?: string }[] = [];
+  for (const match of markdown.matchAll(/(?<!!)\[[^\]]*\]\(([^)\s]+)\)/g)) {
+    const href = match[1]!;
+    if (/^[a-z]+:/i.test(href)) continue;
+    const [target, anchor] = href.split('#');
+    links.push({ target: target ?? '', anchor });
+  }
+  return links;
+}
+
+async function docFiles(): Promise<string[]> {
+  const inDocs = (await readdir(path.join(root, 'docs')))
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => path.join('docs', name));
+  return [...DOC_ROOTS, ...inDocs];
+}
+
+describe('documentation links', () => {
+  it('every docs/ page is reachable from the README', async () => {
+    // A page nobody links to is a page nobody reads, and the reason to keep it
+    // in the repository at all is that the README sends people there.
+    const readme = await readFile(path.join(root, 'README.md'), 'utf8');
+    const pages = (await readdir(path.join(root, 'docs'))).filter((n) => n.endsWith('.md'));
+
+    expect(pages.length).toBeGreaterThan(0);
+    for (const page of pages) {
+      expect(readme, `docs/${page} is not linked from the README`).toContain(`./docs/${page}`);
+    }
+  });
+
+  it('every relative link resolves to a file that exists', async () => {
+    const broken: string[] = [];
+
+    for (const file of await docFiles()) {
+      const markdown = await readFile(path.join(root, file), 'utf8');
+      for (const { target } of linksOf(markdown)) {
+        if (target === '') continue; // same-page anchor, checked below
+        const resolved = path.resolve(path.dirname(path.join(root, file)), target);
+        if (!existsSync(resolved)) broken.push(`${file} → ${target}`);
+      }
+    }
+
+    expect(broken).toEqual([]);
+  });
+
+  it('every link anchor resolves to a heading in the file it points at', async () => {
+    // The half of link rot that a file-existence check misses entirely: the
+    // file is still there, the heading it named is not.
+    const headings = new Map<string, Set<string>>();
+    const broken: string[] = [];
+
+    for (const file of await docFiles()) {
+      const markdown = await readFile(path.join(root, file), 'utf8');
+      headings.set(file, headingsOf(markdown));
+    }
+
+    for (const file of await docFiles()) {
+      const markdown = await readFile(path.join(root, file), 'utf8');
+      for (const { target, anchor } of linksOf(markdown)) {
+        if (!anchor) continue;
+
+        const targetFile =
+          target === ''
+            ? file
+            : path.relative(root, path.resolve(path.dirname(path.join(root, file)), target));
+
+        const known = headings.get(targetFile);
+        if (!known) continue; // not a markdown file we track (e.g. action.yml)
+        if (!known.has(anchor)) broken.push(`${file} → ${targetFile}#${anchor}`);
+      }
+    }
+
+    expect(broken).toEqual([]);
+  });
+});


### PR DESCRIPTION
Reorganises the README so its sections are ordered by who reads them, and moves the operational reference into `docs/`.

The README served three readers in one flat list of sixteen sections — someone deciding whether to try it, someone installing it, someone already operating it — with nothing saying which sections were for whom.

**Length was not the problem.** At 3,352 words it is less than half of ripgrep's, which is a README worth imitating rather than shrinking toward. Ordering was.

### What moved

| section | to | gained |
| --- | --- | --- |
| LLM providers · Bounding a run · Running tests at once · `browser.timeout_ms` | `docs/configuration.md` | full config reference, Ollama notes, `max_snapshot_lines`, `max_retries_per_step` |
| Testing behind a login | `docs/auth.md` | how to capture a session, `auth: false`, what is not automatable |
| In CI | `docs/ci.md` | non-GitHub CI, outputs, report wiring, gating patterns |

### What stayed, deliberately

What it is, whether it fits, how to write a test, impact mapping, the score, what runs without a key, trust boundaries, the dogfood example. These are the sections outside evaluations singled out as the project's strongest material — moving them would have traded the best first impression for tidiness.

### "Does this fit your application?"

Six dense paragraphs — which mixed the accessibility requirement with timeout tuning and restated the step-authoring rule the next section already owns — become three numbered questions with a works / cannot-be-driven table.

### Three files, not five

Fewer surfaces that can contradict each other. This repository has had three documentation-drift defects found by outside readers in a single week, and #30 is open on exactly this class.

`tests/docs-links.test.ts` is the guard: every `docs/` page reachable from the README, every relative link resolving, every anchor pointing at a heading that exists. **Verified by mutation** — an orphan page, a missing file and a stale anchor each fail it.

### Also

- Adds the introduction video near the top.
- Fixes the CI example, which pinned the action at `v0.11.0` while installing package `0.6.0` — #30's exact shape, in the snippet telling people to pin both.

---

`npm run build`, `tsc -p tsconfig.typecheck.json`, and 428 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
