### PR TITLE
docs: cite the issue numbers the measurement produced

### DIFF
--- a/openspec/changes/agent-skill-install/notes-plan-quality.md
+++ b/openspec/changes/agent-skill-install/notes-plan-quality.md
@@ -58,14 +58,14 @@ each step name a control and an outcome that exist on the page.
 
 ## Defects found
 
-1. `plan --write` does not create `.blastproof/tests/`. `writeDraft`
+1. **#74** — `plan --write` does not create `.blastproof/tests/`. `writeDraft`
    (`src/planner.ts:152`) handles `EEXIST` but not `ENOENT`, and the raw Node
    error with an absolute path reaches the user — below the standard `AGENTS.md`
    sets for the prerequisite boundary.
-2. A write failure aborts the whole run. The draft already generated for an
+2. **#75** — a write failure aborts the whole run. The draft already generated for an
    earlier route is discarded and its model calls are spent for nothing.
-3. A step whose verification has no object passes both the authoring check and
-   the runner.
+3. **#72** — a step whose verification has no object passes both the authoring
+   check and the runner.
 
 ## Cost
 
@@ -99,7 +99,7 @@ Reproduced independently. The model states in plain text that it could not carry
 out the step, and the runner accepts `done` anyway. The `fail` action exists and
 the model did not choose it.
 
-**This generalises the fix deferred on #72 and makes it worth more.** The rule
+Filed as **#76**. **This generalises the fix deferred on #72 and makes it worth more.** The rule
 under discussion there — a verification may not close on `done` having emitted no
 assertion — is the same rule this needs: *a step may not close on `done` having
 emitted no action at all*. One structural check, no semantics, covering both


### PR DESCRIPTION
Restores a commit that #73 merged without. The squash was taken from the branch before its last push, so these four lines never landed.

The task 1 measurement found four product defects and recorded them only in `notes-plan-quality.md`. They are now filed, and the notes say so: **#74** (`plan --write` cannot create the directory it writes into, since fixed by #77), **#75** (one unwritable draft ends the whole run), **#72** (a verification with no object passes), and **#76** (a step the agent could not perform is closed as `done`).

`AGENTS.md` requires that every known gap live in an issue rather than in someone's head. A notes file inside a change directory that is about to be archived is someone's head.

Documentation only. 543 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121JsiawVuEUZZbLTpj25D3