### PR TITLE
chore: release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes are recorded here. This project follows [semantic versioning](https://semver.org/);
 while it is pre-1.0, a minor bump may change existing behaviour and a patch never does.
 
+## [0.12.1] — 2026-08-12
+
+### Fixed
+- **The authoring warning promised a consequence that does not happen.** The check shipped in 0.12.0
+  closed with "The runner is forbidden from inventing values, so a step that supplies none cannot be
+  carried out." Measured against `examples/demo-app` with a real model, that is false: the model
+  supplies a value anyway and the step **passes** — `fill the note field` was filled with "This is a
+  test note." twice and "This is a new note" once, passing all three times. The prohibition lives in
+  a prompt, and a prompt instructs rather than enforces.
+
+  The harm is therefore worse than the old wording described, not milder: a green test over a value
+  nobody wrote, and a different one on each run, rather than an honest failure the reader might
+  misjudge. The warning, the planner prompt, the README and the `cli-run-command` requirement now say
+  what was measured. Enforcing the rule in the executor is
+  [#57](https://github.com/hamc/blastproof/issues/57).
+
+  Detection, exit codes and `--fail-on-authoring` are unchanged; only what they claim about the
+  outcome has been corrected.
+
 ## [0.12.0] — 2026-08-10
 
 Two silent false negatives become visible before a run spends anything. Both warn rather than fail,

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,7 +27,7 @@ jobs:
 
       - run: npm start &          # however your app boots
 
-      - uses: hamc/blastproof@v0.12.0
+      - uses: hamc/blastproof@v0.12.1
         with:
           version: '0.11.0'       # pin both when this gates merges
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -51,7 +51,7 @@ failed" from "nothing ran".
 
 ```yaml
       - id: bp
-        uses: hamc/blastproof@v0.12.0
+        uses: hamc/blastproof@v0.12.1
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -73,7 +73,7 @@ workflow, which asserts that a shallow checkout is rejected.
 
 Two versions are in play, and they are independent:
 
-- the **action** ref (`hamc/blastproof@v0.12.0`) — the wrapper
+- the **action** ref (`hamc/blastproof@v0.12.1`) — the wrapper
 - the **`version`** input — which blastproof release the wrapper installs from
   npm, defaulting to `latest`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blastproof",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blastproof",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blastproof",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Open-source AI testing agent for pull requests. Diff in, confidence out.",
   "license": "MIT",
   "author": "Heitor Cardozo <heitor.augusto@gmail.com>",


### PR DESCRIPTION
Cuts 0.12.1 from the one commit that has landed since `v0.12.0`.

`git log --oneline v0.12.0..main` is a single entry — `31780ed`, the correction to what the authoring warning claims happens when a step names no value. Measured against `examples/demo-app` with a real model, the runner *does* invent a value and the step passes, which is worse than the failure the shipped wording promised. Detection, exit codes and `--fail-on-authoring` are unchanged, so this is a patch by the definition `CHANGELOG.md` states: pre-1.0, a patch never changes existing behaviour.

## Why now

0.12.0 is on npm without that correction, so the published tarball still carries the README and the warning text that say the wrong thing. This gets the corrected wording into what people actually download.

## Version surfaces moved together

Per the `CONTRIBUTING.md` release checklist, in one commit:

- `package.json` (and the lockfile) → 0.12.1
- the `CHANGELOG.md` entry, written here rather than in the pull request it describes
- both `uses: hamc/blastproof@v0.12.0` refs in `docs/ci.md`, plus the prose mention

`grep -rn 'blastproof@v' README.md docs/` returns nothing older than the new tag.

## After merge

Tag `v0.12.1` on the merge commit, which is what triggers the publish, then write the GitHub release page — v0.12.0 never got one, which is how this gap was noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)