### PR TITLE
fix: refuse a routes: map written the other way round (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ ignore:
   - "**/*.md"
 ```
 
+The key is the file glob and the value is the routes it can affect — the opposite way round from a test file's own `routes:`, which is a plain list of the routes that test covers. Inverted, the map matches nothing at all and every run reports a diff that affected no page, so `blastproof` refuses a map written that way rather than running green against it.
+
 Every changed file lands in one of three buckets: it matches `routes:` and contributes them, matches `ignore:` and is knowingly irrelevant, or **matches neither — nobody has said what it affects**. `--fail-on-unmapped` blocks on that third case, naming the files and both ways to resolve them.
 
 **Nothing is ignored by default**, on purpose: a default that guesses on your behalf would hide the first files worth thinking about. The flag is additive — a run can meet `--min-score` and still be blocked here, because "the tests I ran passed" and "something changed that nobody classified" are different claims.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,7 +272,9 @@ a step that is making progress in a loop rather than failing.
 
 ## `routes` and `ignore`
 
-The impact map — which changed files can affect which pages.
+The impact map — which changed files can affect which pages. The key is the file
+glob, the value is the routes; written the other way round it matches nothing,
+and blastproof refuses it rather than reporting an unaffected diff.
 
 ```yaml
 routes:

--- a/openspec/changes/refuse-an-inverted-routes-map/.openspec.yaml
+++ b/openspec/changes/refuse-an-inverted-routes-map/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/refuse-an-inverted-routes-map/design.md
+++ b/openspec/changes/refuse-an-inverted-routes-map/design.md
@@ -1,0 +1,88 @@
+# Design: refuse-an-inverted-routes-map
+
+## Context
+
+`routes:` is validated as `z.record(z.array(z.string()))`. That type is symmetric — it cannot tell `{ "src/cart/**": ["/cart"] }` from `{ "/cart": ["src/cart/**"] }`, because both are a string keying a list of strings. The type system has nothing left to say, so the only thing that can separate the two shapes is the *content* of the strings: a route and a repository-relative file path do not look alike.
+
+The failure this closes is silent by construction. An inverted map matches no changed file, so `--impacted` selects nothing, the run exits 0, and the report reads exactly like a diff that affected no page.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Refuse an inverted map at load, before anything is spent
+- Show the correction using the reader's own entry, not a documentation reference
+- Accept every map that a correct configuration could plausibly contain
+
+**Non-Goals:** auto-correction, a warning-only mode, catching inversions that no rule can distinguish, changing what an accepted map means.
+
+## Decisions
+
+### D1: Refuse, do not warn
+
+A warning would preserve the exit code, and the exit code is the defect. The whole failure is that a broken map produces a green run; a warning on stderr next to a green run is the state we are already in, plus text.
+
+The cost is real and worth stating: a team whose map is inverted has a passing pipeline today, and this turns it red on upgrade. That is the strongest argument against, and it loses on one fact — their pipeline is green *because it never ran a test*. Turning that red is the correction, not the regression. It does mean this cannot ship as a patch; see the version note in `proposal.md`.
+
+Precedent is one screen up in the same file: `src/config.ts:84` refuses two auth strategies rather than preferring one, because "silently preferring one would make a typo look like it worked."
+
+### D2: Both halves must look wrong
+
+The key must look like a route **and** some value must look like a file. Either signal alone is not evidence:
+
+- `"src/products/**": ["/products/*"]` — a route may legitimately hold a wildcard
+- `"/src/cart/**": ["/cart"]` — a key may legitimately start with a slash if it also carries a glob
+
+Requiring the conjunction means a false positive needs a key that reads as a route *and* values that read as source paths — which is, definitionally, the inverted map.
+
+### D3: A route-shaped key carries no glob metacharacter
+
+`ROUTE_SHAPED = /^\/[^*?]*$/`. `routes:` globs are repository-relative (`src/cart/**`), so a leading slash is the primary signal; excluding `*` and `?` is what keeps an absolute-looking glob out of the accusation (D2's second example).
+
+### D4: A file-shaped value is a wildcard or **any** extension — never a known list
+
+`FILE_SHAPED = /[*?]|\.[a-z0-9]{1,8}$/i`.
+
+The first implementation enumerated extensions: `.ts`, `.tsx`, `.js`, `.vue`, `.svelte`, `.astro`, `.py`, `.rb`, `.go`, `.php`, `.rs`, `.java`, `.kt`, `.cs`. It was then pointed at the first real config anyone tried — **this repository's own** — whose sources are `.html`. The check passed the inverted map straight through and produced a normal-looking impact report, with the validation installed and inert.
+
+That is worth recording as more than a bug. It is the second time enumeration has lost in this project: the authoring check in `steps-name-their-value` reached the same conclusion, that enumerating the ways to name a value cannot be closed, and asked a structural question instead. A trailing extension is the property that actually distinguishes a file from a route; the list of extensions in the world is not closeable and does not need to be.
+
+It was also found by running the tool against a real config rather than by reading the regex — the same way `drafts-follow-the-rule` was found. Reading would not have surfaced it.
+
+### D5: Detection is a pure exported function, refined into the schema field
+
+`findInvertedRouteEntries(routes)` is exported and unit-testable on its own; the `superRefine` on the `routes` field turns its result into a `ctx.addIssue`, so the message flows out through `loadConfig`'s existing `ConfigError` path and reads like every other config error. Same construction as `authSchema`.
+
+`findUnknownConfigKeys` is unaffected: `unwrapToObjectSchema` unwraps the new `ZodEffects` and stops at the `ZodRecord`, which is not a `ZodObject`, so route globs are still never reported as unknown keys.
+
+### D6: Name one entry, count the rest
+
+```
+routes: is the wrong way round (and 1 more) — the key is the file glob, the value is the routes it affects.
+      found:    "/cart": ["src/cart/**"]
+      expected: "src/cart/**": ["/cart"]
+```
+
+A fully inverted map of ten entries produces one worked example rather than ten. The `found`/`expected` pair is built from the reader's own data, so the correction needs no documentation lookup — the fix is visible in the error.
+
+## Rejected alternatives
+
+- **A1 Warn instead of refusing** — leaves the green exit code that is the defect (D1).
+- **A2 Enumerate known source extensions** — measured failure: missed `.html` and let this repository's own inverted config through (D4).
+- **A3 One-sided rule (key looks like a route)** — flags `"/src/cart/**": ["/cart"]`, a valid map (D2).
+- **A4 Swap the entry automatically** — makes a typo look like it worked, the thing `src/config.ts:84` exists to refuse.
+- **A5 Detect in `impact.ts` when mapping runs** — too late: the browser has launched and the run has begun. Config problems belong at config load.
+- **A6 Require the key to match a stricter glob grammar** — rejects legitimate globs nobody has thought of yet, and puts the burden on correct configs rather than on broken ones.
+
+## Risks / Trade-offs
+
+- **A previously-loading config now exits 2.** Only ever a config that matched nothing (D1). Mentioned in the changelog as behaviour-changing, and released as a minor.
+- **Inversion with no leading slash is not caught** — `{"cart": ["src/cart/**"]}`. No rule separates that from a valid glob mapped to oddly-named routes. Accepted; the common shape is the one users actually write.
+- **A route ending in something extension-like** — `{"/cart": ["/v1.0"]}` would be flagged. Both halves are routes, so the config is meaningless in either direction; refusing it is not a loss.
+
+## Migration Plan
+
+No migration for any working configuration. A config refused by this check never mapped a file to a route, so nothing that functioned stops functioning. The error names the entry and shows the corrected form.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/refuse-an-inverted-routes-map/proposal.md
+++ b/openspec/changes/refuse-an-inverted-routes-map/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: refuse-an-inverted-routes-map
+
+## Why
+
+`routes:` is `{ glob: [route, ...] }` — the file glob is the key. Written the other way round, `{ "/cart": ["src/cart/**"] }`, it still type-checks: both halves are a string keying a list of strings, so `z.record(z.array(z.string()))` accepts it and `loadConfig` returns happily.
+
+Then nothing matches. Every changed file is compared against `/cart` as though it were a glob, falls through to unclassified, and `--impacted` selects zero tests. The run **exits 0** having exercised nothing, and the report is indistinguishable from a diff that genuinely affected no page. `--fail-on-unmapped` would catch it, but it is opt-in and fires only after the run has already started.
+
+Inverting it is not carelessness. The key is named `routes`, and a test file's own `routes:` genuinely *is* a list of routes (`src/runner/testfile.ts:17`) — the same word means the opposite thing one file away, and both files are edited in the same sitting.
+
+This is the same class as `--fail-on-unmapped` and the route-drift warning: a gate that reports safe when it is not. Issue #6.
+
+## What Changes
+
+`loadConfig` refuses a `routes:` map whose entries are inverted, with an error naming the offending entry and showing the correction. Detection is a heuristic over the shape of each entry, requiring **both** halves to look wrong before it accuses.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `impact-mapping`: an inverted `routes:` entry is refused at config load with an actionable error, rather than parsed into a map that matches nothing
+
+## Impact
+
+- New dependencies: **none**
+- Affects: `src/config.ts` (detection + schema refinement), `src/commands/init.ts` (scaffold comment), `tests/config.test.ts`, README, `docs/configuration.md`
+- **Not additive**: a config that loaded before and matched nothing now exits 2. No config that ever selected a test changes behaviour, but the exit code for this input does — this is a minor bump, not a patch, by the definition `CHANGELOG.md` states
+
+## Non-goals
+
+- No auto-correction. Swapping the entry silently is exactly what `src/config.ts:84` already refuses to do for auth strategies: "Silently preferring one would make a typo look like it worked."
+- No detection of inversion whose keys carry no leading slash — indistinguishable from a valid map by any rule
+- No change to `impact.ts`, to matching, or to what an accepted map means
+- No warning-only mode or opt-out flag

--- a/openspec/changes/refuse-an-inverted-routes-map/specs/impact-mapping/spec.md
+++ b/openspec/changes/refuse-an-inverted-routes-map/specs/impact-mapping/spec.md
@@ -1,0 +1,26 @@
+# Spec delta: impact-mapping (refuse-an-inverted-routes-map)
+
+## ADDED Requirements
+
+### Requirement: An inverted routes map is refused
+The system SHALL refuse to load a configuration whose `routes:` entries are inverted — a route as the key mapped to file paths as values — rather than accepting a map that can match no changed file. An entry SHALL be treated as inverted only when its key reads as a route (a leading `/` and no glob metacharacter) **and** at least one of its values reads as a file path (a glob metacharacter, or a trailing file extension). Both conditions SHALL be required, so that neither signal alone rejects a valid map. The error SHALL name one offending entry, SHALL state how many others were found, and SHALL show the corrected form built from that entry's own key and value. The system SHALL NOT correct the entry on the user's behalf.
+
+#### Scenario: An inverted entry is refused
+- **WHEN** config declares `routes: { "/cart": ["src/cart/**"] }`
+- **THEN** loading fails with an actionable error showing `"src/cart/**": ["/cart"]` as the expected form
+
+#### Scenario: The extension does not have to be a known one
+- **WHEN** an inverted entry maps a route to a path ending in any file extension, such as `examples/demo-app/login.html`
+- **THEN** it is refused, because detection does not depend on a list of recognised source extensions
+
+#### Scenario: A route holding a wildcard is not inverted
+- **WHEN** config declares `routes: { "src/products/**": ["/products/*"] }`
+- **THEN** the config loads, because the key does not read as a route even though a value contains a wildcard
+
+#### Scenario: An absolute-looking glob is not inverted
+- **WHEN** config declares `routes: { "/src/cart/**": ["/cart"] }`
+- **THEN** the config loads, because the key carries a glob metacharacter and the values do not read as files
+
+#### Scenario: More than one inverted entry is counted, not listed
+- **WHEN** two entries are inverted
+- **THEN** the error names one of them and reports that one more was found

--- a/openspec/changes/refuse-an-inverted-routes-map/tasks.md
+++ b/openspec/changes/refuse-an-inverted-routes-map/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: refuse-an-inverted-routes-map
+
+## 1. Detection (pure)
+- [ ] 1.1 Add `findInvertedRouteEntries(routes)` and the `InvertedRouteEntry` type to `src/config.ts`, with the `ROUTE_SHAPED` and `FILE_SHAPED` shapes as decided (D2–D4). Exported so it is testable without building a whole config.
+- [ ] 1.2 Unit tests in `tests/config.test.ts`: a correct map returns nothing; an inverted map returns the offending entries; detection is independent of the file extension (`.html`, `.css`, `.rs` — the D4 regression).
+
+## 2. Refusal
+- [ ] 2.1 Attach a `superRefine` to the `routes` field of `configSchema` that raises one issue naming the first inverted entry, counting the rest, and printing the `found:` / `expected:` pair (D5, D6).
+- [ ] 2.2 Confirm `findUnknownConfigKeys` still never flags a route glob now that `routes` is wrapped in `ZodEffects`.
+- [ ] 2.3 Tests in `tests/config.test.ts`: `loadConfig` rejects with `ConfigError`; the message carries the correction; `(and N more)` appears for multiple; **and both false-positive maps still load** — a route holding a wildcard, and an absolute-looking glob.
+
+## 3. Docs
+- [ ] 3.1 `src/commands/init.ts`: a comment above the scaffolded `routes:` naming which side is which, and that a test file's own `routes:` is the opposite shape.
+- [ ] 3.2 README "Impact mapping" and `docs/configuration.md`: state the direction and that an inverted map is refused. CHANGELOG is written at release time, not here.
+
+## 4. Verification
+- [ ] 4.1 `npm run build`, `npm run typecheck`, `npm test` green.
+- [ ] 4.2 Against `examples/demo-app`: `run --impacted --dry-run` still selects tests from the real config; the same config inverted is refused with the expected message; the config is restored and loads again. This step is what caught D4 — verification here means running it, not reading it.

--- a/openspec/changes/refuse-an-inverted-routes-map/tasks.md
+++ b/openspec/changes/refuse-an-inverted-routes-map/tasks.md
@@ -1,18 +1,18 @@
 # Tasks: refuse-an-inverted-routes-map
 
 ## 1. Detection (pure)
-- [ ] 1.1 Add `findInvertedRouteEntries(routes)` and the `InvertedRouteEntry` type to `src/config.ts`, with the `ROUTE_SHAPED` and `FILE_SHAPED` shapes as decided (D2–D4). Exported so it is testable without building a whole config.
-- [ ] 1.2 Unit tests in `tests/config.test.ts`: a correct map returns nothing; an inverted map returns the offending entries; detection is independent of the file extension (`.html`, `.css`, `.rs` — the D4 regression).
+- [x] 1.1 Add `findInvertedRouteEntries(routes)` and the `InvertedRouteEntry` type to `src/config.ts`, with the `ROUTE_SHAPED` and `FILE_SHAPED` shapes as decided (D2–D4). Exported so it is testable without building a whole config.
+- [x] 1.2 Unit tests in `tests/config.test.ts`: a correct map returns nothing; an inverted map returns the offending entries; detection is independent of the file extension (`.html`, `.css`, `.rs` — the D4 regression).
 
 ## 2. Refusal
-- [ ] 2.1 Attach a `superRefine` to the `routes` field of `configSchema` that raises one issue naming the first inverted entry, counting the rest, and printing the `found:` / `expected:` pair (D5, D6).
-- [ ] 2.2 Confirm `findUnknownConfigKeys` still never flags a route glob now that `routes` is wrapped in `ZodEffects`.
-- [ ] 2.3 Tests in `tests/config.test.ts`: `loadConfig` rejects with `ConfigError`; the message carries the correction; `(and N more)` appears for multiple; **and both false-positive maps still load** — a route holding a wildcard, and an absolute-looking glob.
+- [x] 2.1 Attach a `superRefine` to the `routes` field of `configSchema` that raises one issue naming the first inverted entry, counting the rest, and printing the `found:` / `expected:` pair (D5, D6).
+- [x] 2.2 Confirm `findUnknownConfigKeys` still never flags a route glob now that `routes` is wrapped in `ZodEffects`.
+- [x] 2.3 Tests in `tests/config.test.ts`: `loadConfig` rejects with `ConfigError`; the message carries the correction; `(and N more)` appears for multiple; **and both false-positive maps still load** — a route holding a wildcard, and an absolute-looking glob.
 
 ## 3. Docs
-- [ ] 3.1 `src/commands/init.ts`: a comment above the scaffolded `routes:` naming which side is which, and that a test file's own `routes:` is the opposite shape.
-- [ ] 3.2 README "Impact mapping" and `docs/configuration.md`: state the direction and that an inverted map is refused. CHANGELOG is written at release time, not here.
+- [x] 3.1 `src/commands/init.ts`: a comment above the scaffolded `routes:` naming which side is which, and that a test file's own `routes:` is the opposite shape.
+- [x] 3.2 README "Impact mapping" and `docs/configuration.md`: state the direction and that an inverted map is refused. CHANGELOG is written at release time, not here.
 
 ## 4. Verification
-- [ ] 4.1 `npm run build`, `npm run typecheck`, `npm test` green.
-- [ ] 4.2 Against `examples/demo-app`: `run --impacted --dry-run` still selects tests from the real config; the same config inverted is refused with the expected message; the config is restored and loads again. This step is what caught D4 — verification here means running it, not reading it.
+- [x] 4.1 `npm run build`, `npm run typecheck`, `npm test` green.
+- [x] 4.2 Against `examples/demo-app`: `run --impacted --dry-run` still selects tests from the real config; the same config inverted is refused with the expected message; the config is restored and loads again. This step is what caught D4 — verification here means running it, not reading it.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -31,6 +31,9 @@ browser:
 # max_retries_per_step: 3
 
 # Impact hints mapping file globs to routes (used by \`blastproof run --impacted\`).
+# Read each line as "if this file changed, these pages are at risk" — the key is the
+# file glob, the value is the routes. Not the other way round: a test file's own
+# \`routes:\` is a list of routes, and this one is a map keyed by source path.
 routes:
   "src/auth/**": ["/login"]
   "src/cart/**": ["/cart", "/checkout"]

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,8 +107,16 @@ const ROUTE_SHAPED = /^\/[^*?]*$/;
  */
 const FILE_SHAPED = /[*?]|\.[a-z0-9]{1,8}$/i;
 
+/** One `routes:` entry that reads as written the other way round. */
+export interface InvertedRouteEntry {
+  /** The key, which reads as a route rather than as a file glob. */
+  key: string;
+  /** The first value under it reading as a source path — the correction's other half. */
+  file: string;
+}
+
 /**
- * Keys of `routes:` entries written the other way round — a route mapped to the
+ * Finds `routes:` entries written the other way round — a route mapped to the
  * files behind it, rather than a file glob mapped to the routes it can reach.
  *
  * The inverted form type-checks perfectly: both halves are still a string keying
@@ -122,13 +130,6 @@ const FILE_SHAPED = /[*?]|\.[a-z0-9]{1,8}$/i;
  * Both halves must look wrong before this accuses. A route may legitimately hold
  * a wildcard (`/products/*`), and that on its own proves nothing.
  */
-export interface InvertedRouteEntry {
-  /** The key, which reads as a route rather than as a file glob. */
-  key: string;
-  /** The first value under it reading as a source path — the correction's other half. */
-  file: string;
-}
-
 export function findInvertedRouteEntries(routes: Record<string, string[]>): InvertedRouteEntry[] {
   const inverted: InvertedRouteEntry[] = [];
   for (const [key, values] of Object.entries(routes)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,11 +89,78 @@ const authSchema = z
     }
   });
 
+/**
+ * A route as a URL path: a leading slash and no glob metacharacter. `routes:`
+ * globs are repository-relative (`src/cart/**`), so the leading slash is what
+ * tells the two shapes apart.
+ */
+const ROUTE_SHAPED = /^\/[^*?]*$/;
+
+/**
+ * A source path, or a glob over one: a wildcard, or any file extension.
+ *
+ * Deliberately not a list of known extensions. The first version of this check
+ * enumerated `.ts`, `.vue`, `.py` and a dozen more, and missed the very first
+ * real config it was pointed at — this repository's own, whose sources are
+ * `.html`. Enumerating the world's file types is a losing game; a trailing
+ * extension is the property that actually distinguishes a file from a route.
+ */
+const FILE_SHAPED = /[*?]|\.[a-z0-9]{1,8}$/i;
+
+/**
+ * Keys of `routes:` entries written the other way round — a route mapped to the
+ * files behind it, rather than a file glob mapped to the routes it can reach.
+ *
+ * The inverted form type-checks perfectly: both halves are still a string keying
+ * a list of strings, so it parses, and then every changed file matches nothing.
+ * The whole diff is reported as unclassified, `--impacted` selects no tests, and
+ * the run is green having exercised nothing — the failure looks exactly like a
+ * diff that affected no page. Nor is writing it inverted carelessness: the key
+ * is named `routes`, and a test file's own `routes:` genuinely *is* a list of
+ * routes (`runner/testfile.ts`), so the two meanings sit one file apart.
+ *
+ * Both halves must look wrong before this accuses. A route may legitimately hold
+ * a wildcard (`/products/*`), and that on its own proves nothing.
+ */
+export interface InvertedRouteEntry {
+  /** The key, which reads as a route rather than as a file glob. */
+  key: string;
+  /** The first value under it reading as a source path — the correction's other half. */
+  file: string;
+}
+
+export function findInvertedRouteEntries(routes: Record<string, string[]>): InvertedRouteEntry[] {
+  const inverted: InvertedRouteEntry[] = [];
+  for (const [key, values] of Object.entries(routes)) {
+    if (!ROUTE_SHAPED.test(key)) continue;
+    const file = values.find((value) => FILE_SHAPED.test(value));
+    if (file !== undefined) inverted.push({ key, file });
+  }
+  return inverted;
+}
+
 const configSchema = z.object({
   base_url: z.string().url(),
   llm: llmSchema.default({}),
   browser: browserSchema.default({}),
-  routes: z.record(z.array(z.string())).optional(),
+  routes: z
+    .record(z.array(z.string()))
+    .superRefine((value, ctx) => {
+      const inverted = findInvertedRouteEntries(value);
+      const first = inverted[0];
+      if (!first) return;
+      // Refusing is the point: accepting it produces a green run that selected no
+      // tests, which reads as "nothing was affected" rather than as a broken map.
+      const others = inverted.length > 1 ? ` (and ${inverted.length - 1} more)` : '';
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `is the wrong way round${others} — the key is the file glob, the value is the routes it affects.\n` +
+          `      found:    "${first.key}": ["${first.file}"]\n` +
+          `      expected: "${first.file}": ["${first.key}"]`,
+      });
+    })
+    .optional(),
   /** Globs for files knowingly irrelevant to any route (docs, CI config, licences). */
   ignore: z.array(z.string()).optional(),
   /**
@@ -214,9 +281,10 @@ function unwrapToObjectSchema(schema: z.ZodTypeAny): z.ZodObject<z.ZodRawShape> 
 /**
  * Finds keys present in `data` that `schema` does not recognise, recursing into
  * nested sections (`llm`, `browser`, `budget`, `auth` — design task 3.2) so a key
- * misplaced inside one of them is caught too. `routes:` is a `z.record`, not a
- * `z.object`, so its keys (route globs, not schema fields) are deliberately never
- * flagged: `unwrapToObjectSchema` only recurses into an actual object schema.
+ * misplaced inside one of them is caught too. `routes:` is a `z.record` (behind a
+ * refinement), not a `z.object`, so its keys (route globs, not schema fields) are
+ * deliberately never flagged: `unwrapToObjectSchema` unwraps the refinement and
+ * then only recurses into an actual object schema.
  */
 export function findUnknownConfigKeys(
   data: unknown,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,7 +2,13 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { applyEnvOverrides, ConfigError, findUnknownConfigKeys, loadConfig } from '../src/config.js';
+import {
+  applyEnvOverrides,
+  ConfigError,
+  findInvertedRouteEntries,
+  findUnknownConfigKeys,
+  loadConfig,
+} from '../src/config.js';
 
 let dir: string;
 
@@ -381,5 +387,92 @@ describe('unknown configuration keys (design D5, spec preflight)', () => {
     await loadConfig(dir, {});
 
     expect(warnings).toEqual([]);
+  });
+});
+
+describe('an inverted routes: map', () => {
+  /** The rejection message, or a failure if the config loaded when it should not have. */
+  async function messageFromLoading(): Promise<string> {
+    try {
+      await loadConfig(dir, {});
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+    throw new Error('expected loadConfig to reject an inverted routes: map');
+  }
+
+  it('is refused rather than silently matching nothing', async () => {
+    await writeConfig(
+      ['base_url: http://localhost:3000', 'routes:', '  "/cart": ["src/cart/**"]', ''].join('\n'),
+    );
+    await expect(loadConfig(dir, {})).rejects.toThrow(ConfigError);
+  });
+
+  it('shows the correction using the reader\'s own entry', async () => {
+    await writeConfig(
+      ['base_url: http://localhost:3000', 'routes:', '  "/cart": ["src/cart/**"]', ''].join('\n'),
+    );
+    const message = await messageFromLoading();
+    expect(message).toContain('the key is the file glob');
+    expect(message).toContain('found:    "/cart": ["src/cart/**"]');
+    expect(message).toContain('expected: "src/cart/**": ["/cart"]');
+  });
+
+  it('names one entry and counts the rest, rather than reprinting the map', async () => {
+    expect(
+      findInvertedRouteEntries({ '/cart': ['src/cart/**'], '/login': ['src/auth/**'] }),
+    ).toEqual([
+      { key: '/cart', file: 'src/cart/**' },
+      { key: '/login', file: 'src/auth/**' },
+    ]);
+
+    await writeConfig(
+      [
+        'base_url: http://localhost:3000',
+        'routes:',
+        '  "/cart": ["src/cart/**"]',
+        '  "/login": ["src/auth/**"]',
+        '',
+      ].join('\n'),
+    );
+    expect(await messageFromLoading()).toContain('(and 1 more)');
+  });
+
+  it('accepts a route holding a wildcard — one half looking odd is not evidence', async () => {
+    // The false positive the two-sided rule exists to avoid: `*` in a route is
+    // legitimate, and on its own says nothing about which way round the map is.
+    await writeConfig(
+      [
+        'base_url: http://localhost:3000',
+        'routes:',
+        '  "src/products/**": ["/products/*"]',
+        '',
+      ].join('\n'),
+    );
+    const config = await loadConfig(dir, {});
+    expect(config.routes).toEqual({ 'src/products/**': ['/products/*'] });
+  });
+
+  it('accepts an absolute-looking glob mapped to plain routes', async () => {
+    // Key starts with a slash but carries a wildcard, and the values look like
+    // routes rather than files: nothing here is inverted.
+    await writeConfig(
+      ['base_url: http://localhost:3000', 'routes:', '  "/src/cart/**": ["/cart"]', ''].join('\n'),
+    );
+    const config = await loadConfig(dir, {});
+    expect(config.routes).toEqual({ '/src/cart/**': ['/cart'] });
+  });
+
+  it('catches it whatever the file extension is', () => {
+    // Regression: the first version of the check enumerated code extensions and
+    // let this repository's own inverted config through, because a demo app is
+    // written in .html. Any trailing extension counts now, not a known list.
+    for (const file of ['examples/demo-app/login.html', 'app/styles.css', 'lib/mod.rs']) {
+      expect(findInvertedRouteEntries({ '/login': [file] })).toEqual([{ key: '/login', file }]);
+    }
+  });
+
+  it('leaves a correct map alone', () => {
+    expect(findInvertedRouteEntries({ 'src/cart/**': ['/cart', '/checkout'] })).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #6.

## The defect

`routes:` is `{ glob: [route, ...] }` — the file glob is the key. Written the other way round it still type-checks, because `z.record(z.array(z.string()))` cannot tell the two apart: both halves are a string keying a list of strings.

```yaml
routes:
  "/cart": ["src/cart/**"]      # loads fine, matches nothing, ever
```

Every changed file is then compared against `/cart` as though it were a glob, falls through to unclassified, and `--impacted` selects zero tests. **The run exits 0 having exercised nothing**, and the report is indistinguishable from a diff that genuinely affected no page. `--fail-on-unmapped` would catch it, but it is opt-in and fires only after the run has started.

Inverting it is a reasonable first guess rather than carelessness: the key is named `routes`, and a test file's own `routes:` genuinely *is* a list of routes (`src/runner/testfile.ts:17`). The same word means the opposite thing one file away, and both files get edited in the same sitting.

## What it does now

```
error: Invalid .blastproof/config.yaml:
  - routes: is the wrong way round — the key is the file glob, the value is the routes it affects.
      found:    "/login": ["examples/demo-app/login.html"]
      expected: "examples/demo-app/login.html": ["/login"]
```

The correction is built from the reader's own entry, so the fix is visible in the error rather than in the docs. More than one inverted entry is counted, not listed.

## Why it refuses rather than warns

A warning preserves the exit code, and the exit code is the whole defect — a green run over a broken map is exactly the state we are in today, plus text. The precedent is one screen up in the same file: `src/config.ts:84` refuses two auth strategies rather than preferring one, because *"silently preferring one would make a typo look like it worked."*

The cost is stated in the design and worth repeating here: a team whose map is inverted has a passing pipeline today and this turns it red on upgrade. That is the correction, not a regression — their pipeline is green because it never ran a test. It does mean this is a **minor bump, not a patch**, by the definition `CHANGELOG.md` states.

## Both halves must look wrong

A key that reads as a route **and** a value that reads as a file. Either alone is not evidence, and these two still load:

- `"src/products/**": ["/products/*"]` — a route may legitimately hold a wildcard
- `"/src/cart/**": ["/cart"]` — a key may start with a slash if it also carries a glob

## The bug this PR found in itself

The first implementation enumerated source extensions — `.ts`, `.vue`, `.py` and a dozen more. Pointed at the first real config anyone tried, **this repository's own**, it passed the inverted map straight through and produced a normal-looking impact report, with the validation installed and inert. The demo app is written in `.html`.

The file test is now any trailing extension. This is the second time enumeration has lost in this project — the authoring check in `steps-name-their-value` reached the same conclusion — and, like `drafts-follow-the-rule`, it was found by running the tool rather than reading the code. Both are recorded in `design.md` (D4).

## Verification

- `npm run build`, `npm run typecheck`, `npm test` — 502 passing
- 7 unit tests in `tests/config.test.ts`, of which three assert **non**-detection, since a false positive here blocks a valid config
- Against `examples/demo-app` running on `:4173`: the real config still selects 7 tests over 8 affected routes; the same config inverted is refused with the message above; restored, it loads and selects again

## OpenSpec

`openspec/changes/refuse-an-inverted-routes-map/` — proposal, design (D1–D6 and six rejected alternatives), tasks and the `impact-mapping` spec delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)