### PR TITLE
fix: an {{env.*}} placeholder is a source only when the step names it (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ The agent is **forbidden from inventing values** — one it types must come from
 
 The rule used to live only in the prompt, and a prompt instructs rather than enforces. Run against a real model, `fill the note field` did not fail — the agent made a value up, filled it, and the step **passed**, producing "This is a test note." on two runs and "This is a new note" on a third. A test going green over a value nobody wrote, differing between runs, is worse than a failure.
 
+A placeholder counts as a source **only when the step names that variable**. `fill the password field with {{env.TEST_PASSWORD}}` works; `fill the password field` does not become valid because the agent supplies `{{env.SOMETHING}}` itself. An agent cannot know the name of a variable nobody showed it, so one it produces is a guess — and a guessed variable would put a live credential into a field your test never pointed one at, in output that cannot redact a secret it was never told about.
+
 Two limits worth knowing. A value the page shows in one format and the field wants in another — `1234` in the step, `1,234.00` in the box — is refused, and the fix is to write the value the way it is typed. And a very short value (`3`) appears somewhere in almost any page, so it will pass; this closes fabricated content, not every fabricated character.
 
 `run` also warns about it first — the same rule caught earlier, from the test file, on every path, before launching a browser or asking for a key:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -91,6 +91,14 @@ prompt and is substituted at the moment of typing — the real value exists
 between the substitution and the keystroke, and never enters a page snapshot, a
 step record, a log line or a report.
 
+**A step may only use a variable it names.** The agent cannot type
+`{{env.API_TOKEN}}` into a field unless the step it is executing references
+`{{env.API_TOKEN}}`. This is enforced, not asked: a placeholder naming any other
+variable is refused and never substituted. Without it, an agent facing a step
+that supplies no value could name a variable of its own — and a secret nobody
+pointed at that field is also a secret the redaction above was never told to
+protect, since it registers the values your steps and your recipe reference.
+
 Every value your tests or auth recipe reference is redacted from everything else
 crossing into a prompt, in both literal and percent-encoded form. Redaction
 matches known values, so treat it as a strong default rather than a guarantee

--- a/openspec/changes/env-placeholder-must-be-named/.openspec.yaml
+++ b/openspec/changes/env-placeholder-must-be-named/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/env-placeholder-must-be-named/design.md
+++ b/openspec/changes/env-placeholder-must-be-named/design.md
@@ -1,0 +1,91 @@
+# Design: env-placeholder-must-be-named
+
+## Context
+
+`refuse-an-invented-value` closed the case where a model types a value from nowhere. It left one door open by design, and the design reasoned about the wrong half of it.
+
+D3 of that change argued — correctly — that a placeholder cannot survive a text comparison: substitution runs after the check, and the masked page shows `***`, so comparing would refuse every authenticated test. It then drew the wrong conclusion, that a placeholder needs no check at all. "Is this well-formed?" became a proxy for "did the test ask for this?", and those are different questions.
+
+The consequence is not merely that the sourcing rule is bypassable. Because the mask registers only the variables the config and the tests reference, a variable that is set but unnamed is substituted **and** unmasked — so a live credential reaches the model's prompt and the run's artifacts. That is a hole in `run-wide-secret-mask`, reached through `refuse-an-invented-value`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A substituted value is always one a step asked for, and therefore always one the mask knows
+- One definition of "a placeholder" in the codebase, not two
+- The refusal explains without inviting another guess
+
+**Non-Goals:** changing substitution or masking, registering model-supplied variables, widening the scope beyond the current step.
+
+## Decisions
+
+### D1: Every variable a value references must be referenced by the step
+
+Not "the value is a placeholder" but "the value references only variables this step names". Per-variable, so a value composing two placeholders is admitted only if the step names both.
+
+The model cannot know the name of a variable nobody showed it. If it produces one, it guessed — and refusing a guess is the entire point of the surrounding change.
+
+### D2: Reuse `referencedEnvVars`, delete the second regex
+
+`recovery.ts` carries `ENV_PLACEHOLDER`, and `runner/env.ts` carries a different one used by both `substituteEnv` and `SecretsMask.registerFrom`. They disagree, and it is measurable:
+
+| value | `env.ts` (substitutes and masks) | `recovery.ts` (exempts) |
+|---|---|---|
+| `{{env.TOKEN}}` | yes | yes |
+| `{{ env.TOKEN }}` | yes | **no** |
+| `Bearer {{env.TOKEN}}` | yes | **no** |
+
+Two rules about the same concept, maintained by hand, already drifted — the shape `AGENTS.md` names as this repository's recurring defect, and the shape #45 exists about. The fix is not to align them but to have one: `referencedEnvVars` already answers "which variables does this text reference", which is exactly the question both callers need.
+
+This also fixes the disagreement's practical effect. Today `Bearer {{env.TOKEN}}` skips the exemption and falls to the string comparison, passing only because the step happens to contain that text. After this change it is judged by the same rule as every other value.
+
+### D3: Compare against the raw step text, not the normalised haystack
+
+`StepRecovery.readable` holds the step lowercased, because case is presentation for a typed value. Environment variable names are **not** presentation: `TOKEN` and `token` are different variables, and matching case-insensitively would admit `{{env.token}}` on a step naming `TOKEN` — a different secret, or none.
+
+So the instance keeps the step verbatim alongside the normalised copy. Two fields holding the same string in two forms is a small cost for not having a case-folding bug in the one place that decides which secret gets typed.
+
+### D4: The current step, not the test, not the suite
+
+The strictest reading available, and the one the defect argues for.
+
+The adversarial run saw the mild version of this bug — the secret was masked — precisely because sibling tests in the same batch referenced `ACTUAL_PASSWORD` and the mask is run-wide. Widening this check to the same scope would reproduce that accident: the check would pass because of a neighbouring test, and the reader would have no way to tell an intended secret from a guessed one.
+
+Setup steps carry their own text and are checked identically. An `auth.steps` journey runs through the same executor with the recipe's step as the step text, so a recipe naming its own placeholder is unaffected.
+
+### D5: Same choke point, same cost
+
+The check joins `unsourcedValueRefusal`, ahead of the exemption it qualifies. One decision site, one retry accounting, no new counter — the reasoning in `refuse-an-invented-value` D1 and D7 applies unchanged.
+
+### D6: The message must not teach the attack
+
+The existing refusal quotes the offending value, which is safe here — the placeholder is not the secret. But it must not read as *try a different variable*. It names what the step references, and offers the two legitimate exits: use a value the step supplies, or fail the step because it supplies none.
+
+### D7: The invariant this restores
+
+**A substituted value is always a masked value.** It holds today only by coincidence of scope; after this change it holds by construction, because a step that names a variable is a step `buildRunMask` registered from.
+
+Worth stating in the spec rather than leaving as an emergent property, since the two mechanisms sit in different files and neither currently says it depends on the other.
+
+## Rejected alternatives
+
+- **A1 Check the mask instead** — "refuse a value whose expansion the mask does not know". Equivalent in effect today and cheaper to state, but it couples the executor to the mask's contents and expresses the wrong intent: the question is whether the *test* asked for this secret, not whether some other test did.
+- **A2 Widen to any step in the test or the suite** — recreates the run-wide accident that disguised the defect (D4).
+- **A3 Drop the exemption entirely** — refuses every authenticated test; this is what `refuse-an-invented-value` D3 correctly rejected.
+- **A4 Register the model's variable into the mask on the fly** — removes the leak and keeps the wrong behaviour: a secret still gets typed into a field the author never pointed at, now invisibly. Treats the symptom that makes it findable.
+- **A5 Warn instead of refusing** — a warning next to a typed credential is a report of something that already happened.
+
+## Risks / Trade-offs
+
+- **A suite whose steps do not name their variables now fails.** No such suite can have worked as intended, since an unnamed variable is one nobody pointed at that field. Released as a minor.
+- **Two copies of the step string per instance** (verbatim and normalised). Bounded by the step, discarded with it (D3).
+- **This does not stop a secret being typed into the wrong *field*.** A step naming `{{env.PASSWORD}}` consents to that secret in that step; which control receives it is the resolver's business, and #60's.
+- **`auth.headers` and `auth.cookies` are untouched**, since neither passes through the executor's value path. Their placeholders are resolved and masked at the auth boundary.
+
+## Migration Plan
+
+No migration for a suite that names the variables it uses — the shape every documented example and every shipped test already follows. A suite relying on the model to supply a variable name starts failing, which is the defect.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/env-placeholder-must-be-named/proposal.md
+++ b/openspec/changes/env-placeholder-must-be-named/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: env-placeholder-must-be-named
+
+## Why
+
+0.14.0 refuses a `fill`/`select` value the model cannot trace to the step, the pages it was shown, or a value it already typed. One thing is exempt unconditionally — an `{{env.*}}` placeholder (`src/runner/recovery.ts:215`).
+
+The exemption is necessary: substitution happens after the check, so a placeholder is all there is to see, and the masked page shows `***` where the secret is. Treating it as ordinary text would refuse every authenticated test.
+
+But it asks the wrong question. It asks *is this a placeholder?* when what makes one legitimate is *did the test point this secret here?* Nothing checks the second, so the model can name a variable no step mentioned and the runner substitutes it. An adversarial pass against Actual Budget with `blastproof@0.14.0` did exactly that: given `fill the Password field` with no value, the model supplied `{{env.ACTUAL_PASSWORD}}` itself, and the real password was typed.
+
+Worse than it looks. The secrets mask is built from the variables **referenced** in the config and the parsed tests (`src/commands/run.ts:156-164`) — and only those. A variable set in the environment but named by no step is never registered, so nothing redacts it. Verified end to end: the value is typed into the page and comes back in the next snapshot handed to the model, unredacted. The placeholder exemption can defeat the secrets mask, which is the guarantee `run-wide-secret-mask` exists to provide. Issue #66.
+
+## What Changes
+
+A value may reference an `{{env.*}}` variable only when the step being executed references that same variable. A value naming any variable the step does not is refused at the same choke point, with the same retry cost.
+
+The check reuses `referencedEnvVars` from `runner/env.ts` — the function that already decides what a placeholder is for substitution and for masking — replacing the second, subtly different regex in `recovery.ts`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agentic-execution`: an `{{env.*}}` placeholder is admissible only when the step names that variable, so a substituted value is always one the test asked for and the mask knows
+
+## Impact
+
+- New dependencies: **none**
+- Affects: `src/runner/recovery.ts`, `tests/`, README, `docs/auth.md`
+- **Not additive**: a suite whose steps do not name the variables their values reference now fails. No such suite can have worked as intended — an unnamed variable is one the author never pointed at that field — but it is a behaviour change, so a minor bump
+
+## Non-goals
+
+- No change to how substitution or masking work; this narrows what reaches them
+- No registration of a model-supplied variable into the mask on the fly — that hides the leak while still typing a secret the author never pointed there
+- No widening to "any step in the test" or "any step in the suite". Run-wide scope is exactly what disguised this defect in the run that found it
+- No change to `auth.headers`/`auth.cookies`, which never pass through the executor's value path

--- a/openspec/changes/env-placeholder-must-be-named/specs/agentic-execution/spec.md
+++ b/openspec/changes/env-placeholder-must-be-named/specs/agentic-execution/spec.md
@@ -1,0 +1,62 @@
+# Spec delta: agentic-execution (env-placeholder-must-be-named)
+
+## MODIFIED Requirements
+
+### Requirement: A typed value must come from the test or the application
+The executor SHALL NOT perform a `fill` or `select` whose value is traceable to none of: an `{{env.*}}` placeholder the step being executed references, the text of that step, any accessibility snapshot shown to the model during that step, or a value the model already typed successfully in that step. The attempt SHALL be refused rather than performed, the refusal SHALL be returned to the model as that action's result together with the sources it may draw from, and it SHALL count as one failed attempt against the existing per-step retry budget.
+
+A value SHALL be refused when it references any `{{env.*}}` variable the step does not reference, whatever else the value contains. Variable names SHALL be compared exactly, without case folding, since two names differing only by case are two different variables. What counts as a referenced variable SHALL be decided by the same rule that governs substitution and masking, so that a value cannot be substituted under one definition of a placeholder and admitted under another.
+
+A value referencing only variables the step names SHALL be admitted without any text comparison, since substitution happens after this point and a masked value could match neither the step nor the page.
+
+Comparison of all other values SHALL be made against the **masked** snapshot text — what the model was actually shown — and SHALL be case-insensitive with runs of whitespace collapsed. No further normalization SHALL be applied.
+
+The record of snapshots and typed values SHALL be scoped to the step and reset at every step boundary. The set of referenced variables SHALL be taken from the step being executed alone, not from other steps of the test or of the run.
+
+This requirement SHALL apply regardless of the language a step is written in, because it compares text rather than parsing grammar. It does not replace the authoring warning, which predicts the same defect before a run at the cost of being English-only.
+
+`press` and `navigate` SHALL NOT be refused by this rule: a `press` value is a key name rather than free text, and a `navigate` value is already constrained by the trust boundary.
+
+#### Scenario: An invented value is refused
+- **WHEN** the step is `fill the note field` and the model proposes a `fill` with a value appearing in neither the step nor any snapshot shown
+- **THEN** the fill is not performed, the model is told it was refused and which sources it may use, and one failed attempt is spent
+
+#### Scenario: A placeholder the step never named is refused
+- **WHEN** the step is `fill the Password field`, naming no variable, and the model proposes `{{env.ACTUAL_PASSWORD}}`
+- **THEN** the fill is refused, because a variable the step does not reference is one the test never pointed at that field
+
+#### Scenario: A placeholder the step named is performed
+- **WHEN** the step is `fill the Password field with {{env.TEST_PASSWORD}}` and the model proposes that placeholder
+- **THEN** the fill is performed and substitution proceeds, without any text comparison
+
+#### Scenario: A substituted value is always a masked value
+- **WHEN** a value is admitted because the step references its variables
+- **THEN** those variables were registered for masking from that same step text, so no substituted value can reach a prompt or a report unredacted
+
+#### Scenario: Variable names are compared exactly
+- **WHEN** the step references `{{env.TOKEN}}` and the model proposes `{{env.token}}`
+- **THEN** the fill is refused, because they name different variables
+
+#### Scenario: A value embedding a placeholder is judged by the same rule
+- **WHEN** a value contains a placeholder alongside other text, such as `Bearer {{env.TOKEN}}`
+- **THEN** its variables are subject to the same requirement as a value that is only a placeholder
+
+#### Scenario: A value read from a page earlier in the step is performed
+- **WHEN** the model is shown an order number on one page, navigates to another, and types that order number
+- **THEN** the fill is performed, because the value appeared in a snapshot shown during this step
+
+#### Scenario: Case and spacing differences are not inventions
+- **WHEN** the step names `Order not received` and the model types `order not  received`
+- **THEN** the fill is performed
+
+#### Scenario: A value the model already typed may be typed again
+- **WHEN** a submit is answered by a redirect that empties the form, and the model re-types the value it used earlier in the step
+- **THEN** the fill is performed, because that value passed this check when it was first typed
+
+#### Scenario: The record does not cross steps
+- **WHEN** a later step types a value that appeared only in an earlier step's snapshot
+- **THEN** it is refused, because the record is scoped to a single step
+
+#### Scenario: Refusal cannot loop
+- **WHEN** the model keeps proposing values it cannot source
+- **THEN** the failed attempts accumulate and the step fails on the existing retry budget

--- a/openspec/changes/env-placeholder-must-be-named/tasks.md
+++ b/openspec/changes/env-placeholder-must-be-named/tasks.md
@@ -1,24 +1,41 @@
 # Tasks: env-placeholder-must-be-named
 
 ## 1. One definition of a placeholder
-- [ ] 1.1 Delete `ENV_PLACEHOLDER` from `src/runner/recovery.ts` and use `referencedEnvVars` from `src/runner/env.ts` instead (D2). Nothing else in the codebase should carry a second rule for what a placeholder is.
-- [ ] 1.2 Unit tests pinning the cases the old regex disagreed on: `{{ env.TOKEN }}` with internal spaces, and `Bearer {{env.TOKEN}}` embedding one, are now judged by the same rule as a bare placeholder.
+- [x] 1.1 Delete `ENV_PLACEHOLDER` from `src/runner/recovery.ts` and use `referencedEnvVars` from `src/runner/env.ts` instead (D2). Nothing else in the codebase should carry a second rule for what a placeholder is.
+- [x] 1.2 Unit tests pinning the cases the old regex disagreed on: `{{ env.TOKEN }}` with internal spaces, and `Bearer {{env.TOKEN}}` embedding one, are now judged by the same rule as a bare placeholder.
 
 ## 2. The check
-- [ ] 2.1 Keep the step verbatim on `StepRecovery` alongside the normalised copy (D3), so variable names are compared without case folding.
-- [ ] 2.2 In `unsourcedValueRefusal`, refuse when the value references any variable the step does not — ahead of the exemption it qualifies (D1, D5). A value referencing only named variables stays exempt from the text comparison.
-- [ ] 2.3 The message names what the step references and offers the two legitimate exits, without reading as an invitation to try another variable (D6).
-- [ ] 2.4 Unit tests: a placeholder the step names passes; one it does not is refused; `{{env.TOKEN}}` vs `{{env.token}}` is refused; a value naming two variables needs both; a fresh instance does not inherit the previous step's variables.
+- [x] 2.1 Keep the step verbatim on `StepRecovery` alongside the normalised copy (D3), so variable names are compared without case folding.
+- [x] 2.2 In `unsourcedValueRefusal`, refuse when the value references any variable the step does not — ahead of the exemption it qualifies (D1, D5). A value referencing only named variables stays exempt from the text comparison.
+- [x] 2.3 The message names what the step references and offers the two legitimate exits, without reading as an invitation to try another variable (D6).
+- [x] 2.4 Unit tests: a placeholder the step names passes; one it does not is refused; `{{env.TOKEN}}` vs `{{env.token}}` is refused; a value naming two variables needs both; a fresh instance does not inherit the previous step's variables.
 
 ## 3. End to end
-- [ ] 3.1 Executor test reproducing #66: step `fill the Password field` naming no value, model proposes `{{env.ACTUAL_PASSWORD}}`, refused rather than typed — and the real value never reaches the page.
-- [ ] 3.2 A regression test for the leak itself (D7): a variable set in the environment but named by no step is refused, so no unmasked secret can reach a prompt. This is the property the issue was really about and it should fail loudly if the check is ever loosened.
-- [ ] 3.3 Confirm an `auth.steps` login journey is unaffected — the recipe's own step names its placeholder (D4).
+- [x] 3.1 Executor test reproducing #66: step `fill the Password field` naming no value, model proposes `{{env.ACTUAL_PASSWORD}}`, refused rather than typed — and the real value never reaches the page.
+- [x] 3.2 A regression test for the leak itself (D7): a variable set in the environment but named by no step is refused, so no unmasked secret can reach a prompt. This is the property the issue was really about and it should fail loudly if the check is ever loosened.
+- [x] 3.3 Confirm an `auth.steps` login journey is unaffected — the recipe's own step names its placeholder (D4).
 
 ## 4. Docs
-- [ ] 4.1 README, beside the value rule: a placeholder counts as a source only when the step names it, and why.
-- [ ] 4.2 `docs/auth.md`: the same, where `{{env.*}}` is introduced as the only way to reference a credential. CHANGELOG is written at release time, not here.
+- [x] 4.1 README, beside the value rule: a placeholder counts as a source only when the step names it, and why.
+- [x] 4.2 `docs/auth.md`: the same, where `{{env.*}}` is introduced as the only way to reference a credential. CHANGELOG is written at release time, not here.
 
 ## 5. Verification
-- [ ] 5.1 `npm run build`, `npm run typecheck`, `npm test` green.
-- [ ] 5.2 Against `examples/demo-app` with a real model: the login test, whose step names `{{env.*}}`, still passes; and a step naming no value is refused rather than filled with a guessed placeholder. Both halves, as in `refuse-an-invented-value` — the second proves the fix, the first proves it did not break authentication.
+- [x] 5.1 `npm run build`, `npm run typecheck`, `npm test` green.
+- [x] 5.2 Against `examples/demo-app` with a real model: the login test, whose step names `{{env.*}}`, still passes; and a step naming no value is refused rather than filled with a guessed placeholder. Both halves, as in `refuse-an-invented-value` — the second proves the fix, the first proves it did not break authentication.
+
+  **Measured** (`anthropic/claude-haiku-4.5` via OpenRouter, against `examples/demo-app`).
+  A login whose steps name `{{env.TEST_EMAIL}}` and `{{env.TEST_PASSWORD}}` scores **100**, with both
+  placeholders passed through unresolved to the runner and substituted at the keystroke — the
+  regression risk that mattered, since this change touches the path every authenticated suite uses.
+
+  The refusal half did **not** reproduce with a live model here, and the reason is worth recording
+  rather than retrying until it did. Asked to `fill the password field` with no value, the model
+  typed `demo123` — and was correctly allowed, because the demo app's login page displays
+  `demo@blastproof.dev / demo123` on screen as a hint. The value genuinely came from the page. That
+  is the check working, not a bypass, but it means this application cannot stage the guessed-variable
+  case: there is no field here whose value the page withholds.
+
+  The refusal is therefore pinned deterministically instead, in `tests/executor.test.ts`. Both of
+  those tests were confirmed to fail with the new condition disabled and pass with it enabled, so
+  they are load-bearing rather than decorative. A live reproduction needs an application that hides
+  its credentials — the Actual Budget run in #66 is that application, and its report is the evidence.

--- a/openspec/changes/env-placeholder-must-be-named/tasks.md
+++ b/openspec/changes/env-placeholder-must-be-named/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: env-placeholder-must-be-named
+
+## 1. One definition of a placeholder
+- [ ] 1.1 Delete `ENV_PLACEHOLDER` from `src/runner/recovery.ts` and use `referencedEnvVars` from `src/runner/env.ts` instead (D2). Nothing else in the codebase should carry a second rule for what a placeholder is.
+- [ ] 1.2 Unit tests pinning the cases the old regex disagreed on: `{{ env.TOKEN }}` with internal spaces, and `Bearer {{env.TOKEN}}` embedding one, are now judged by the same rule as a bare placeholder.
+
+## 2. The check
+- [ ] 2.1 Keep the step verbatim on `StepRecovery` alongside the normalised copy (D3), so variable names are compared without case folding.
+- [ ] 2.2 In `unsourcedValueRefusal`, refuse when the value references any variable the step does not — ahead of the exemption it qualifies (D1, D5). A value referencing only named variables stays exempt from the text comparison.
+- [ ] 2.3 The message names what the step references and offers the two legitimate exits, without reading as an invitation to try another variable (D6).
+- [ ] 2.4 Unit tests: a placeholder the step names passes; one it does not is refused; `{{env.TOKEN}}` vs `{{env.token}}` is refused; a value naming two variables needs both; a fresh instance does not inherit the previous step's variables.
+
+## 3. End to end
+- [ ] 3.1 Executor test reproducing #66: step `fill the Password field` naming no value, model proposes `{{env.ACTUAL_PASSWORD}}`, refused rather than typed — and the real value never reaches the page.
+- [ ] 3.2 A regression test for the leak itself (D7): a variable set in the environment but named by no step is refused, so no unmasked secret can reach a prompt. This is the property the issue was really about and it should fail loudly if the check is ever loosened.
+- [ ] 3.3 Confirm an `auth.steps` login journey is unaffected — the recipe's own step names its placeholder (D4).
+
+## 4. Docs
+- [ ] 4.1 README, beside the value rule: a placeholder counts as a source only when the step names it, and why.
+- [ ] 4.2 `docs/auth.md`: the same, where `{{env.*}}` is introduced as the only way to reference a credential. CHANGELOG is written at release time, not here.
+
+## 5. Verification
+- [ ] 5.1 `npm run build`, `npm run typecheck`, `npm test` green.
+- [ ] 5.2 Against `examples/demo-app` with a real model: the login test, whose step names `{{env.*}}`, still passes; and a step naming no value is refused rather than filled with a guessed placeholder. Both halves, as in `refuse-an-invented-value` — the second proves the fix, the first proves it did not break authentication.

--- a/openspec/changes/env-placeholder-must-be-named/tasks.md
+++ b/openspec/changes/env-placeholder-must-be-named/tasks.md
@@ -39,3 +39,19 @@
   those tests were confirmed to fail with the new condition disabled and pass with it enabled, so
   they are load-bearing rather than decorative. A live reproduction needs an application that hides
   its credentials — the Actual Budget run in #66 is that application, and its report is the evidence.
+
+  **Staged live, by an adversarial pass against Actual Budget v26.8.1** (`claude-sonnet-4.6`), on the
+  unreleased build — the application that can withhold a credential, which `examples/demo-app` cannot.
+  This is the half the demo app could not verify, and it now has evidence:
+
+  - Test 10 (`fill the Password field`, no value), run **alone** with a config referencing no
+    environment variable at all — the configuration in which the leak was unmasked. The model proposed
+    `{{env.PASSWORD}}`, a name **nothing had shown it**, which is the hypothesis this change rests on.
+    Refused, not substituted. The model then gave up in one attempt, with an honest reason: it tried
+    no other variable name and no alternate control, so the message does not read as an invitation
+    (D6 held).
+  - The full nine-test suite with an `auth:` recipe: **zero refusals**, six legitimate
+    `{{env.ACTUAL_PASSWORD}}` fills accepted and substituted. No authored step was refused anywhere.
+    That was the P0 risk — a false refusal here would break every authenticated suite, which is worse
+    than the defect being fixed.
+

--- a/src/runner/recovery.ts
+++ b/src/runner/recovery.ts
@@ -1,4 +1,5 @@
 import type { AgentAction } from '../llm/schemas.js';
+import { referencedEnvVars } from './env.js';
 
 /**
  * The actions that commit — the point at which a side effect lands in the
@@ -36,8 +37,27 @@ const COMMIT_KEYS: ReadonlySet<string> = new Set(['Enter', 'NumpadEnter', ' ', '
  */
 const SOURCED_VALUE_ACTIONS: ReadonlySet<string> = new Set(['fill', 'select']);
 
-/** A value the model must pass through untouched; substitution happens later. */
-const ENV_PLACEHOLDER = /^\s*\{\{env\.[A-Za-z_][A-Za-z0-9_]*\}\}\s*$/;
+/**
+ * Whether every `{{env.*}}` variable `value` references is one `step` references
+ * (design env-placeholder-must-be-named, D1).
+ *
+ * `referencedEnvVars` is deliberately the same function that decides what gets
+ * substituted and what gets registered for masking (D2). This file used to carry
+ * its own regex, and the two had already drifted: `{{ env.TOKEN }}` and
+ * `Bearer {{env.TOKEN}}` are substituted by one and were not recognised by the
+ * other. A value must not be able to expand under one definition of a
+ * placeholder and be admitted under a different one.
+ *
+ * Names are compared exactly. Case is presentation for a typed value and is
+ * normalised away everywhere else here, but `TOKEN` and `token` are two
+ * variables holding two different secrets, so folding them together in the one
+ * place that decides which secret gets typed would be a bug wearing a
+ * convenience.
+ */
+function referencesOnlyNamedVars(value: string, step: string): boolean {
+  const named = new Set(referencedEnvVars(step));
+  return referencedEnvVars(value).every((name) => named.has(name));
+}
 
 /**
  * Case and spacing are presentation, so they are normalised away before any
@@ -123,8 +143,17 @@ export class StepRecovery {
    * step — which is also the whole of the "does not cross steps" rule.
    */
   private readonly readable: string[];
+  /**
+   * The step exactly as written, for deciding which `{{env.*}}` variables it
+   * names (design env-placeholder-must-be-named, D3). Kept alongside the
+   * normalised copy rather than derived from it: `readable` is lowercased, and
+   * environment variable names are case-sensitive, so `TOKEN` and `token` must
+   * stay distinguishable in the one place that decides which secret gets typed.
+   */
+  private readonly step: string;
 
   constructor(step: string) {
+    this.step = step;
     this.readable = [normalise(step)];
   }
 
@@ -208,11 +237,28 @@ export class StepRecovery {
     if (!SOURCED_VALUE_ACTIONS.has(action.action)) return undefined;
     const value = action.value;
     if (!value) return undefined;
-    // Checked before any comparison: substitution happens inside `performAction`,
-    // after this point, so the placeholder is all there is to see — and a masked
-    // value could match neither the step nor the page, so treating it as
-    // unsourced would refuse every authenticated test (D3).
-    if (ENV_PLACEHOLDER.test(value)) return undefined;
+    // A variable the step never names is one the test never pointed at this
+    // field, whatever else the value contains (design
+    // env-placeholder-must-be-named, D1). Checked first and separately from the
+    // exemption below, because this is the half the original design missed: it
+    // asked whether a value was a placeholder, when what makes one legitimate is
+    // whether the test asked for that secret. A model that produces a variable
+    // name nobody showed it guessed, and the guess is what gets refused.
+    if (!referencesOnlyNamedVars(value, this.step)) {
+      const named = referencedEnvVars(this.step);
+      return (
+        `refused: the value "${value}" was NOT typed, because this step does not reference that {{env.*}} ` +
+        `variable. ${named.length > 0 ? `This step references ${named.map((n) => `{{env.${n}}}`).join(', ')}.` : 'This step references no environment variable.'} ` +
+        `A placeholder is a source only when the step names it — otherwise the test never asked for that secret ` +
+        `to be typed here. Use a value this step supplies, or fail the step and say it supplies none.`
+      );
+    }
+    // Now the exemption, and only now: substitution happens inside
+    // `performAction`, after this point, so the placeholder is all there is to
+    // see — and a masked value could match neither the step nor the page, so
+    // comparing it as text would refuse every authenticated test
+    // (refuse-an-invented-value, D3).
+    if (referencedEnvVars(value).length > 0) return undefined;
     const needle = normalise(value);
     if (needle === '') return undefined;
     if (this.readable.some((source) => source.includes(needle))) return undefined;

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -1294,7 +1294,9 @@ describe('executeTest recovery containment', () => {
 
     await executeTest(
       page,
-      makeTest(),
+      // Names the variable it uses: a step that named none would now be refused
+      // for that instead (#66), and this test is about the unresolved record.
+      makeTest({ steps: ['sign in with {{env.PW}}'] }),
       baseOptions(brain, {
         resolveValue: (v) => v.replace('{{env.PW}}', 's3cret'),
         mask: (s) => s.replaceAll('s3cret', '***'),
@@ -1332,6 +1334,104 @@ describe('executeTest recovery containment', () => {
     expect(secondTurn?.stepHistory).toHaveLength(1);
     expect(JSON.stringify(secondTurn?.stepHistory)).not.toContain('s3cret');
     expect(secondTurn?.stepHistory?.[0]?.action).toContain('***');
+  });
+});
+
+describe('executeTest refuses a placeholder the step never named (#66)', () => {
+  const fillPw = (value: string): AgentAction => ({
+    action: 'fill',
+    target: { role: 'textbox', name: 'Password' },
+    value,
+    reasoning: 'type',
+  });
+
+  it('reproduces the adversarial case: the secret is never typed', async () => {
+    const page = new FakePage();
+    page.visible.add('role:textbox|Password');
+    // The step names no value. Facing that, the model supplied the placeholder
+    // itself — and 0.14.0 exempted it, so the real password was typed.
+    const brain = scriptedBrain([fillPw('{{env.ACTUAL_PASSWORD}}'), { action: 'fail', reasoning: 'gave up' }], []);
+    const events: ExecutorEvent[] = [];
+
+    const result = await executeTest(
+      page,
+      makeTest({ steps: ['fill the Password field'] }),
+      baseOptions(brain, {
+        snapshot: async () => '- textbox "Password"',
+        resolveValue: (v) => v.replace('{{env.ACTUAL_PASSWORD}}', 'testpass123'),
+        onEvent: (e) => events.push(e),
+      }),
+    );
+
+    expect(result.status).toBe('failed');
+    expect(page.calls.filter((c) => c.startsWith('fill'))).toHaveLength(0);
+    expect(JSON.stringify(page.calls)).not.toContain('testpass123');
+    expect(events.filter((e) => e.type === 'action' && e.result.startsWith('refused:'))).toHaveLength(1);
+  });
+
+  it('is what keeps a substituted value always a masked value', async () => {
+    // The property the issue was really about. buildRunMask registers only the
+    // variables the config and the parsed tests reference, so a variable that is
+    // set but named by no step would be substituted and NOT redacted — reaching
+    // the model's next prompt and the run's artifacts in the clear. Verified
+    // before the fix; this pins that it cannot come back.
+    const page = new FakePage();
+    page.visible.add('role:textbox|Search');
+    const leak = (value: string): AgentAction => ({
+      action: 'fill',
+      target: { role: 'textbox', name: 'Search' },
+      value,
+      reasoning: 'type',
+    });
+    // Records what the model is actually shown, so the assertion below is about
+    // the prompt rather than about a list nobody filled.
+    const prompts: string[] = [];
+    const script: AgentAction[] = [leak('{{env.STRIPE_KEY}}'), { action: 'fail', reasoning: 'gave up' }];
+    let turn = 0;
+    const brain: AgentBrain = {
+      async nextAction(input): Promise<AgentAction> {
+        prompts.push(input.snapshot);
+        return script[turn++]!;
+      },
+      async judge(): Promise<AssertJudgment> {
+        throw new Error('no judgment expected');
+      },
+    };
+
+    await executeTest(
+      page,
+      // No step anywhere names STRIPE_KEY, so no mask would ever know its value.
+      makeTest({ steps: ['fill the search box'] }),
+      baseOptions(brain, {
+        // A text input shows what was typed into it, as a real a11y tree does.
+        snapshot: async () =>
+          `- textbox "Search" [${(page.calls.find((c) => c.startsWith('fill ')) ?? '=').split('=')[1]}]`,
+        resolveValue: (v) => v.replace('{{env.STRIPE_KEY}}', 'sk-live-abc123'),
+        onEvent: () => {},
+      }),
+    );
+
+    expect(page.calls.filter((c) => c.startsWith('fill'))).toHaveLength(0);
+    expect(JSON.stringify(prompts)).not.toContain('sk-live-abc123');
+  });
+
+  it('leaves an authenticated step that names its variable alone', async () => {
+    const page = new FakePage();
+    page.visible.add('role:textbox|Password');
+    const brain = scriptedBrain([fillPw('{{env.TEST_PASSWORD}}'), { action: 'done', reasoning: 'typed' }], []);
+
+    const result = await executeTest(
+      page,
+      makeTest({ steps: ['fill the Password field with {{env.TEST_PASSWORD}}'] }),
+      baseOptions(brain, {
+        snapshot: async () => '- textbox "Password"',
+        resolveValue: (v) => v.replace('{{env.TEST_PASSWORD}}', 'sealed'),
+        mask: (t) => t.replaceAll('sealed', '***'),
+      }),
+    );
+
+    expect(result.status).toBe('passed');
+    expect(page.calls).toContain('fill role:textbox|Password=sealed');
   });
 });
 
@@ -1469,13 +1569,58 @@ describe('StepRecovery unsourced values', () => {
     expect(recovery.refusalFor(fill('#BP-1001'))).toBeUndefined();
   });
 
-  it('allows an {{env.*}} placeholder without comparing anything', () => {
+  it('allows an {{env.*}} placeholder the step names, without comparing anything', () => {
     // Substitution happens after this point, so the placeholder is all there is
     // to see — and a masked value matches neither step nor page, so treating it
     // as unsourced would refuse every authenticated test (design D3).
-    const recovery = new StepRecovery('fill the password field');
+    const recovery = new StepRecovery('fill the password field with {{env.TEST_PASSWORD}}');
     recovery.observe('- textbox "Password"');
     expect(recovery.refusalFor(fill('{{env.TEST_PASSWORD}}'))).toBeUndefined();
+  });
+
+  it('refuses a placeholder the step never named', () => {
+    // This test asserted the opposite until #66. The original read the exemption
+    // as "a placeholder is always sourced", which let a model facing a valueless
+    // step supply {{env.ACTUAL_PASSWORD}} itself — and the real password was
+    // typed into a field the test never pointed a secret at.
+    const recovery = new StepRecovery('fill the Password field');
+    recovery.observe('- textbox "Password"');
+    const refusal = recovery.refusalFor(fill('{{env.ACTUAL_PASSWORD}}'));
+    expect(refusal).toContain('refused:');
+    expect(refusal).toContain('does not reference that {{env.*}} variable');
+    // Says what the step does reference, rather than inviting another guess.
+    expect(refusal).toContain('references no environment variable');
+  });
+
+  it('compares variable names exactly, because case names a different secret', () => {
+    const recovery = new StepRecovery('fill the field with {{env.TOKEN}}');
+    expect(recovery.refusalFor(fill('{{env.TOKEN}}'))).toBeUndefined();
+    expect(recovery.refusalFor(fill('{{env.token}}'))).toBeDefined();
+  });
+
+  it('judges an embedded or spaced placeholder by the same rule as a bare one', () => {
+    // recovery.ts used to carry its own regex, which recognised neither of these
+    // while env.ts substituted both (#66, design D2). One definition now.
+    const named = new StepRecovery('send {{env.TOKEN}} as the bearer token');
+    expect(named.refusalFor(fill('Bearer {{env.TOKEN}}'))).toBeUndefined();
+    expect(named.refusalFor(fill('{{ env.TOKEN }}'))).toBeUndefined();
+
+    const unnamed = new StepRecovery('send the bearer token');
+    expect(unnamed.refusalFor(fill('Bearer {{env.TOKEN}}'))).toBeDefined();
+    expect(unnamed.refusalFor(fill('{{ env.TOKEN }}'))).toBeDefined();
+  });
+
+  it('requires every variable a value references, not just one of them', () => {
+    const recovery = new StepRecovery('sign in with {{env.USER}}');
+    expect(recovery.refusalFor(fill('{{env.USER}}'))).toBeUndefined();
+    expect(recovery.refusalFor(fill('{{env.USER}}:{{env.PASS}}'))).toBeDefined();
+  });
+
+  it('does not inherit the previous step\'s variables', () => {
+    const first = new StepRecovery('fill the password with {{env.PW}}');
+    expect(first.refusalFor(fill('{{env.PW}}'))).toBeUndefined();
+    const second = new StepRecovery('fill the confirmation field');
+    expect(second.refusalFor(fill('{{env.PW}}'))).toBeDefined();
   });
 
   it('treats case and spacing as presentation, not invention', () => {


### PR DESCRIPTION
Closes #66. Found by an adversarial pass against Actual Budget with the published `blastproof@0.14.0` — the first external test aimed at 0.14.0's flagship guarantee, and it went through it.

## The hole, and it is mine

`refuse-an-invented-value` exempted any well-formed `{{env.*}}` from the sourcing check:

```ts
if (ENV_PLACEHOLDER.test(value)) return undefined;
```

The exemption is necessary — substitution happens after the check and the masked page shows `***`, so comparing a placeholder as text would refuse every authenticated test. That reasoning is in D3 of that change and it is correct.

It just answers the wrong question. It asks *"is this a placeholder?"* when what makes a placeholder legitimate is *"did the test point this secret here?"* Given `fill the Password field` with no value, the model supplied `{{env.ACTUAL_PASSWORD}}` itself, nothing refused it, and the real password was typed into a field nobody aimed a secret at.

## Worse than a bypass: it defeats the mask

The secrets mask registers the variables **referenced** in the config and the parsed tests (`run.ts:156-164`), and only those. A variable that is set but named by no step is never registered, so nothing redacts it.

Verified end to end before the fix: the value is typed into the page **and comes back in the next snapshot handed to the model, unredacted**. That is a live credential entering a prompt and the run's artifacts — a hole in `run-wide-secret-mask`, reached through the value check.

The adversarial run only saw the mild version because sibling tests in the same batch happened to reference `ACTUAL_PASSWORD`, and the mask is run-wide. Run that test alone and nothing masks anything.

## The rule

A value may reference only `{{env.*}}` variables that **its own step** references. Checked before the exemption it qualifies.

The model cannot know the name of a variable nobody showed it. If it produces one, it guessed — and a guess is what the surrounding change exists to refuse.

Scoped to the current step deliberately, not the test or the suite: run-wide scope is precisely the accident that disguised this defect.

## Two details that would have been bugs

**Names compare exactly.** `readable` is lowercased, because case is presentation for a typed value. Variable names are not: `TOKEN` and `token` are two different secrets. So the step is kept verbatim alongside the normalised copy, and `{{env.token}}` on a step naming `TOKEN` is refused. Pinned by a test.

**There were two definitions of "a placeholder", and they disagreed.** `recovery.ts` had its own regex; `env.ts` has the one that governs substitution *and* masking. Measured:

| value | `env.ts` substitutes | old `recovery.ts` recognised |
|---|:--:|:--:|
| `{{env.TOKEN}}` | yes | yes |
| `{{ env.TOKEN }}` | yes | **no** |
| `Bearer {{env.TOKEN}}` | yes | **no** |

A value must not be able to expand under one definition and be admitted under another. `referencedEnvVars` is now the only rule, which also removes a #45-shaped drift.

## Verification

**Deterministic.** 524 tests green, typecheck clean. The two tests that matter — the adversarial reproduction, and the leak property itself — were confirmed to **fail with the new condition disabled and pass with it enabled**, so they are load-bearing rather than decorative.

**Live** (`claude-haiku-4.5`, `examples/demo-app`). A login whose steps name `{{env.TEST_EMAIL}}` and `{{env.TEST_PASSWORD}}` scores **100**, placeholders passed through unresolved and substituted at the keystroke. That is the regression risk that mattered, since this touches the path every authenticated suite uses.

The refusal half did **not** reproduce live, and the reason is recorded in `tasks.md` rather than retried until it did: asked to `fill the password field`, the model typed `demo123` and was correctly allowed, because the demo app's login page *displays* `demo@blastproof.dev / demo123` as a hint. The value really did come from the page. This application cannot stage the guessed-variable case — it has no field whose value the page withholds. Staging it live needs an app that hides its credentials, which is what #66's report used.

## Test changes worth reading

One existing test asserted the defect:

```ts
it('allows an {{env.*}} placeholder without comparing anything', ...)
//   step: 'fill the password field'   ← names no variable
//   value: '{{env.TEST_PASSWORD}}'    ← admitted
```

I wrote that in #57. It encoded "a placeholder is always sourced" as intended behaviour. It is now the pair it should always have been: one test for a placeholder the step names, one for a placeholder it does not.

## Not additive

A suite whose steps do not name the variables their values reference now fails. No such suite can have worked as intended — an unnamed variable is one the author never pointed at that field — but it is a behaviour change, so **minor, not patch**.

## OpenSpec

`openspec/changes/env-placeholder-must-be-named/` — proposal, design (D1–D7, five rejected alternatives) and the `agentic-execution` delta, which now states the invariant explicitly: *a substituted value is always a masked value.* It held by coincidence of scope before; it holds by construction now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)