### PR TITLE
test: assert every action.yml input maps to a flag the CLI accepts

### DIFF
--- a/tests/action-manifest.test.ts
+++ b/tests/action-manifest.test.ts
@@ -1,10 +1,39 @@
-import { readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { access, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { promisify } from 'node:util';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
+const run = promisify(execFile);
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cli = path.join(root, 'dist', 'cli.js');
+
+// Inputs the action handles itself; they never reach the CLI as anything.
+// `command` picks the subcommand, `version` pins the npm install, `install-browser`
+// gates a playwright step, `working-directory` is a step field, and `api-key`
+// lands in an environment variable the config points at by name.
+const wrapperInputs = ['command', 'version', 'install-browser', 'working-directory', 'api-key'];
+
+// Inputs the CLI reads from the environment rather than from a flag. The
+// allowlist is not a free pass: each one is checked against the env: block below.
+const envMappedInputs: Record<string, string> = {
+  provider: 'BLASTPROOF_LLM_PROVIDER',
+  model: 'BLASTPROOF_LLM_MODEL',
+  'llm-base-url': 'BLASTPROOF_LLM_BASE_URL',
+  url: 'BLASTPROOF_BASE_URL',
+};
+
+async function optionsOf(command: string): Promise<string[]> {
+  const { stdout } = await run(process.execPath, [cli, command, '--help']);
+  // commander indents an option by exactly two spaces and wraps its description
+  // deeper, so this reads the flags and never a `--flag` named in prose.
+  return stdout
+    .split('\n')
+    .map((line) => /^ {2}(--[a-z0-9-]+)/.exec(line)?.[1])
+    .filter((flag): flag is string => flag !== undefined);
+}
 
 describe('action.yml', () => {
   it('parses as YAML', async () => {
@@ -36,5 +65,60 @@ describe('action.yml', () => {
       .split('\n')
       .filter((line) => /description:/.test(line) && /\$\{\{/.test(line));
     expect(offending).toEqual([]);
+  });
+
+  describe('every input maps to something the CLI accepts', () => {
+    let manifest: { inputs: Record<string, unknown> };
+    let script: string;
+    let envBlock: string;
+    let flags: Set<string>;
+
+    beforeAll(async () => {
+      const raw = await readFile(path.join(root, 'action.yml'), 'utf8');
+      manifest = parse(raw) as { inputs: Record<string, unknown> };
+      script = raw.slice(raw.indexOf('runs:'));
+      const envStart = raw.indexOf('BLASTPROOF_ACTION_API_KEY');
+      envBlock = raw.slice(envStart, raw.indexOf('run: |', envStart));
+      await expect(
+        access(cli),
+        `${cli} is missing — run \`npm run build\` before the tests; this one reads the built CLI's --help`,
+      ).resolves.toBeUndefined();
+      const perCommand = await Promise.all(['run', 'test', 'plan'].map(optionsOf));
+      flags = new Set(perCommand.flat());
+    });
+
+    it('sends each flag-shaped input as a flag the CLI declares', () => {
+      const unmapped: string[] = [];
+      for (const input of Object.keys(manifest.inputs)) {
+        if (wrapperInputs.includes(input) || input in envMappedInputs) continue;
+        const flag = `--${input}`;
+        // The boundary matters: `args+=(--min-scores` contains `args+=(--min-score`,
+        // and a typo that passes for the wrong reason is worse than no test.
+        const sent = new RegExp(`args\\+=\\(${flag}(?![a-z0-9-])`).test(script);
+        if (!sent || !flags.has(flag)) unmapped.push(input);
+      }
+      expect(unmapped).toEqual([]);
+    });
+
+    it('passes each env-mapped input through the variable the CLI reads', () => {
+      const missing = Object.entries(envMappedInputs).filter(
+        ([input, variable]) => !envBlock.includes(`${variable}: \${{ inputs.${input} }}`),
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it('names every allowlisted input, so a removed input cannot hide there', () => {
+      const declared = Object.keys(manifest.inputs);
+      const stale = [...wrapperInputs, ...Object.keys(envMappedInputs)].filter(
+        (input) => !declared.includes(input),
+      );
+      expect(stale).toEqual([]);
+    });
+
+    it('passes no flag the CLI does not declare', () => {
+      const used = [...script.matchAll(/args\+=\((--[a-z0-9-]+)/g)].map(([, flag]) => flag ?? '');
+      expect(used.length).toBeGreaterThan(0);
+      expect(used.filter((flag) => !flags.has(flag))).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
Part of #30 — the **second shape only**. The other three are architecture decisions, yours to make, and I did not touch them.

Deliberately not `Closes #30`: three shapes in that issue are still undecided, and auto-closing would drop them off the backlog without anyone having decided them. Close it by hand once the release-time check, the publish-on-merge question and the unreleased-marker convention have been settled — or split them out and close it then.

## What it does

Reads the built CLI's `--help` for `run`, `test` and `plan`, and holds `action.yml` against it. Four assertions:

1. every flag-shaped input is actually sent as `args+=(--<input>` **and** exists in the CLI;
2. every env-mapped input travels in the variable the CLI reads;
3. every allowlisted input is still declared in the manifest;
4. no flag the composite script passes is unknown to the CLI.

## The allowlist is two categories, not one

This is the part your comment did not cover, and conflating them would be exactly the loose match you warned about:

- **Wrapper concerns** — `command`, `version`, `install-browser`, `working-directory`, `api-key`. These never reach the CLI as anything.
- **Env-mapped** — `provider`, `model`, `llm-base-url`, `url`. These *do* reach the CLI, as environment variables.

So the second list is not an exemption. Each entry is checked against the `env:` block, and assertion 3 fails if an allowlisted input stops being declared — a removed input cannot hide in either list.

## Mutation-checked before opening this

| mutation in `action.yml` | result |
|---|---|
| `--min-score` → `--min-scores` | fails (2 assertions) |
| input `min-score` renamed, script untouched | fails |
| `BLASTPROOF_LLM_MODEL` renamed | fails |
| input `url` removed | fails (2 assertions) |

The first one initially slipped past assertion 1 — `args+=(--min-score` is a substring of `args+=(--min-scores`. Fixed with a word boundary, then re-checked.

## Notes

- Test-only, no behaviour change, so **no change proposal** — as the issue says.
- Needs `npm run build` first, since it reads `dist/cli.js`. CI already builds before it tests; running `npm test` on a cold checkout gives an explicit "run `npm run build`" message rather than a confusing failure.
- `npm run typecheck` clean, `npm test` 528/528 across 31 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA4xaDa3dxWLWuMLPyZQGd
