### PR TITLE
fix: pin the verdict, leave the search free

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ blastproof run --min-score 80    # one failing P2 is tolerated
 
 `--min-score` **replaces** the all-must-pass rule rather than adding to it. Only executed tests count: filtered and unrouted tests are neither numerator nor denominator, and a run that executed nothing scores 100, so a docs-only PR is never blocked. JUnit carries the score as a `<property name="score">`, and unrouted tests appear as `<skipped/>` so the coverage gap shows up in CI rather than vanishing.
 
+**The verdict behind that number is pinned, and that is not the same as reproducible.** The model call that decides whether a step passed runs at temperature 0, so the same page and the same expectation are not re-sampled into a different answer — a gate that flips on identical input teaches people to re-run until green, which is worse than no gate. What pinning does not survive: provider-side batching, floating point, and a gateway routing two calls to different providers or quantizations. Expect far less variance, not a guarantee of the same output twice.
+
+The calls that *choose* an action, and the one that drafts a test, are deliberately left free — that latitude is what re-resolves a control after a redesign instead of failing on it.
+
 Wiring this into a pipeline, with the gating patterns worth knowing: [Running in CI](./docs/ci.md).
 
 ## Without a browser or a key

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,16 @@ return malformed actions, which a step spends from its retry budget — expect m
 retries than a hosted model, and prefer tests whose steps state their outcomes
 plainly.
 
