### PR TITLE
Fix: mkdir before writeDraft and handle fs errors with PlannerError

### DIFF
--- a/src/planner.ts
+++ b/src/planner.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { stringify } from 'yaml';
 import type { PlannerBrain } from './llm/brain.js';
@@ -6,6 +6,7 @@ import type { GeneratedTest } from './llm/schemas.js';
 import type { PageLike } from './runner/actions.js';
 import { defaultSnapshot } from './runner/executor.js';
 import { TESTS_RELATIVE_DIR, type TestFile } from './runner/testfile.js';
+import { fsReason } from './report/errors.js';
 
 export class PlannerError extends Error {
   constructor(message: string) {
@@ -154,18 +155,23 @@ export async function writeDraft(
   draft: TestDraft,
   meta: ProvenanceMeta,
 ): Promise<string> {
-  const file = path.join(cwd, TESTS_RELATIVE_DIR, `${routeToSlug(meta.route)}.yaml`);
+  const dir = path.join(cwd, TESTS_RELATIVE_DIR);
+  const file = path.join(dir, `${routeToSlug(meta.route)}.yaml`);
   try {
+    await mkdir(dir, { recursive: true });
     // 'wx' fails if the file exists — atomic, so a concurrent write cannot slip through.
     await writeFile(file, renderTestYaml(draft, meta), { flag: 'wx' });
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'EEXIST' && err.syscall !== 'mkdir') {
       throw new PlannerError(
         `Refusing to overwrite ${path.relative(cwd, file)} (route ${meta.route}). ` +
           'Delete or rename it to regenerate.',
       );
     }
-    throw error;
+    throw new PlannerError(
+      `Cannot write draft to ${file}: ${fsReason(error)}. Check that ${path.dirname(file)} is a directory you can write to, not a file.`
+    );
   }
   return file;
 }

--- a/tests/planner.test.ts
+++ b/tests/planner.test.ts
@@ -259,6 +259,38 @@ describe('writeDraft', () => {
     );
     await expect(readFile(existing, 'utf8')).resolves.toContain('do not clobber me');
   });
+
+  it('creates the tests directory if it does not exist', async () => {
+    // dir is created by beforeEach, but not .blastproof/tests
+    const freshDir = await mkdtemp(path.join(tmpdir(), 'blastproof-write-fresh-'));
+    try {
+      const draft: TestDraft = { ...DRAFT, routes: ['/cart/discount'] };
+      const file = await writeDraft(freshDir, draft, { route: '/cart/discount', base: 'main' });
+      
+      expect(path.relative(freshDir, file)).toBe(path.join('.blastproof', 'tests', 'cart-discount.yaml'));
+      const parsed = await parseTestFile(file);
+      expect(parsed.routes).toEqual(['/cart/discount']);
+    } finally {
+      await rm(freshDir, { recursive: true, force: true });
+    }
+  });
+
+  it('wraps filesystem errors in PlannerError with path and remedy', async () => {
+    const freshDir = await mkdtemp(path.join(tmpdir(), 'blastproof-write-fail-'));
+    try {
+      // Create a file where the directory should be
+      const testsDir = path.join(freshDir, '.blastproof', 'tests');
+      await mkdir(path.join(freshDir, '.blastproof'));
+      await writeFile(testsDir, 'not a directory');
+
+      const draft: TestDraft = { ...DRAFT, routes: ['/cart'] };
+      await expect(writeDraft(freshDir, draft, { route: '/cart', base: 'main' })).rejects.toThrow(
+        /Cannot write draft to .*cart.yaml.*Check that .*tests is a directory you can write to, not a file./
+      );
+    } finally {
+      await rm(freshDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('coveredRoutes', () => {


### PR DESCRIPTION
Resolves #74

- Ensures that the \.blastproof/tests\ directory is created before attempting to write a test draft, fixing the \ENOENT\ issue when running \lastproof plan --write\ without an existing directory.
- Wraps unexpected filesystem errors from both directory creation and file writing in a \PlannerError\ with a standardized \sReason\ format and clear remedy (similar to \commands/init.ts\).
- Distinguishes between \mkdir\'s \EEXIST\ (which indicates a file conflict rather than a directory existing, handled by \sReason\) and \writeFile\'s \EEXIST\ (which is atomic protection against overwriting an existing test draft).