### PR TITLE
feat: warn when a test step enters a value but names none

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ Write steps that end in an observable result — text on the page, a count, a st
 
 **Inline error messages should be plain visible text.** `role="alert"` is read correctly from the accessibility tree and needs no special handling, but note that an alert your page has cleared shows up as an empty element: if a verdict says an alert exists whose content is missing, the message was emptied, not hidden.
 
+### A step that enters a value writes the value
+
+```yaml
+- fill the note field with Order not received   # runs
+- fill the note field                           # cannot run
+```
+
+The agent is **forbidden from inventing values** — one it types must come from the step, from the page, or from an `{{env.*}}` placeholder. So the second step is not merely vague, it is impossible, and the run discovers that a minute in, with a failure reason about page state that reads as though your application is broken.
+
+`run` warns about it first, on every path, before launching a browser or asking for a key:
+
+```
+Authoring (a step enters a value but names none):
+  Add a note (.blastproof/tests/notes.yaml) step 2:
+      fill the note field
+    → fill the note field with <value>
+```
+
+Non-fatal by default — `--fail-on-authoring` turns it into exit 1 for teams enforcing it in CI. Taking the value from the page is fine and is not flagged: `fill the recipient field with the address shown on the confirmation page`.
+
+**The check reads English only.** A suite written in another language runs exactly as well but is not inspected, and prints no warning saying so — silence from this check means "nothing found in English", never "this suite is clean".
+
 ## Commands
 
 ```bash
@@ -153,6 +175,7 @@ Common flags — `blastproof <command> --help` has the full list:
 | `--url <url>` | Override `base_url` for this run (e.g. a PR preview) |
 | `--min-score <n>` | Gate on a weighted score instead of all-must-pass |
 | `--fail-on-unmapped` | Fail when a changed file matches no `routes:` or `ignore:` glob |
+| `--fail-on-authoring` | Fail when a step enters a value but names none (warns by default) |
 | `--junit [path]` · `--html [path]` | Write reports |
 | `--concurrency <n>` | Run tests at once — [when that is safe](./docs/configuration.md#concurrency--running-tests-at-once) |
 | `--write` | `plan` only — persist drafts instead of previewing |

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: 'Fail when a changed file matches no routes: or ignore: glob.'
     required: false
     default: 'false'
+  fail-on-authoring:
+    description: 'Fail when a test step enters a value but names none. Warns without this.'
+    required: false
+    default: 'false'
   write:
     description: 'Persist generated test drafts instead of only previewing them. Ignored when command is run, which generates nothing.'
     required: false
@@ -128,6 +132,10 @@ runs:
         esac
         [ -n "${{ inputs.min-score }}" ] && args+=(--min-score "${{ inputs.min-score }}")
         [ "${{ inputs.fail-on-unmapped }}" = "true" ] && args+=(--fail-on-unmapped)
+        # `plan` reads no test files, so it has no authoring to check.
+        case "${{ inputs.command }}" in
+          run|test) [ "${{ inputs.fail-on-authoring }}" = "true" ] && args+=(--fail-on-authoring) ;;
+        esac
         # `write` only exists on test/plan; passing it to `run` is a usage error.
         case "${{ inputs.command }}" in
           test|plan) [ "${{ inputs.write }}" = "true" ] && args+=(--write) ;;

--- a/openspec/changes/steps-name-their-value/design.md
+++ b/openspec/changes/steps-name-their-value/design.md
@@ -58,6 +58,8 @@ One exception: `in` counts as a connector only when it is not adjacent to the ve
 
 The verb set stays closed and small — `fill`, `enter`, `type`, `input`, `set` — for the reason the issue gives: *"something narrow is probably enough, and probably better than something clever."* Matching is word-boundary and case-insensitive, never substring: `setup the account` must not match `set`.
 
+**The verb is anchored at the head of the step, not merely contained in it.** Found while implementing: `type` and `set` are nouns as often as verbs, so `verify the type is Premium` and `verify the set of results is empty` matched a contained verb, carried no connector, and were flagged — legitimate checks, reported as authoring defects. Test steps are imperative, so the leading word is the action; anchoring costs a step phrased as `then fill the note field`, which is a false negative and therefore the safe direction.
+
 The two lists fail in opposite directions, and only one of them is dangerous. **An unlisted verb** produces a false negative — the check stays silent and the run fails honestly, exactly as it does today. **An unlisted connector** produces a false positive — a legitimate step is flagged. So the verb set is the one that must be extended carefully, and the connector set is the one that can be extended freely: adding a connector can only ever quiet the check.
 
 **Alternative rejected:** parse the step with an LLM. Breaks the keyless guarantee that makes this check free, and reintroduces the cost the check exists to avoid.

--- a/openspec/changes/steps-name-their-value/specs/test-authoring/spec.md
+++ b/openspec/changes/steps-name-their-value/specs/test-authoring/spec.md
@@ -8,7 +8,7 @@ The system SHALL detect, over the `steps` and `setup` of every parsed test file,
 
 Detection is defined over English grammar only. A step written in another language SHALL produce no finding, and the absence of a finding SHALL NOT be represented anywhere as evidence that a suite was checked.
 
-A step names a value-entering action when it contains one of the closed verb set `fill`, `enter`, `type`, `input`, `set`, matched case-insensitively on word boundaries.
+A step names a value-entering action when it **begins with** one of the closed verb set `fill`, `enter`, `type`, `input`, `set`, matched case-insensitively and terminated by a word boundary. A verb appearing later in the step SHALL NOT match, because these words are nouns as often as verbs.
 
 A step supplies a value when it contains a connector: `with`, `to`, `as`, `using`, `into`, `from`, `in`, `:`, `=`, a quotation mark, or an `{{env.` placeholder. A step containing any connector SHALL NOT be reported. The connector `in` SHALL count only when it is not adjacent to the value-entering verb, so that the phrasal verbs `fill in` and `type in` do not silence the check.
 
@@ -47,6 +47,10 @@ A step supplies a value when it contains a connector: `with`, `to`, `as`, `using
 #### Scenario: setup steps are checked too
 - **WHEN** a test declares `setup: ["fill the search box"]` and no offending entry under `steps`
 - **THEN** the setup step is reported, because setup steps run through the same executor
+
+#### Scenario: A verb used as a noun is not reported
+- **WHEN** a test declares the step `verify the type is Premium`
+- **THEN** the step is not reported, because `type` is not the step's leading verb
 
 #### Scenario: The verb match is word-bounded
 - **WHEN** a test declares the step `setup the account and verify the dashboard is shown`

--- a/openspec/changes/steps-name-their-value/tasks.md
+++ b/openspec/changes/steps-name-their-value/tasks.md
@@ -2,35 +2,35 @@
 
 ## 1. Detection (pure)
 
-- [ ] 1.1 Add `src/runner/authoring.ts` with `detectMissingValues(tests): AuthoringResult` plus `AuthoringFinding` types. Read `steps` and `setup` from each `TestFile` (D2), fire only when a closed-set verb (`fill`, `enter`, `type`, `input`, `set`) matches on a word boundary and the step carries **no connector** (D3) — `with`, `to`, `as`, `using`, `into`, `from`, `in`, `:`, `=`, a quote, or `{{env.`, with `in` discounted when adjacent to the verb so `fill in` stays a bare step. Findings carry the test, whether the step came from `steps` or `setup`, its 1-based index and its text; grouped by test in input order, then step order. Pure — no I/O, no config, no CLI.
-- [ ] 1.2 Add `suggestValueClause(step): string` in the same module: the offending step with a value clause appended, as the shape to follow (D6). It never invents a value.
-- [ ] 1.3 Unit tests in `tests/authoring.test.ts` covering every scenario in `specs/test-authoring/spec.md`: bare `fill`, `with` clause, `{{env.*}}`, page-sourced value, quoted value, `set … to High`, `enter … in the subject field`, `fill in the note field` (phrasal verb still reported), `setup` coverage, `setup the account` not matching `set`, a non-value step, and grouping/order stability. Add one test per verb and one per connector so dropping either fails.
-- [ ] 1.4 Run the detector over `.blastproof/tests/*.yaml` and `examples/**` as a fixture test: the project's own suite must produce zero findings. It is the only corpus of real steps the repo has, and a check that fires on it is wrong.
+- [x] 1.1 Add `src/runner/authoring.ts` with `detectMissingValues(tests): AuthoringResult` plus `AuthoringFinding` types. Read `steps` and `setup` from each `TestFile` (D2), fire only when a closed-set verb (`fill`, `enter`, `type`, `input`, `set`) matches on a word boundary and the step carries **no connector** (D3) — `with`, `to`, `as`, `using`, `into`, `from`, `in`, `:`, `=`, a quote, or `{{env.`, with `in` discounted when adjacent to the verb so `fill in` stays a bare step. Findings carry the test, whether the step came from `steps` or `setup`, its 1-based index and its text; grouped by test in input order, then step order. Pure — no I/O, no config, no CLI.
+- [x] 1.2 Add `suggestValueClause(step): string` in the same module: the offending step with a value clause appended, as the shape to follow (D6). It never invents a value.
+- [x] 1.3 Unit tests in `tests/authoring.test.ts` covering every scenario in `specs/test-authoring/spec.md`: bare `fill`, `with` clause, `{{env.*}}`, page-sourced value, quoted value, `set … to High`, `enter … in the subject field`, `fill in the note field` (phrasal verb still reported), `setup` coverage, `setup the account` not matching `set`, a non-value step, and grouping/order stability. Add one test per verb and one per connector so dropping either fails.
+- [x] 1.4 Run the detector over `.blastproof/tests/*.yaml` and `examples/**` as a fixture test: the project's own suite must produce zero findings. It is the only corpus of real steps the repo has, and a check that fires on it is wrong.
 
 ## 2. Surfacing
 
-- [ ] 2.1 In `src/commands/run.ts`, add `printAuthoring(result, cwd)` writing to stderr: the test, the step's origin and position, its text, why the executor cannot carry it out, and the corrected shape from 1.2 (D6).
-- [ ] 2.2 Compute findings once after the parse loop and print from a **single unconditional call site**, beside `printRouteDrift` (D5, inherited from `route-drift-warning`). No `if (dryRun)` guard, no second call site — a future code path must not be able to bypass it.
-- [ ] 2.3 Tests in `tests/run.test.ts`: plain `run`, `--dry-run`, and `--impacted --dry-run` each warn exactly once; a clean suite prints nothing; stdout stays clean; exit code unchanged in all four. Use the empty-selection trick (`--tag` no test declares) to reach the real path without a browser or key.
+- [x] 2.1 In `src/commands/run.ts`, add `printAuthoring(result, cwd)` writing to stderr: the test, the step's origin and position, its text, why the executor cannot carry it out, and the corrected shape from 1.2 (D6).
+- [x] 2.2 Compute findings once after the parse loop and print from a **single unconditional call site**, beside `printRouteDrift` (D5, inherited from `route-drift-warning`). No `if (dryRun)` guard, no second call site — a future code path must not be able to bypass it.
+- [x] 2.3 Tests in `tests/run.test.ts`: plain `run`, `--dry-run`, and `--impacted --dry-run` each warn exactly once; a clean suite prints nothing; stdout stays clean; exit code unchanged in all four. Use the empty-selection trick (`--tag` no test declares) to reach the real path without a browser or key.
 
 ## 3. The gate
 
-- [ ] 3.1 Add `--fail-on-authoring` to `run` and `test` in `src/cli.ts` and thread `failOnAuthoring` through `RunOptions`/`TestOptions` (D7). No companion-flag validation — unlike `--fail-on-unmapped`, this needs no `--impacted`.
-- [ ] 3.2 In `run.ts`, return `EXIT_FAILED` when the flag is set and findings exist, positioned after parsing and **before** preflight, browser launch and any key check, so the gate costs nothing when it fires (D7).
-- [ ] 3.3 Tests: gate exits 1 with no browser launched and no key required; gate passes a clean suite through to the normal exit code; gate accepted without `--impacted`; the warning still prints when the flag is absent.
+- [x] 3.1 Add `--fail-on-authoring` to `run` and `test` in `src/cli.ts` and thread `failOnAuthoring` through `RunOptions`/`TestOptions` (D7). No companion-flag validation — unlike `--fail-on-unmapped`, this needs no `--impacted`.
+- [x] 3.2 In `run.ts`, return `EXIT_FAILED` when the flag is set and findings exist, positioned after parsing and **before** preflight, browser launch and any key check, so the gate costs nothing when it fires (D7).
+- [x] 3.3 Tests: gate exits 1 with no browser launched and no key required; gate passes a clean suite through to the normal exit code; gate accepted without `--impacted`; the warning still prints when the flag is absent.
 
 ## 4. Rule-drift guard (#45)
 
-- [ ] 4.1 Add a test asserting the rule's key phrase appears in `plannerSystemPrompt` (`src/llm/prompts.ts`), in the README's test-authoring section, and in the check's own message — failing and naming which two disagree when they diverge (D8). Precedent: `tests/action-manifest.test.ts`.
+- [x] 4.1 Add a test asserting the rule's key phrase appears in `plannerSystemPrompt` (`src/llm/prompts.ts`), in the README's test-authoring section, and in the check's own message — failing and naming which two disagree when they diverge (D8). Precedent: `tests/action-manifest.test.ts`.
 
 ## 5. Docs
 
-- [ ] 5.1 README: document the check and `--fail-on-authoring` in the flag list and beside the existing *Writing tests* rule. Keep the wording consistent with 4.1, which will fail otherwise. Do not edit `CHANGELOG.md` — it is written at release time (CONTRIBUTING.md:22).
-- [ ] 5.2 README: state plainly that the check is English-only and that a non-English suite receives no warning that it went unchecked (D9). Not a footnote — a reader must not infer coverage that does not exist. Add a regression test asserting the check's own message and the README agree on this, alongside 4.1.
-- [ ] 5.3 `action.yml`: add the input if the flag is exposed to the Action, or record in the PR why it is not. `tests/action-manifest.test.ts` asserts the manifest and CLI agree (#30).
+- [x] 5.1 README: document the check and `--fail-on-authoring` in the flag list and beside the existing *Writing tests* rule. Keep the wording consistent with 4.1, which will fail otherwise. Do not edit `CHANGELOG.md` — it is written at release time (CONTRIBUTING.md:22).
+- [x] 5.2 README: state plainly that the check is English-only and that a non-English suite receives no warning that it went unchecked (D9). Not a footnote — a reader must not infer coverage that does not exist. Add a regression test asserting the check's own message and the README agree on this, alongside 4.1.
+- [x] 5.3 `action.yml`: add the input if the flag is exposed to the Action, or record in the PR why it is not. `tests/action-manifest.test.ts` asserts the manifest and CLI agree (#30).
 
 ## 6. Verification
 
-- [ ] 6.1 `npm run build`, `npm run typecheck`, `npm test` all green.
-- [ ] 6.2 Run the built CLI (`dist/cli.js`) against a scratch project with one offending test and one clean test: confirm the warning fires on all three paths, `--fail-on-authoring` exits 1 with no key set, and `grep -c` shows the warning printed exactly once per path.
-- [ ] 6.3 Confirm the PR body says **`Part of #44`**, never `Closes #44` — the headline no-outcome rule is phase 2 and stays open. #45 also stays open; 4.1 is a guard, not the single source it asks for.
+- [x] 6.1 `npm run build`, `npm run typecheck`, `npm test` all green.
+- [x] 6.2 Run the built CLI (`dist/cli.js`) against a scratch project with one offending test and one clean test: confirm the warning fires on all three paths, `--fail-on-authoring` exits 1 with no key set, and `grep -c` shows the warning printed exactly once per path.
+- [x] 6.3 Confirm the PR body says **`Part of #44`**, never `Closes #44` — the headline no-outcome rule is phase 2 and stays open. #45 also stays open; 4.1 is a guard, not the single source it asks for.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,7 @@ program
   .option('--junit [path]', 'write a JUnit XML report (default: .blastproof/reports/<session>/junit.xml)')
   .option('--html [path]', 'write a self-contained HTML report (default: .blastproof/reports/<session>/report.html)')
   .option('--fail-on-unmapped', 'fail when a changed file matches no routes: or ignore: glob')
+  .option('--fail-on-authoring', 'fail when a step enters a value but names none (warns by default)')
   .option(
     '--concurrency <n>',
     'run this many tests at once (overrides config; default 1 — see the README on when this is safe)',
@@ -121,6 +122,7 @@ program
       junit?: string | boolean;
       html?: string | boolean;
       failOnUnmapped?: boolean;
+      failOnAuthoring?: boolean;
       concurrency?: number;
       maxLlmCalls?: number;
       maxTokens?: number;
@@ -140,6 +142,7 @@ program
           junit: options.junit,
           html: options.html,
           failOnUnmapped: options.failOnUnmapped,
+          failOnAuthoring: options.failOnAuthoring,
           concurrency: options.concurrency,
           maxLlmCalls: options.maxLlmCalls,
           maxTokens: options.maxTokens,
@@ -222,6 +225,7 @@ program
   .option('--html [path]', 'write a self-contained HTML report (default: .blastproof/reports/<session>/report.html)')
   .option('--write', 'persist generated drafts under .blastproof/tests/ instead of previewing them')
   .option('--fail-on-unmapped', 'fail when a changed file matches no routes: or ignore: glob')
+  .option('--fail-on-authoring', 'fail when a step enters a value but names none (warns by default)')
   .option(
     '--max-llm-calls <n>',
     'stop the pipeline after this many model calls, shared by both phases (overrides config)',
@@ -246,6 +250,7 @@ program
       html?: string | boolean;
       write?: boolean;
       failOnUnmapped?: boolean;
+      failOnAuthoring?: boolean;
       maxLlmCalls?: number;
       maxTokens?: number;
       maxDuration?: number;
@@ -260,6 +265,7 @@ program
           html: options.html,
           write: options.write,
           failOnUnmapped: options.failOnUnmapped,
+          failOnAuthoring: options.failOnAuthoring,
           maxLlmCalls: options.maxLlmCalls,
           maxTokens: options.maxTokens,
           maxDuration: options.maxDuration,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -17,6 +17,11 @@ import {
   type BudgetSpend,
   type RunBudgetOptions,
 } from '../runner/budget.js';
+import {
+  detectMissingValues,
+  suggestValueClause,
+  type AuthoringResult,
+} from '../runner/authoring.js';
 import { MissingEnvError, SecretsMask, substituteEnv } from '../runner/env.js';
 import { runWithConcurrency } from '../runner/pool.js';
 import { describeAction } from '../runner/recovery.js';
@@ -89,6 +94,13 @@ export interface RunOptions extends TestFilters, BudgetFlags {
    * selected and still be blocked by a change nobody has classified (design D4).
    */
   failOnUnmapped?: boolean;
+  /**
+   * Fail the run when a step enters a value but names none. Off by default: the
+   * detection is a judgment about English, not a proof, and a false positive would
+   * block a test that works (design steps-name-their-value D1). Needs no companion
+   * flag — authoring is independent of the diff.
+   */
+  failOnAuthoring?: boolean;
   /**
    * A budget already constructed by a composing caller (`test`), so both of its
    * phases draw against one allowance instead of each resolving and starting its
@@ -469,6 +481,31 @@ function printRouteDrift(drift: RouteDriftResult, cwd: string): void {
   console.error('Fix the route typo, or add the route to a routes: mapping in .blastproof/config.yaml.');
 }
 
+/**
+ * Prints steps that enter a value but name none, to stderr (design
+ * steps-name-their-value D6). Each finding shows the user's own step beside the
+ * shape that runs: a warning citing the README is ignorable in the way all
+ * warnings are, and the fix here is mechanical enough to print.
+ *
+ * The English-only line is not a footnote (D9). An empty result means "nothing
+ * found in English", never "this suite is clean", and a reader who infers the
+ * second has been misled by us rather than by their own carelessness.
+ */
+function printAuthoring(result: AuthoringResult, cwd: string): void {
+  if (result.findings.length === 0) return;
+  console.error('\nAuthoring (a step enters a value but names none):');
+  for (const { test, origin, index, step } of result.findings) {
+    const where = origin === 'setup' ? `setup step ${index}` : `step ${index}`;
+    console.error(`  ${test.summary} (${path.relative(cwd, test.path)}) ${where}:`);
+    console.error(`      ${step}`);
+    console.error(`    → ${suggestValueClause(step)}`);
+  }
+  console.error(
+    'The runner is forbidden from inventing values, so a step that supplies none cannot be carried out.',
+  );
+  console.error('Steps are inspected in English only; steps in other languages are not checked.');
+}
+
 function printDryRun(
   selected: TestFile[],
   config: BlastproofConfig,
@@ -593,6 +630,23 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // unchanged. One call site (not two guarded by `!dryRun`) so a fourth code path
   // added later cannot silently drop the guarantee.
   printRouteDrift(drift, options.cwd);
+
+  // Same single-call-site rule as the drift warning above (D5): a step that names
+  // no value is independent of the diff and of selection, so there is no path that
+  // could legitimately skip it, and no guard to get wrong when a fifth code path
+  // is added later.
+  const authoring = detectMissingValues(parsed);
+  printAuthoring(authoring, options.cwd);
+
+  // The gate sits here, above preflight, the browser launch and the key check, so
+  // it costs nothing when it fires (D7) — the whole point is to fail before the
+  // 80 seconds this predicts. Opt-in: without the flag the finding stays a warning.
+  if (options.failOnAuthoring && authoring.findings.length > 0) {
+    console.error(
+      `error: --fail-on-authoring: ${authoring.findings.length} step(s) enter a value but name none.`,
+    );
+    return EXIT_FAILED;
+  }
 
   // Impacted selection first, tag/priority/query filters applied within it (D3/D4).
   const selection: ImpactedSelection = impact

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -26,6 +26,8 @@ export interface TestOptions extends BudgetFlags {
   write?: boolean;
   /** Fail when the diff contains a file matching neither routes: nor ignore:. */
   failOnUnmapped?: boolean;
+  /** Fail when a step enters a value but names none. */
+  failOnAuthoring?: boolean;
 }
 
 function section(title: string): void {
@@ -73,6 +75,7 @@ export async function testCommand(options: TestOptions): Promise<number> {
     junit: options.junit,
     html: options.html,
     failOnUnmapped: options.failOnUnmapped,
+    failOnAuthoring: options.failOnAuthoring,
     budget,
   });
   if (runCode === EXIT_USAGE) return EXIT_USAGE;

--- a/src/runner/authoring.ts
+++ b/src/runner/authoring.ts
@@ -1,0 +1,110 @@
+import type { TestFile } from './testfile.js';
+
+/** Which of a test file's two step lists a finding came from. */
+export type StepOrigin = 'setup' | 'steps';
+
+export interface AuthoringFinding {
+  /** The test declaring the step. */
+  test: TestFile;
+  /** Which list the step came from — `setup` runs first and fails the same way. */
+  origin: StepOrigin;
+  /** 1-based position within `origin`'s list, as a reader counts them. */
+  index: number;
+  /** The step, verbatim. */
+  step: string;
+}
+
+export interface AuthoringResult {
+  findings: AuthoringFinding[];
+}
+
+/**
+ * Steps that put a value into the page. Closed and small on purpose (design D3):
+ * an unlisted verb produces a false negative — the check stays silent and the run
+ * fails honestly, as it does today — while an unlisted connector produces a false
+ * positive, flagging a step that works. Only one of those is worth risking.
+ */
+const VALUE_VERBS = ['fill', 'enter', 'type', 'input', 'set'];
+
+/**
+ * Anchored at the start of the step, not merely contained in it. Test steps are
+ * imperative ("fill the note field"), so the leading word is the action; a step
+ * using one of these words as a noun — `verify the type is Premium` — is a check,
+ * and matching it anywhere would flag it. `\b` after the verb keeps `setup the
+ * account` from matching `set`.
+ */
+const LEADING_VALUE_VERB = new RegExp(`^\\s*(?:${VALUE_VERBS.join('|')})\\b`, 'i');
+
+/**
+ * A step that names a value always carries one of these. Enumerating the ways to
+ * *name* a value cannot be closed — that set is open English, and trying it flagged
+ * `set the priority to High` — so the question is inverted (design D3): a bare step
+ * is a verb followed by a field and stops. Widening this list can only ever quiet
+ * the check, which makes it the safe one to extend.
+ */
+const CONNECTOR_WORDS = ['with', 'to', 'as', 'using', 'into', 'from', 'in'];
+
+const CONNECTOR_WORD = new RegExp(`\\b(?:${CONNECTOR_WORDS.join('|')})\\b`, 'i');
+
+/** A quote, an assignment or a placeholder is a value even with no connector word. */
+const CONNECTOR_SYMBOL = /["'`:=]|\{\{env\./i;
+
+/**
+ * `fill in` and `type in` are phrasal verbs, so their `in` belongs to the verb and
+ * says nothing about a value. Dropped before the connector test, so `fill in the
+ * note field` stays a bare step while `enter Order not received in the subject
+ * field` keeps the `in` that introduces where the value goes.
+ */
+const PHRASAL_IN = new RegExp(`^(\\s*(?:${VALUE_VERBS.join('|')}))\\s+in\\b`, 'i');
+
+/** True when the step enters a value but supplies no source for it. */
+function namesNoValue(step: string): boolean {
+  if (!LEADING_VALUE_VERB.test(step)) return false;
+  const withoutPhrasal = step.replace(PHRASAL_IN, '$1');
+  return !CONNECTOR_WORD.test(withoutPhrasal) && !CONNECTOR_SYMBOL.test(withoutPhrasal);
+}
+
+/**
+ * Pure detection of steps the executor cannot carry out (design steps-name-their-value
+ * D1–D9). `src/llm/prompts.ts` forbids the executor from inventing a value — one it
+ * types must come from the step, from the page, or from an `{{env.*}}` placeholder —
+ * so a step supplying none of the three is required to fail, several model calls into
+ * a run. This predicts that from the parsed test file, with no browser, model, network
+ * or key.
+ *
+ * Covers `setup` as well as `steps` (D2): setup steps run through the same executor
+ * and fail the same way, and a check that covered one list would be the call-site
+ * shape AGENTS.md names as this repository's recurring defect.
+ *
+ * **English only** (D9). The verb set, the connectors and the phrasal-verb exception
+ * are English grammar; a step in another language matches no verb and yields no
+ * finding. An empty result therefore means "nothing found in English", never "this
+ * suite was checked" — callers must not present it as coverage.
+ *
+ * Findings are grouped by test in input order, `setup` before `steps`, then step
+ * order, so output is stable across runs.
+ */
+export function detectMissingValues(tests: TestFile[]): AuthoringResult {
+  const findings: AuthoringFinding[] = [];
+  for (const test of tests) {
+    for (const origin of ['setup', 'steps'] as const) {
+      const steps = origin === 'setup' ? (test.setup ?? []) : test.steps;
+      steps.forEach((step, position) => {
+        if (namesNoValue(step)) {
+          findings.push({ test, origin, index: position + 1, step });
+        }
+      });
+    }
+  }
+  return { findings };
+}
+
+/**
+ * The offending step with a value clause appended — the shape to follow, not a value
+ * (design D6). `<value>` stays literal: guessing one is exactly what `prompts.ts`
+ * forbids the executor from doing, and a check that did it while enforcing the rule
+ * against everyone else would not deserve to be believed.
+ */
+export function suggestValueClause(step: string): string {
+  return `${step.trimEnd()} with <value>`;
+}

--- a/tests/authoring.test.ts
+++ b/tests/authoring.test.ts
@@ -1,0 +1,199 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { detectMissingValues, suggestValueClause } from '../src/runner/authoring.js';
+import { discoverTestFiles, parseTestFile, type TestFile } from '../src/runner/testfile.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function makeTest(overrides: Partial<TestFile> & { summary: string }): TestFile {
+  return {
+    path: `/repo/.blastproof/tests/${overrides.summary}.yaml`,
+    steps: ['do something'],
+    priority: 'P1',
+    tags: [],
+    routes: [],
+    auth: true,
+    ...overrides,
+  };
+}
+
+/** The findings for a single-step test, as the step text — the unit under test. */
+function flagged(step: string): boolean {
+  const result = detectMissingValues([makeTest({ summary: 'one', steps: [step] })]);
+  return result.findings.length === 1;
+}
+
+describe('detectMissingValues', () => {
+  it('reports a value-entering step that names no value', () => {
+    const test = makeTest({ summary: 'Add a note', steps: ['navigate to /notes', 'fill the note field'] });
+    const { findings } = detectMissingValues([test]);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ test, origin: 'steps', index: 2, step: 'fill the note field' });
+  });
+
+  it('does not report a step that names its value', () => {
+    expect(flagged('fill the note field with Order not received')).toBe(false);
+  });
+
+  it('does not report a value taken from an env placeholder', () => {
+    expect(flagged('fill password with {{env.TEST_PASSWORD}}')).toBe(false);
+  });
+
+  it('does not report a value taken from the page', () => {
+    // prompts.ts permits a value that comes from the page, so this runs today.
+    // Failing it would block a working test — the reason the check only warns (D1).
+    expect(flagged('fill the recipient field with the address shown on the confirmation page')).toBe(false);
+  });
+
+  it('does not report a quoted value', () => {
+    expect(flagged('enter "Order not received" in the note field')).toBe(false);
+  });
+
+  it('does not report a value introduced by a connector other than `with`', () => {
+    // The shape that broke the first design: enumerating ways to name a value
+    // cannot be closed, so the check asks for a connector instead (D3).
+    expect(flagged('set the priority to High')).toBe(false);
+  });
+
+  it('does not report a value that precedes its field', () => {
+    expect(flagged('enter Order not received in the subject field')).toBe(false);
+  });
+
+  it('reports a phrasal verb, whose `in` belongs to the verb', () => {
+    expect(flagged('fill in the note field')).toBe(true);
+    expect(flagged('type in the search box')).toBe(true);
+  });
+
+  it('does not report a step with no value-entering verb', () => {
+    expect(flagged('click Save and verify the confirmation is shown')).toBe(false);
+  });
+
+  it('does not match a verb used as a noun', () => {
+    // `type` and `set` are nouns as often as verbs. Matching them anywhere in the
+    // step rather than at its head flagged these, which is why the verb is anchored.
+    expect(flagged('verify the type is Premium')).toBe(false);
+    expect(flagged('verify the set of results is empty')).toBe(false);
+  });
+
+  it('does not match a longer word starting with a verb', () => {
+    expect(flagged('setup the account and verify the dashboard')).toBe(false);
+    expect(flagged('entering the building is not a step')).toBe(false);
+  });
+
+  it('checks setup steps too, before steps', () => {
+    // setup runs through the same executor and fails the same way (D2).
+    const test = makeTest({
+      summary: 'Search',
+      setup: ['fill the search box'],
+      steps: ['fill the note field'],
+    });
+    const { findings } = detectMissingValues([test]);
+
+    expect(findings).toHaveLength(2);
+    expect(findings[0]).toMatchObject({ origin: 'setup', index: 1, step: 'fill the search box' });
+    expect(findings[1]).toMatchObject({ origin: 'steps', index: 1, step: 'fill the note field' });
+  });
+
+  it('returns nothing for a clean suite', () => {
+    const clean = makeTest({ summary: 'Clean', steps: ['fill the note field with Check the invoice'] });
+    expect(detectMissingValues([clean]).findings).toEqual([]);
+  });
+
+  it('returns nothing for no tests at all', () => {
+    expect(detectMissingValues([]).findings).toEqual([]);
+  });
+
+  it('groups by test in input order, then by step order', () => {
+    const first = makeTest({ summary: 'First', steps: ['fill a', 'click b', 'enter c'] });
+    const second = makeTest({ summary: 'Second', steps: ['type d'] });
+    const { findings } = detectMissingValues([first, second]);
+
+    expect(findings.map((finding) => finding.step)).toEqual(['fill a', 'enter c', 'type d']);
+  });
+
+  it('produces no finding for a non-English step', () => {
+    // Documents the gap as intended, not as an oversight: the check is English
+    // grammar in code (D9), so a suite in another language is silently unchecked.
+    // #53 is the language-independent answer. When it lands, this test should fail
+    // and force the decision rather than let the gap survive unnoticed.
+    expect(flagged('preencha o campo de observação')).toBe(false);
+  });
+
+  describe('every verb in the closed set is matched', () => {
+    for (const verb of ['fill', 'enter', 'type', 'input', 'set']) {
+      it(`matches \`${verb}\``, () => {
+        expect(flagged(`${verb} the note field`)).toBe(true);
+      });
+    }
+  });
+
+  describe('every connector silences the check', () => {
+    for (const connector of ['with', 'to', 'as', 'using', 'into', 'from']) {
+      it(`accepts \`${connector}\``, () => {
+        expect(flagged(`fill the note field ${connector} something`)).toBe(false);
+      });
+    }
+
+    for (const [name, step] of [
+      ['a quote', 'fill the note field "x"'],
+      ['an equals sign', 'fill the note field = x'],
+      ['a colon', 'fill the note field: x'],
+      ['a placeholder', 'fill the note field {{env.NOTE}}'],
+      ['a loose `in`', 'fill x in the note field'],
+    ] as const) {
+      it(`accepts ${name}`, () => {
+        expect(flagged(step)).toBe(false);
+      });
+    }
+  });
+
+  it('finds nothing in the project’s own suite', async () => {
+    // The only corpus of real steps this repository has. A check that fires on the
+    // tests we ship is wrong, whatever the unit tests say.
+    const files = await discoverTestFiles(path.join(root, '.blastproof', 'tests'));
+    const tests = await Promise.all(files.map((file) => parseTestFile(file)));
+
+    expect(detectMissingValues(tests).findings).toEqual([]);
+  });
+});
+
+describe('suggestValueClause', () => {
+  it('appends a value clause without inventing a value', () => {
+    expect(suggestValueClause('fill the note field')).toBe('fill the note field with <value>');
+  });
+
+  it('is itself a step the check accepts', () => {
+    // The suggestion must not be something the tool would warn about again.
+    expect(flagged(suggestValueClause('fill the note field'))).toBe(false);
+  });
+});
+
+describe('the authoring rule reads the same everywhere it is stated', () => {
+  // Third copy of a rule that already exists twice and has already drifted once
+  // (#45). This does not make a single source; it makes divergence loud.
+  const RULE = 'forbidden from inventing values';
+
+  it('appears in the planner prompt, the README and the check’s own message', async () => {
+    const places = {
+      'src/llm/prompts.ts': await readFile(path.join(root, 'src/llm/prompts.ts'), 'utf8'),
+      'README.md': await readFile(path.join(root, 'README.md'), 'utf8'),
+      'src/commands/run.ts': await readFile(path.join(root, 'src/commands/run.ts'), 'utf8'),
+    };
+    const missing = Object.entries(places)
+      .filter(([, contents]) => !contents.includes(RULE))
+      .map(([name]) => name);
+
+    expect(missing, `"${RULE}" is missing from: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('states the English-only limit in both the README and the message', async () => {
+    const readme = await readFile(path.join(root, 'README.md'), 'utf8');
+    const runner = await readFile(path.join(root, 'src/commands/run.ts'), 'utf8');
+
+    expect(readme).toContain('English only');
+    expect(runner).toContain('in English only');
+  });
+});

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -695,3 +695,119 @@ steps:
     expect(errOut().match(/Route drift/g)?.length).toBe(1);
   });
 });
+
+describe('runCommand authoring warning', () => {
+  const BARE_VALUE_TEST = `summary: Add a note
+routes: ["/cart"]
+steps:
+  - navigate to /notes
+  - fill the note field
+`;
+
+  const CLEAN_VALUE_TEST = `summary: Add a note
+routes: ["/cart"]
+steps:
+  - fill the note field with Check the invoice
+`;
+
+  // A tag no test declares empties the selection, so the run short-circuits before
+  // any browser launch or key check while still taking the real execution path.
+  const emptySelection = { tags: ['no-such-tag'] };
+
+  it('warns on stderr in a plain run', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, ...emptySelection });
+
+    expect(code).toBe(EXIT_OK);
+    expect(getChangedFilesMock).not.toHaveBeenCalled();
+    expect(errOut()).toContain('a step enters a value but names none');
+    expect(errOut()).toContain('Add a note');
+    expect(errOut()).toContain('step 2');
+    expect(errOut()).toContain('fill the note field with <value>');
+    expect(errOut()).toContain('forbidden from inventing values');
+  });
+
+  it('warns in --dry-run', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, tags: [], dryRun: true });
+
+    expect(code).toBe(EXIT_OK);
+    expect(errOut()).toContain('a step enters a value but names none');
+  });
+
+  it('warns in --impacted --dry-run, exactly once', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+    getChangedFilesMock.mockResolvedValue(['src/cart/discount.ts']);
+
+    const code = await runCommand({ cwd: dir, tags: [], impacted: true, dryRun: true });
+
+    expect(code).toBe(EXIT_OK);
+    expect(errOut().match(/a step enters a value but names none/g)?.length).toBe(1);
+  });
+
+  it('keeps stdout clean and the exit code unchanged', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, tags: [], dryRun: true });
+
+    expect(code).toBe(EXIT_OK);
+    expect(out()).not.toContain('enters a value');
+  });
+
+  it('prints nothing for a suite whose steps name their values', async () => {
+    await writeProject({ 'notes.yaml': CLEAN_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, tags: [], dryRun: true });
+
+    expect(code).toBe(EXIT_OK);
+    expect(errOut()).not.toContain('enters a value');
+  });
+
+  it('states the English-only limit alongside the warning', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+
+    await runCommand({ cwd: dir, tags: [], dryRun: true });
+
+    expect(errOut()).toContain('in English only');
+  });
+
+  it('--fail-on-authoring exits 1 with no browser launched and no key required', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, tags: [], failOnAuthoring: true });
+
+    expect(code).toBe(EXIT_FAILED);
+    expect(launchMock).not.toHaveBeenCalled();
+    expect(errOut()).toContain('error: --fail-on-authoring');
+    // Still shows the finding, not only the refusal.
+    expect(errOut()).toContain('fill the note field with <value>');
+  });
+
+  it('--fail-on-authoring needs no --impacted, unlike --fail-on-unmapped', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, tags: [], failOnAuthoring: true });
+
+    expect(code).toBe(EXIT_FAILED);
+    expect(errOut()).not.toContain('requires --impacted');
+  });
+
+  it('--fail-on-authoring lets a clean suite through', async () => {
+    await writeProject({ 'notes.yaml': CLEAN_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, ...emptySelection, failOnAuthoring: true });
+
+    expect(code).toBe(EXIT_OK);
+  });
+
+  it('stays a warning without the flag', async () => {
+    await writeProject({ 'notes.yaml': BARE_VALUE_TEST });
+
+    const code = await runCommand({ cwd: dir, ...emptySelection });
+
+    expect(code).toBe(EXIT_OK);
+    expect(errOut()).not.toContain('error: --fail-on-authoring');
+  });
+});


### PR DESCRIPTION
Implements `openspec/changes/steps-name-their-value` — phase 1 of #44.

`prompts.ts` forbids the executor from inventing values, so `fill the note field` cannot be carried out and the runner is *required* to fail it. Today that costs a browser launch, a key check and several model calls, and surfaces as a reason about page state that reads as though the application is broken. Now it is caught from the parsed test file, before anything is spent.

```
Authoring (a step enters a value but names none):
  Add a note (.blastproof/tests/notes.yaml) step 2:
      fill the note field
    → fill the note field with <value>
The runner is forbidden from inventing values, so a step that supplies none cannot be carried out.
Steps are inspected in English only; steps in other languages are not checked.
```

Printed from a **single unconditional call site**, the shape `route-drift-warning` established, so plain `run`, `--dry-run` and `--impacted` are all covered and a future code path cannot bypass it.

## Two refinements the design gained while being implemented

Both recorded in D3 rather than left as undocumented behaviour:

- **The verb is anchored at the head of the step.** `type` and `set` are nouns as often as verbs, so `verify the type is Premium` matched a contained verb, carried no connector, and was flagged — a legitimate check reported as a defect.
- **The phrasal `fill in` does not count as the connector `in`**, so `fill in the note field` stays a bare step while `enter Order not received in the subject field` does not.

## Verified against the built CLI, no key set

| path | result |
|---|---|
| plain `run` | warns, exit 0 |
| `--dry-run` | warns, exit 0 |
| `--impacted --dry-run` | warns exactly once, stderr only, stdout clean, exit 0 |
| `--fail-on-authoring` | exit 1, no browser launched, no key required |
| `test --fail-on-authoring` | exit 1 (threading works) |
| clean suite + gate | exit 0 |

`setup` steps are covered too. Correctly silent on `set the priority to High` and `fill the recipient field with the address shown on the confirmation page`.

494 tests pass (was 447), build and typecheck clean, `openspec validate --strict` passes.

## English only

The check is English grammar in code. A suite in another language is runnable today and receives no check — the warning says so, the README says so, and a test asserts the gap is intended. #53 is the language-independent answer.

**Part of #44** — the headline no-outcome rule is phase 2 and stays open. #45 stays open too: the rule-drift test here makes divergence loud, it is not the single source that issue asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)