+### Temperature is not configurable, on purpose
+
+There is no `temperature` key. The call that judges a step is pinned to 0 in the source; the calls that choose an action and draft a test are left at the provider's default.
+
+They want opposite things. Judging is a decision, and two decisions about one page must agree — it is the number `--min-score` gates a merge on. Choosing an action is a search, and sampling is how the agent finds a route through a page the test's author never saw.
+
+A key here would be set once, forgotten, and surface months later as a gate that flips, with nobody connecting the two. If a real workload needs it, that is evidence worth reopening on.
+
+**Pinning narrows variance; it does not make a run reproducible.** Provider batching, floating point, and gateway routing between providers or quantizations all remain — and a gateway is exactly where the reported flip was measured.
+
 ## `browser` — waiting and snapshots
 
 ```yaml

--- a/openspec/changes/deterministic-verdicts/.openspec.yaml
+++ b/openspec/changes/deterministic-verdicts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/deterministic-verdicts/design.md
+++ b/openspec/changes/deterministic-verdicts/design.md
@@ -1,0 +1,72 @@
+# Design: deterministic-verdicts
+
+## Context
+
+`createBrain` (`src/llm/brain.ts:82`) returns two methods that call the same model through the same narrowed `generateObject` wrapper, and neither passes a temperature. `createPlanner` is a third caller with the same omission. The AI SDK defaults to the provider's own default, which is 1.0 for the providers blastproof supports.
+
+The three calls do different jobs, and the omission costs them differently. `nextAction` chooses the next gesture from a snapshot; when a page has moved, its freedom to choose differently is the self-healing behaviour the whole tool is built around. `judge` decides whether a step passed. `draft` writes a test a person will read before running.
+
+Only one of those is a decision that must not move.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The same page and expectation reach the same verdict
+- Self-healing keeps the latitude it needs
+- The limits of that guarantee are written down where a user reads them
+
+**Non-Goals:** a configuration key, a claim of reproducibility, changes to the planner or the executor's action choice, detecting a disagreement when one happens anyway.
+
+## Decisions
+
+### D1: Pin the judge, and only the judge
+`judge` is called with `temperature: 0`. `nextAction` and the planner's `draft` are left untouched.
+
+The distinction is the whole change, so it is worth stating plainly: **latitude is a feature where the model is searching, and a defect where it is deciding.** `nextAction` searches — it is handed a snapshot of a page that may have been redesigned since the test was written, and asked what to do about it. Sampling is how it finds a route the author did not anticipate; that is `self-healing` in one sentence. `judge` decides — it is handed a claim and asked whether the page supports it. There is no search there, and nothing to gain from variance.
+
+Pinning both was rejected as the obvious mistake this change exists to avoid. It would trade a real flakiness problem for a quiet regression in the behaviour that distinguishes the product, and the regression would be invisible: a suite that self-heals less does not fail, it just starts reporting defects that are not there, which reads as the same flakiness from the other side.
+
+Pinning neither and adding retries was also rejected. Re-running a sampled judgment until it agrees with itself is a slower way of sampling.
+
+### D2: A constant, not a config key
+The value is `0` in the source, not `judge_temperature` in `config.yaml`.
+
+A key here has a specific failure mode: it is set once, forgotten, and surfaces months later as a gate that flips, at which point nobody connects the two. The tool's own conventions push the same way — `concurrency` is opt-in and defaults to 1 because a wrong value produces failures the user cannot attribute (`AGENTS.md`), and this is that shape exactly, with a smaller blast radius and a subtler symptom.
+
+If a real workload turns up that wants a judge to explore, that is evidence, and evidence is what should buy the key. There is none today.
+
+### D3: `temperature` belongs to the call, not to the model
+It is added to `GenerateObjectFn` and passed per call, rather than baked into the model object returned by `createModel`.
+
+The alternative — configuring the provider once — reads as simpler and forecloses D1: one model instance cannot be pinned for judging and free for acting. Two model instances would work and would mean every consumer of `createModel` learning which one to ask for, to express something that is a property of the question rather than of the model.
+
+`GenerateObjectFn` is narrowed on purpose ("so tests can inject a stub"), so widening it is deliberate surface: the stubs in `tests/brain.test.ts` see the new field and can assert on it, which is how D1 gets a test at all.
+
+### D4: The documentation states the limit, not the intent
+`temperature: 0` narrows a distribution. It does not survive provider-side batching, floating-point non-associativity, or a gateway routing two calls to different providers or quantizations — and OpenRouter, which the reported failure used, does exactly that.
+
+So the README says the verdict is pinned and that repeatability is not guaranteed. Claiming determinism would be the same class of error as the authoring check's English-only silence: a guarantee the user believes and the code does not make. That comparison is in `references/authoring.md` already, and the same standard applies here.
+
+## Rejected alternatives
+
+- **Pin every call** — trades flakiness for a silent loss of self-healing (D1)
+- **Pin nothing, retry the judgment** — sampling more slowly (D1)
+- **A `judge_temperature` config key** — a wrong value surfaces as an unattributable flipped gate (D2)
+- **Set temperature on the model in `createModel`** — one instance cannot be both pinned and free (D3)
+- **Judge twice and report disagreement** — the better guarantee, and a different change with a real cost per assertion; noted in the proposal's non-goals so it is not lost
+
+## Risks / Trade-offs
+
+- **A pinned judge is consistently wrong where it was previously sometimes right.** Variance occasionally rescued a marginal call. That is not a loss worth keeping — a verdict that is right by luck cannot be relied on either way — but the failure rate on a marginal expectation may look worse before it looks better.
+- **This does not fix the reported symptom, it narrows it.** If the Juice Shop search test still flips after this lands, the cause is elsewhere and the next place to look is gateway routing.
+- **The evidence is one external evaluation.** Two runs of one test on one application, with one model, through one gateway. The mechanism is certain — nothing sets a temperature — but the size of the effect is not measured, and this change does not measure it.
+
+## Migration Plan
+
+Nothing to migrate. No config, no flag, no file format. A suite that passes today passes after, with less variance around the marginal cases.
+
+## Open Questions
+
+- **Does it hold on the application that produced the report?** The honest test is the Juice Shop suite, re-run several times, not `examples/demo-app`.
+- **How often did this actually fire before?** Unknown, and unmeasurable retrospectively — a flipped verdict left no mark in any report.
+- **Does the planner want pinning too?** Argued no here, on the grounds that a person reads the draft. If drafts turn out to vary in quality rather than in wording, that argument is wrong.

--- a/openspec/changes/deterministic-verdicts/proposal.md
+++ b/openspec/changes/deterministic-verdicts/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: deterministic-verdicts
+
+## Why
+
+Nothing in `src/llm/brain.ts` sets a temperature, so every model call runs at the provider's default — typically 1.0. A verdict is therefore sampled rather than computed.
+
+An outside evaluation drove blastproof against OWASP Juice Shop and got **Score 0 and then Score 100 from the same test, run twice, with nothing changed between** (#81). That number is what `--min-score` gates a merge on. A gate that flips on identical input is worth less than no gate, because it teaches people to re-run until green.
+
+## What Changes
+
+- `GenerateObjectFn` carries an optional `temperature`, and `createBrain` sets it per call rather than per model
+- **`judge` is pinned to 0.** Its job is to decide, and two decisions on one page must agree
+- **`nextAction` is left at the provider default.** It is the self-healing loop; latitude there is the feature that re-resolves an element after a redesign instead of failing on it
+- `createPlanner` is left at the provider default: a draft is read by a person before it runs
+- The README and `docs/configuration.md` state what pinning does and does not buy
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agentic-execution`: a judgment is a decision, not a sample — the call that makes it is pinned, and the calls that explore are not
+
+## Impact
+
+- New dependencies: **none**. `temperature` is a standard setting the AI SDK normalises across Anthropic, OpenAI and OpenAI-compatible gateways
+- Affects: `src/llm/brain.ts`, the stub type its tests inject, README, `docs/configuration.md`
+- No config surface, no flag, no behaviour change for a passing suite
+
+## Non-goals
+
+- **No configurable temperature.** A key that can be set wrong in a way nobody notices until a gate flips is worse than a constant. Revisit if a real workload wants it
+- **No claim of determinism.** Provider batching, floating point and gateway routing between providers all remain; this narrows the distribution, and the documentation says exactly that
+- **No pinning of `nextAction` or the planner.** Different jobs, opposite requirements
+- **No double-judging to detect disagreement.** Judging each assertion twice would make a flipped verdict visible rather than merely rarer, at one extra call per assertion. It is the better fix and it is a different change

--- a/openspec/changes/deterministic-verdicts/specs/agentic-execution/spec.md
+++ b/openspec/changes/deterministic-verdicts/specs/agentic-execution/spec.md
@@ -1,0 +1,25 @@
+# Spec delta: agentic-execution (deterministic-verdicts)
+
+## ADDED Requirements
+
+### Requirement: A judgment is a decision, not a sample
+The model call that judges a step SHALL be made with `temperature: 0`. The calls that choose the next action and that draft a test SHALL NOT be pinned, because their latitude is what re-resolves an element the test's author did not anticipate.
+
+#### Scenario: Judging is pinned
+- **WHEN** a step's expectation is judged against a snapshot
+- **THEN** the call carries `temperature: 0`
+
+#### Scenario: Acting is not pinned
+- **WHEN** the model is asked for the next action, or for a test draft
+- **THEN** the call carries no temperature, and the provider's default applies
+
+#### Scenario: The same page reaches the same verdict
+- **WHEN** the same expectation is judged twice against the same snapshot and history
+- **THEN** the two calls are identical in everything the model receives, including the temperature
+
+### Requirement: The limit of the guarantee is documented
+The documentation SHALL state that pinning narrows verdict variance and does not make a run reproducible, naming provider batching and gateway routing as what remains.
+
+#### Scenario: A reader looks for a repeatability guarantee
+- **WHEN** the reader reaches what the documentation says about verdicts
+- **THEN** it says the judgment is pinned, and that identical output across runs is not guaranteed

--- a/openspec/changes/deterministic-verdicts/tasks.md
+++ b/openspec/changes/deterministic-verdicts/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: deterministic-verdicts
+
+## 1. Carry a temperature on the call
+
+- [x] 1.1 `src/llm/brain.ts` — widen `GenerateObjectFn` with an optional `temperature: number`. It is narrowed deliberately so tests can inject a stub, so this is the surface that lets a test assert what was sent (design D3)
+- [x] 1.2 Unit test: the stub records the options it received, so the assertions below read a real call rather than a mock's configuration
+
+## 2. Pin the judge, and only the judge
+
+- [x] 2.1 `createBrain.judge` — pass `temperature: 0` (design D1)
+- [x] 2.2 `createBrain.nextAction` — pass nothing, and say why in a comment: latitude here is the self-healing behaviour, not an oversight. Without the comment the next reader "fixes" the inconsistency
+- [x] 2.3 `createPlanner` — pass nothing, same reasoning, a person reads the draft first
+- [x] 2.4 Unit tests: judging sends `temperature: 0`; the action call and the planner call send none. Assert the absence, not just the presence — a change that pins everything must fail
+
+## 3. Say what it does not buy
+
+- [x] 3.1 `README.md` — the verdict is pinned; repeatability is not guaranteed, and name what remains (provider batching, gateway routing between providers or quantizations)
+- [x] 3.2 `docs/configuration.md` — same, next to the provider settings, where someone choosing a gateway will be reading
+- [x] 3.3 Do not add a config key, and do not describe one (design D2)
+
+## 4. Verification
+
+- [x] 4.1 Mutation: pin `nextAction` too and confirm a test fails — the self-healing regression this change exists to avoid must be caught, not just avoided by hand. **Caught.** A third mutation, pinning the planner, is caught too
+- [x] 4.2 Mutation: remove the pin from `judge` and confirm a test fails
+- [x] 4.3 `npm run build`
+- [x] 4.4 `npm run typecheck`
+- [x] 4.5 `npm test`

--- a/src/llm/brain.ts
+++ b/src/llm/brain.ts
@@ -43,12 +43,20 @@ export interface AgentBrain {
   ): Promise<AssertJudgment>;
 }
 
-/** Narrowed signature of `generateObject` so tests can inject a stub. */
+/**
+ * Narrowed signature of `generateObject` so tests can inject a stub.
+ *
+ * `temperature` is per call rather than per model on purpose (design D3,
+ * deterministic-verdicts): one model instance has to serve a judgment that must
+ * not move and an action choice that must be free to, and that is a property of
+ * the question, not of the model.
+ */
 export type GenerateObjectFn = (options: {
   model: LanguageModel;
   schema: z.ZodTypeAny;
   system?: string;
   prompt?: string;
+  temperature?: number;
 }) => Promise<{ object: unknown; usage?: { totalTokens?: number } }>;
 
 export class MalformedModelOutputError extends Error {
@@ -92,6 +100,13 @@ export function createBrain(
 ): AgentBrain {
   return {
     async nextAction(input) {
+      // Deliberately unpinned (design D1, deterministic-verdicts). This call is
+      // searching, not deciding: it is handed a page that may have been
+      // redesigned since the test was written and asked what to do about it, and
+      // sampling is how it finds a route the author did not anticipate. That is
+      // self-healing. Pinning it would trade a visible flakiness problem for an
+      // invisible one — a suite that heals less does not fail, it starts
+      // reporting defects that are not there.
       const result = await countedGenerate(generate, budget, {
         model,
         schema: agentActionSchema,
@@ -108,11 +123,21 @@ export function createBrain(
     },
 
     async judge(step, expectation, snapshot, stepHistory) {
+      // Pinned (design D1, deterministic-verdicts). This call decides, and two
+      // decisions about one page must agree: it is the verdict `--min-score`
+      // gates a merge on. Left at the provider's default — 1.0 for all three —
+      // the same test scored 0 and then 100 against a real application with
+      // nothing changed between the runs (#81).
+      //
+      // This narrows the distribution; it does not make a run reproducible.
+      // Provider batching, floating point, and a gateway routing two calls to
+      // different providers or quantizations all survive it.
       const result = await countedGenerate(generate, budget, {
         model,
         schema: assertJudgmentSchema,
         system: assertSystemPrompt(),
         prompt: assertUserPrompt(step, expectation, snapshot, stepHistory),
+        temperature: 0,
       });
       const parsed = assertJudgmentSchema.safeParse(result.object);
       if (!parsed.success) {
@@ -141,6 +166,10 @@ export function createPlanner(
 ): PlannerBrain {
   return {
     async planTest(input) {
+      // Deliberately unpinned, like `nextAction` and for a related reason
+      // (design D1, deterministic-verdicts): a draft is read by a person before
+      // it ever runs, so variance here costs a review comment rather than a
+      // wrong verdict.
       const result = await countedGenerate(generate, budget, {
         model,
         schema: generatedTestSchema,

--- a/tests/brain.test.ts
+++ b/tests/brain.test.ts
@@ -152,6 +152,43 @@ describe('createBrain', () => {
   });
 });
 
+describe('what is pinned and what is not (design D1, deterministic-verdicts)', () => {
+  it('pins the judgment, because two decisions about one page must agree', async () => {
+    const captured: { options?: { temperature?: number } } = {};
+    const brain = createBrain(fakeModel, stubGenerate({ pass: true, reason: 'ok' }, captured), new RunBudget());
+    await brain.judge('verify the total is $80', 'total shows $80', '- text "$80"');
+    expect(captured.options?.temperature).toBe(0);
+  });
+
+  it('leaves the action choice free, because that latitude is the self-healing', async () => {
+    // Asserting the absence, not just the presence elsewhere: a change that
+    // pins every call would fix the flakiness and quietly cost the behaviour
+    // the tool is built around, and nothing else would fail.
+    const captured: { options?: { temperature?: number } } = {};
+    const brain = createBrain(
+      fakeModel,
+      stubGenerate({ action: 'click', target: { role: 'button', name: 'Save' }, reasoning: 'save' }, captured),
+      new RunBudget(),
+    );
+    await brain.nextAction({ step: 'save', snapshot: '- button "Save"', retriesLeft: 3, iterationsLeft: 10 });
+    expect(captured.options).not.toHaveProperty('temperature');
+  });
+
+  it('leaves the planner free, because a person reads the draft before it runs', async () => {
+    const captured: { options?: { temperature?: number } } = {};
+    const planner = createPlanner(
+      fakeModel,
+      stubGenerate(
+        { summary: 'Cart shows the discount', steps: ['navigate to /cart and verify the heading "Your cart" is shown'], priority: 'P1', tags: ['cart'] },
+        captured,
+      ),
+      new RunBudget(),
+    );
+    await planner.planTest({ route: '/cart', snapshot: '- heading "Your cart"', changedFiles: [] });
+    expect(captured.options).not.toHaveProperty('temperature');
+  });
+});
+
 describe('createBrain budget enforcement (design D2)', () => {
   it('counts a nextAction call against the budget', async () => {
     const budget = new RunBudget({ maxCalls: 1 });


### PR DESCRIPTION
Closes #81. **Read the measurement section before the rest — it narrows what this claims.**

Nothing in `src/llm/brain.ts` set a temperature, so every call ran at the provider's default — 1.0 for all three. A verdict was **sampled**, not computed.

## What changed

**`judge` decides.** Two decisions about one page must agree — it is the number `--min-score` gates a merge on. Pinned to 0.

**`nextAction` searches.** It is handed a page that may have been redesigned since the test was written and asked what to do about it; sampling is how it finds a route the author did not anticipate. That is self-healing in one sentence. Left free. The planner too: a person reads the draft before it runs.

A test asserts the **absence** of a temperature on both free calls, so a future change that pins everything fails loudly instead of quietly costing the behaviour the tool is built around. Verified with three mutations.

## Measured after the fact, and it narrows the claim

An external A/B against OWASP Juice Shop — 10 runs a side, interleaved, same model, same gateway, same suite:

| mechanism | before | after |
|---|---|---|
| flips caused by the **judge** | 1 | **0** |
| flips caused by the **action path** | 0 | **3** |
| **total** | 1/10 | 3/10 |

Across all 20 runs the judgment agreed with the snapshot it was given, every time, with no exception. That is the pin working.

But the total went the other way, because a second mechanism showed up that this change does not touch: the agent typed into the search field, never submitted, and asserted against an unfiltered page. **The flip that motivated this work was probably never the judge's.** The commit message originally claimed otherwise and has been corrected.

That second mechanism is #83. This PR should not be read as repairing it.

Self-healing was probed separately with deliberately inexact accessible names: 5/5 resolved on both sides. The pin cost nothing there.

## Why merge it anyway

It removes a real source of sampled verdicts — one that was measurably present before and measurably absent after, in the only component it touches. It is the correct behaviour regardless of whether it happens to be the dominant symptom on one application with one model.

## What the documentation says

That pinning **narrows variance and does not make a run reproducible**. Provider batching, floating point, and gateway routing all survive it. Claiming determinism would be the same class of error as the authoring check's English-only silence.

## No config key

A `judge_temperature` would be set once, forgotten, and surface months later as a gate that flips with nobody connecting the two — the same reasoning `AGENTS.md` records for `concurrency`.

## Caveats on the evidence

n=10 a side is underpowered; Fisher exact on the totals gives p≈0.58. And both sides used one cheap model, so "the loop cannot recover from a wrong action" and "this model sometimes fails to complete a submit" predict the same trace. #83 says to separate those before building anything.

Build, typecheck, 547 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121JsiawVuEUZZbLTpj25D3
