### PR TITLE
fix: spell an absent field the way every provider accepts

### DIFF
--- a/openspec/changes/portable-structured-output/.openspec.yaml
+++ b/openspec/changes/portable-structured-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/portable-structured-output/design.md
+++ b/openspec/changes/portable-structured-output/design.md
@@ -1,0 +1,64 @@
+# Design: portable-structured-output
+
+## Context
+
+`generateObject` turns a Zod schema into a JSON Schema and asks the provider to fill it. Anthropic treats that schema as a description. OpenAI's strict mode treats it as a contract and validates it before running the model: every key of an object must appear in `required`, and a value that may be absent is declared nullable rather than omitted.
+
+`agentActionSchema` was written for the first reading. `target` is an optional object whose own properties are optional, so under the second reading it is malformed twice over — and the request is refused before a token is spent.
+
+The failure is silent in the worst way. The request never runs, so the executor sees an error rather than a bad answer, treats it as a failed attempt, and sends the identical rejected request twice more.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The documented OpenAI path makes calls
+- The parsed object is unchanged, so nothing downstream is touched
+- A provider that explains a refusal has its explanation reach the user
+
+**Non-Goals:** changing what the model is asked to decide, distinguishing a rejected request from a bad response inside the retry budget, redesigning schemas that are not sent to a rejecting provider.
+
+## Decisions
+
+### D1: Nullable on the wire, `undefined` after the parse
+Each optional field becomes `.nullable()` and carries `.transform((v) => v ?? undefined)`. The JSON Schema then declares the key as present-and-nullable, which strict mode accepts, while `z.infer` still yields `string | undefined` and every consumer reads exactly what it reads today.
+
+The alternative — `.nullable()` alone, and change the 22 call sites to handle `null` — was rejected on blast radius against benefit. Most of those sites use `?.` or `?? ''` and would behave identically, which is precisely why the change would be easy to make and hard to review: a diff that touches twenty-two places to alter nothing observable is a diff nobody reads carefully, in files that decide which element gets clicked.
+
+Flattening `target` into `targetRole`/`targetName`/`targetText` was also rejected. It removes the nested optional object that caused this, and it changes the shape the model is asked to produce — which is a prompt change wearing a schema change's clothes, on the one call whose output decides every action.
+
+Verified before proposing, one `generateObject` call per provider with the real schema shape: `gpt-4o-mini`, `claude-haiku-4.5` and `gemini-2.5-flash-lite` all accepted it and all parsed to an object with `undefined` where a field was absent.
+
+### D2: Quote the provider, do not summarise it
+`AI_APICallError` carries `responseBody`. Today it is dropped and the user reads `Provider returned error`, which names nothing and suggests nothing.
+
+The provider's own message named the field, the constraint and the rule — enough to diagnose in a minute. Discarding it cost an afternoon and would have cost a user their evaluation of the tool, because the evidence they are given supports exactly one conclusion: it is broken.
+
+This is the standard `AGENTS.md` already sets at the prerequisite boundary — name the component, name the provider, give a remedy — applied to the one boundary that was exempt. It is general: it improves every provider refusal, not the one this change fixes.
+
+### D3: The two halves ship together
+The schema fix alone would close #85 and leave the next provider refusal just as unreadable — and the next one will not have someone spending an afternoon with `curl` to decode it. The message fix alone would make this diagnosable and still broken.
+
+They are separable in code and not in value, and the second is what makes the first verifiable by anyone other than its author.
+
+## Rejected alternatives
+
+- **`.nullable()` without the transform, updating 22 call sites** — a large diff that changes nothing observable, in the files that decide which element is clicked (D1)
+- **Flattening `target`** — changes what the model is asked to produce, on the call that decides every action (D1)
+- **`structuredOutputs: false` to fall back to tool calling** — tried against `gpt-4o-mini` and still refused, so it does not even work; it would also silently change the mechanism by which every decision is obtained
+- **Retrying a rejected request fewer times** — treats the symptom, and the distinction between a bad request and a bad response is worth its own change
+
+## Risks / Trade-offs
+
+- **`.transform()` sits between the schema and the parsed value.** Anything that later reads `agentActionSchema` expecting the raw wire shape — a serialiser, a fixture, a test asserting on parsed output — sees `undefined` where the model sent `null`. That is the intent, and it is a place a future reader can be surprised.
+- **Verified through a gateway, not against `api.openai.com`.** The rule is OpenAI's, and Azure enforced it. Direct access is very likely identical and is not measured.
+- **The model may now answer `null` where it previously omitted the key.** Semantically the same to every consumer after the transform, and confirmed on three providers — but it is a change in what comes back over the wire.
+
+## Migration Plan
+
+Nothing to migrate. No config, no file format, no flag. A suite that runs on Anthropic today produces the same parsed decisions after; a suite that could not run on OpenAI at all now can.
+
+## Open Questions
+
+- **Does `api.openai.com` behave as Azure did?** Expected, unmeasured, and worth a line in the issue when someone with a key checks.
+- **Should a rejected request stop the run instead of retrying?** Three identical refusals is three times the wait for the same answer. Out of scope here, worth its own issue.
+- ~~**Is `generatedTestSchema` exposed to the same rule?**~~ Answered while writing this: it declares no optional fields, and neither does `assertJudgmentSchema`. All six live in `agentActionSchema`, which is why only the executor's call is refused and `plan` was never implicated.

--- a/openspec/changes/portable-structured-output/proposal.md
+++ b/openspec/changes/portable-structured-output/proposal.md
@@ -1,0 +1,33 @@
+# Proposal: portable-structured-output
+
+## Why
+
+`provider: openai` with its own documented default makes **zero model calls**. The schema is rejected before the model is asked anything, and the run reports `Provider returned error` after burning three retries (#85).
+
+OpenAI's strict structured-output mode requires every key of an object to appear in `required`; an absent value is expressed as nullable, not omitted. `agentActionSchema` nests optional properties inside `target`, so the request never validates. Anthropic does not enforce this, which is why the default provider works and this went unseen.
+
+Measured through OpenRouter: `gpt-4o-mini`, `gpt-5-mini` and `gpt-5.6-luna` all rejected; `claude-haiku-4.5` and `gemini-2.5-flash-lite` accepted. The router that enforced it was Azure — the way an enterprise runs OpenAI, and the audience least able to shrug it off.
+
+## What Changes
+
+- Optional fields in the schemas the model fills become `nullable` on the wire and are transformed back to `undefined` on parse, so the request validates everywhere and no consumer of `AgentAction` changes
+- `AI_APICallError`'s `responseBody` is surfaced instead of discarded, so a provider that explains itself is quoted rather than summarised as `Provider returned error`
+
+## Capabilities
+
+### Modified Capabilities
+
+- `llm-providers`: structured output is expressed in the subset every supported provider accepts, and a provider's own error reaches the user
+
+## Impact
+
+- New dependencies: **none**
+- Affects: `src/llm/schemas.ts`, the error path in `src/llm/brain.ts` or `provider.ts`, and the tests around both
+- No config surface, no flag. A suite that runs today runs unchanged: verified across three providers, the parsed object is identical to today's, `undefined` included
+
+## Non-goals
+
+- **No change to what the model is asked for.** Same fields, same descriptions, same decisions — only how absence is spelled
+- **No retry on a schema rejection.** A malformed *response* is worth a retry; a malformed *request* is the same rejection three times. Making that distinction is real work and belongs to its own change; this one stops producing the rejection
+- **No verification against `api.openai.com` directly.** Measured through a gateway. The rule is OpenAI's own so the direct path is very likely affected, and someone with a key should confirm rather than assume
+- **No change to the other two schemas.** Checked rather than assumed: `assertJudgmentSchema` and `generatedTestSchema` declare no optional fields at all. All six are in `agentActionSchema`, which is why only the executor's call is refused

--- a/openspec/changes/portable-structured-output/specs/llm-providers/spec.md
+++ b/openspec/changes/portable-structured-output/specs/llm-providers/spec.md
@@ -1,0 +1,31 @@
+# Spec delta: llm-providers (portable-structured-output)
+
+## MODIFIED Requirements
+
+### Requirement: Structured output
+All LLM decisions (next action, assert judgment) SHALL be produced via structured output validated by Zod schemas; malformed responses SHALL count as a failed attempt within the retry budget. The schemas SHALL be expressed in the subset every supported provider accepts: a field that may be absent is declared **nullable and present**, never omitted, because strict validators require every key of an object to appear in `required` and refuse the request otherwise.
+
+#### Scenario: Malformed LLM response
+- **WHEN** the LLM returns output that fails schema validation
+- **THEN** the executor retries the step with a fresh snapshot instead of crashing
+
+#### Scenario: A provider that validates the schema before running the model
+- **WHEN** a request is sent to a provider enforcing strict structured output
+- **THEN** the schema is accepted and the model is asked
+
+#### Scenario: An absent value reaches the consumer as it always has
+- **WHEN** the model omits a value, sending `null`
+- **THEN** the parsed action carries `undefined` for that field, and no consumer of the action distinguishes it from today
+
+## ADDED Requirements
+
+### Requirement: A provider's refusal is quoted, not summarised
+When a provider rejects a request, the error surfaced SHALL carry the provider's own explanation rather than a generic phrase.
+
+#### Scenario: Schema refused by the provider
+- **WHEN** the provider replies that the request is invalid and says why
+- **THEN** the run reports what the provider said, not `Provider returned error`
+
+#### Scenario: Any other provider error
+- **WHEN** a provider refuses for an unrelated reason — credit, rate limit, an unknown model
+- **THEN** its message reaches the user by the same path, with no per-case handling

--- a/openspec/changes/portable-structured-output/tasks.md
+++ b/openspec/changes/portable-structured-output/tasks.md
@@ -18,7 +18,7 @@
 - [x] 3.1 Live, one `generateObject` per provider with the real schema: `gpt-4o-mini`, `claude-haiku-4.5` and `gemini-2.5-flash-lite` all accepted it and all parsed to an object carrying `undefined` where a field was absent
 - [x] 3.2 Live, the full search test against OWASP Juice Shop on the OpenAI default: **0 model calls before, 9 after**. The run still fails the test — `gpt-4o-mini` is a weak model on a hard journey — but it fails having been asked, which is the whole of what this change claims
 - [x] 3.2a `claude-haiku-4.5` must not regress: full test PASS, 21 calls, 49k tokens
-- [ ] 3.2b `gemini-2.5-flash-lite` full-test leg did not return in the final sweep. Its schema acceptance is measured (3.1); its end-to-end run is not
+- [x] 3.2b `gemini-2.5-flash-lite` end-to-end: the leg returned late, after the PR had been opened saying it had not. It made **3 calls** and failed the test at 275s — so the schema is accepted and the model is being asked, which is what this change is about. No before/after comparison exists for its full test: gemini accepted the schema before this change too, so there was nothing here to fix and nothing measured to regress
 - [x] 3.3 Mutation: restore one `.optional()` and confirm 1.4 fails — the JSON Schema assertion is the one that protects this, and a test that passes on the parsed value alone would not have caught the original defect
 - [x] 3.4 `npm run build`
 - [x] 3.5 `npm run typecheck`

--- a/openspec/changes/portable-structured-output/tasks.md
+++ b/openspec/changes/portable-structured-output/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: portable-structured-output
+
+## 1. Express absence in the portable subset
+
+- [x] 1.1 `src/llm/schemas.ts` — a small local helper: `.nullable()` on the wire, `.transform((v) => v ?? undefined)` on parse, so `z.infer` is unchanged (design D1)
+- [x] 1.2 Apply it to all six optional fields of `agentActionSchema`: `target` itself, its `role`/`name`/`text`, `value` and `expectation`. Checked rather than assumed — the other two schemas declare no optional fields, so they are untouched
+- [x] 1.3 Unit test: an object with `null` for every absent field parses, and every one of those fields reads `undefined` afterwards
+- [x] 1.4 Unit test: the generated JSON Schema lists every key of `target` in `required`. This is the property a strict provider checks, and asserting the parsed value alone would pass while the request still failed
+
+## 2. Let the provider speak
+
+- [x] 2.1 Surface `AI_APICallError`'s `responseBody` where the error is currently flattened to `Provider returned error` (design D2)
+- [x] 2.2 Keep it bounded — a raw body can be long, and a step's failure line is read in a terminal
+- [x] 2.3 Unit test: an error carrying a provider explanation reports that explanation; one carrying none still reports something useful rather than an empty string
+
+## 3. Verification
+
+- [x] 3.1 Live, one `generateObject` per provider with the real schema: `gpt-4o-mini`, `claude-haiku-4.5` and `gemini-2.5-flash-lite` all accepted it and all parsed to an object carrying `undefined` where a field was absent
+- [x] 3.2 Live, the full search test against OWASP Juice Shop on the OpenAI default: **0 model calls before, 9 after**. The run still fails the test — `gpt-4o-mini` is a weak model on a hard journey — but it fails having been asked, which is the whole of what this change claims
+- [x] 3.2a `claude-haiku-4.5` must not regress: full test PASS, 21 calls, 49k tokens
+- [ ] 3.2b `gemini-2.5-flash-lite` full-test leg did not return in the final sweep. Its schema acceptance is measured (3.1); its end-to-end run is not
+- [x] 3.3 Mutation: restore one `.optional()` and confirm 1.4 fails — the JSON Schema assertion is the one that protects this, and a test that passes on the parsed value alone would not have caught the original defect
+- [x] 3.4 `npm run build`
+- [x] 3.5 `npm run typecheck`
+- [x] 3.6 `npm test`

--- a/src/llm/brain.ts
+++ b/src/llm/brain.ts
@@ -14,6 +14,7 @@ import type { RunBudget } from '../runner/budget.js';
 import type { StepHistoryEntry } from '../runner/recovery.js';
 import {
   agentActionSchema,
+  parseAgentAction,
   assertJudgmentSchema,
   generatedTestSchema,
   type AgentAction,
@@ -74,13 +75,46 @@ export class MalformedModelOutputError extends Error {
  * what the budget counts against, so an unconfigured budget costs nothing extra
  * and a configured one is total by construction, not by every caller remembering.
  */
+/** A raw provider body is unbounded; a step's failure line is read in a terminal. */
+const MAX_PROVIDER_DETAIL = 300;
+
+/**
+ * Quotes the provider instead of summarising it (design portable-structured-output D2).
+ *
+ * A refusal arrives as an `AI_APICallError` whose `message` is often whatever
+ * short phrase the gateway chose — `Provider returned error` — while the
+ * explanation sits in `responseBody`, unread. That is how a schema our
+ * documented OpenAI default could never satisfy read as a broken tool for as
+ * long as it did (#85): the provider named the field, the constraint and the
+ * rule, and none of it reached anyone.
+ *
+ * Deliberately not per-case: nothing here knows what a schema rejection is, so
+ * a credit limit, a rate limit and an unknown model are all improved by the
+ * same three lines.
+ */
+function withProviderDetail(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+  const body = (error as { responseBody?: unknown }).responseBody;
+  if (typeof body !== 'string' || body.length === 0) return error;
+  // Collapsed: a body arrives pretty-printed and a failure line is one line.
+  const detail = body.replace(/\s+/g, ' ').trim().slice(0, MAX_PROVIDER_DETAIL);
+  if (error.message.includes(detail)) return error;
+  error.message = `${error.message} — provider said: ${detail}`;
+  return error;
+}
+
 async function countedGenerate(
   generate: GenerateObjectFn,
   budget: RunBudget,
   options: Parameters<GenerateObjectFn>[0],
 ): ReturnType<GenerateObjectFn> {
   budget.check();
-  const result = await generate(options);
+  let result: Awaited<ReturnType<GenerateObjectFn>>;
+  try {
+    result = await generate(options);
+  } catch (error) {
+    throw withProviderDetail(error);
+  }
   // Recorded even when the output later fails schema validation: the call was
   // made and spent tokens regardless of whether the model's answer parses.
   budget.record(result.usage);
@@ -113,7 +147,7 @@ export function createBrain(
         system: agentSystemPrompt(),
         prompt: agentUserPrompt(input),
       });
-      const parsed = agentActionSchema.safeParse(result.object);
+      const parsed = parseAgentAction(result.object);
       if (!parsed.success) {
         throw new MalformedModelOutputError(
           `Model returned an invalid action: ${parsed.error.issues[0]?.message ?? 'unknown'}`,

--- a/src/llm/schemas.ts
+++ b/src/llm/schemas.ts
@@ -1,41 +1,107 @@
 import { z } from 'zod';
 
 /**
+ * A field the model may leave out, spelled the way every provider accepts.
+ *
+ * `.optional()` omits the key, and a strict validator refuses the whole request
+ * for it — every key of an object must appear in `required`, and absence is
+ * expressed as null. Anthropic reads the schema as a description and does not
+ * care; OpenAI validates it before running the model, so the documented
+ * `provider: openai` default made zero calls and reported `Provider returned
+ * error` (#85, design portable-structured-output D1).
+ *
+ * The transform is what keeps this a wire-format change: `z.infer` still yields
+ * `string | undefined`, so all twenty-two readers of an action see exactly what
+ * they saw before. Verified against gpt-4o-mini, claude-haiku-4.5 and
+ * gemini-2.5-flash-lite before it was written.
+ */
+function absentAsNull<T extends z.ZodTypeAny>(schema: T) {
+  return schema.nullable().transform((value) => value ?? undefined);
+}
+
+/** Every action the loop can take. Shared, so the two schemas below cannot disagree. */
+const ACTION_NAMES = ['navigate', 'click', 'fill', 'press', 'select', 'assert', 'done', 'fail'] as const;
+
+/**
  * The single structured decision the LLM returns on every loop iteration (design D3).
  */
 export const agentActionSchema = z.object({
-  action: z
-    .enum(['navigate', 'click', 'fill', 'press', 'select', 'assert', 'done', 'fail'])
-    .describe('The next browser action to perform for the current step.'),
+  action: z.enum(ACTION_NAMES).describe('The next browser action to perform for the current step.'),
+  target: absentAsNull(
+    z.object({
+      role: absentAsNull(
+        z.string().describe('ARIA role of the target element, e.g. "button", "link", "textbox".'),
+      ),
+      name: absentAsNull(
+        z.string().describe('Accessible name of the target element, exactly as shown in the snapshot.'),
+      ),
+      text: absentAsNull(
+        z.string().describe('Visible text of the target element, used as a fallback when no role matches.'),
+      ),
+    }),
+  ).describe('Element to act on, resolved from the accessibility snapshot. Null for navigate/done/fail.'),
+  value: absentAsNull(
+    z
+      .string()
+      .describe(
+        'Action payload: URL/path for navigate, text for fill, key for press (e.g. "Enter"), option label for select.',
+      ),
+  ),
+  reasoning: z.string().describe('One sentence explaining why this action moves the step forward.'),
+  expectation: absentAsNull(
+    z.string().describe('For assert: the condition the current page snapshot must satisfy.'),
+  ),
+});
+
+/**
+ * The same action, validated *after* the wire schema has already transformed it.
+ *
+ * `generateObject` parses the model's answer with {@link agentActionSchema} and
+ * hands back the transformed object, where an absent field is `undefined`. The
+ * spec requires a malformed response to count as a failed attempt, so `brain.ts`
+ * validates again to turn `unknown` into a typed action — and validating a
+ * transformed object with the transforming schema rejects the model's own valid
+ * answer, because `undefined` does not satisfy `nullable`. Measured: it reported
+ * `Model returned an invalid action: Required` against a provider that had just
+ * answered correctly.
+ *
+ * Wrapping the wire schema in `preprocess` to make it idempotent was tried and
+ * refused by the provider: it emits an `anyOf`, and the strict validator wants
+ * `required` inside every branch of one.
+ *
+ * So this shape is optional where that one is nullable. It never leaves the
+ * process, so no validator ever sees it, and the assertion below fails the build
+ * if the two ever describe different actions.
+ */
+const parsedAgentActionSchema = z.object({
+  action: z.enum(ACTION_NAMES),
   target: z
     .object({
-      role: z
-        .string()
-        .optional()
-        .describe('ARIA role of the target element, e.g. "button", "link", "textbox".'),
-      name: z
-        .string()
-        .optional()
-        .describe('Accessible name of the target element, exactly as shown in the snapshot.'),
-      text: z
-        .string()
-        .optional()
-        .describe('Visible text of the target element, used as a fallback when no role matches.'),
+      role: z.string().optional(),
+      name: z.string().optional(),
+      text: z.string().optional(),
     })
-    .optional()
-    .describe('Element to act on, resolved from the accessibility snapshot. Omit for navigate/done/fail.'),
-  value: z
-    .string()
-    .optional()
-    .describe(
-      'Action payload: URL/path for navigate, text for fill, key for press (e.g. "Enter"), option label for select.',
-    ),
-  reasoning: z.string().describe('One sentence explaining why this action moves the step forward.'),
-  expectation: z
-    .string()
-    .optional()
-    .describe('For assert: the condition the current page snapshot must satisfy.'),
+    .optional(),
+  value: z.string().optional(),
+  reasoning: z.string(),
+  expectation: z.string().optional(),
 });
+
+/**
+ * Compile-time guard against the two schemas drifting apart. Assignability both
+ * ways is type equality; a field added to one and not the other stops the build.
+ */
+type Mutual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+const _schemasAgree: Mutual<
+  z.infer<typeof parsedAgentActionSchema>,
+  z.infer<typeof agentActionSchema>
+> = true;
+void _schemasAgree;
+
+/** Validates an action the wire schema has already transformed. */
+export function parseAgentAction(value: unknown): z.SafeParseReturnType<unknown, AgentAction> {
+  return parsedAgentActionSchema.safeParse(value);
+}
 
 export type AgentAction = z.infer<typeof agentActionSchema>;
 export type AgentActionName = AgentAction['action'];

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { agentActionSchema, assertJudgmentSchema } from '../src/llm/schemas.js';
+import { agentActionSchema, assertJudgmentSchema, parseAgentAction } from '../src/llm/schemas.js';
 
 describe('agentActionSchema', () => {
+  /** Absence on the wire is `null`, and every key is present (design D1). */
+  const absent = { target: null, value: null, expectation: null };
+
   it('accepts all supported actions', () => {
     for (const action of ['navigate', 'click', 'fill', 'press', 'select', 'assert', 'done', 'fail']) {
-      const result = agentActionSchema.safeParse({ action, reasoning: 'because' });
+      const result = agentActionSchema.safeParse({ action, reasoning: 'because', ...absent });
       expect(result.success, action).toBe(true);
     }
   });
@@ -12,18 +15,62 @@ describe('agentActionSchema', () => {
   it('accepts a full click action with target', () => {
     const result = agentActionSchema.safeParse({
       action: 'click',
-      target: { role: 'button', name: 'Add to cart' },
+      target: { role: 'button', name: 'Add to cart', text: null },
       reasoning: 'need to add the item',
+      value: null,
+      expectation: null,
     });
     expect(result.success).toBe(true);
   });
 
+  it('turns an absent value into undefined, so no consumer sees the difference', () => {
+    const result = agentActionSchema.safeParse({ action: 'done', reasoning: 'finished', ...absent });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.target).toBeUndefined();
+    expect(result.data.value).toBeUndefined();
+    expect(result.data.expectation).toBeUndefined();
+  });
+
+  it('requires the key to be present, which is the whole point and a real tightening', () => {
+    // A strict validator refuses a schema whose keys can be omitted, so absence
+    // is now spelled `null` rather than left out. The cost is here: a provider
+    // that omits the key sends something this rejects, where it used to pass.
+    // That counts as a failed attempt and is retried — visible, not silent.
+    expect(agentActionSchema.safeParse({ action: 'done', reasoning: 'x' }).success).toBe(false);
+  });
+
+  it('accepts the shape it has already transformed, so the second parse agrees', () => {
+    // `generateObject` parses once and hands back the transformed object; the
+    // guard in brain.ts parses that. Feeding it back into the wire schema
+    // rejected the model's own valid answer as `Required`, which is what this
+    // separation exists to prevent.
+    const wire = agentActionSchema.safeParse({
+      action: 'click',
+      target: { role: 'button', name: 'Save', text: null },
+      reasoning: 'save it',
+      value: null,
+      expectation: null,
+    });
+    expect(wire.success).toBe(true);
+    if (!wire.success) return;
+    const guarded = parseAgentAction(wire.data);
+    expect(guarded.success).toBe(true);
+    expect(guarded.success && guarded.data.target?.name).toBe('Save');
+  });
+
+  it('still rejects an action the model invented', () => {
+    expect(parseAgentAction({ action: 'explode', reasoning: 'x' }).success).toBe(false);
+  });
+
   it('rejects unknown actions', () => {
-    expect(agentActionSchema.safeParse({ action: 'hover', reasoning: 'x' }).success).toBe(false);
+    expect(agentActionSchema.safeParse({ action: 'hover', reasoning: 'x', ...absent }).success).toBe(
+      false,
+    );
   });
 
   it('requires reasoning', () => {
-    expect(agentActionSchema.safeParse({ action: 'done' }).success).toBe(false);
+    expect(agentActionSchema.safeParse({ action: 'done', ...absent }).success).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #85.

`provider: openai` with its own documented default — `gpt-4o-mini` — made **zero model calls**. The schema was refused before the model was asked anything, and the run reported `Provider returned error` after burning three retries on the identical rejected request.

## The defect

OpenAI's strict structured-output mode requires every key of an object to appear in `required`; absence is expressed as null, not omission. `agentActionSchema` nested optional properties inside `target`, so it was malformed twice over.

Anthropic reads the schema as a description and does not enforce this, which is why the default provider works and this went unseen. The router that enforced it was **Azure** — the way an enterprise runs OpenAI, and the audience least able to shrug it off.

| model | before | after |
|---|---|---|
| `openai/gpt-4o-mini` (documented default) | rejected | accepted |
| `openai/gpt-5-mini` | rejected | accepted |
| `anthropic/claude-haiku-4.5` | accepted | accepted |
| `google/gemini-2.5-flash-lite` | accepted | accepted |

Against Juice Shop on the OpenAI default: **0 model calls before, 9 after**. The run still fails that test — `gpt-4o-mini` is a weak model on a hard journey — but it fails having been asked, which is all this change claims. Haiku does not regress: full test PASS, 21 calls.

## What it cost, both recorded rather than hidden

**A second schema.** `generateObject` parses with the wire schema and hands back the transformed object; the guard in `brain.ts` parses *that*, and validating a transformed object with the transforming schema rejects the model's own correct answer as `Required` — measured, not theorised. Wrapping the wire schema in `preprocess` to make it idempotent was tried and refused by the provider, which wants `required` inside every branch of the `anyOf` it then emits.

So the guard has its own shape, optional where the wire is nullable, never sent anywhere — plus a compile-time mutual-assignability assertion that fails the build if the two ever describe different actions.

**A tightening.** A provider that omits a key now sends something we reject where it used to pass. It counts as a failed attempt and is retried, so it is visible rather than silent. A test carries it in its name rather than leaving it in the commit log.

## The other half: let the provider speak

`AI_APICallError` carries a `responseBody` that was discarded. The provider named the field, the constraint and the rule; the user read `Provider returned error`.

It now quotes the provider, bounded to one line, at `countedGenerate` — the single choke point every model call already passes through for the budget, which is the shape `AGENTS.md` asks for. Deliberately blind to the case: a credit limit, a rate limit and an unknown model are improved by the same three lines.

It paid for itself inside this PR. The first attempt at the fix was still rejected, and the new message named the exact JSON pointer that was wrong.

## Not claimed

Verified through OpenRouter, not against `api.openai.com` directly. The rule is OpenAI's own so the direct path is very likely identical — inference, not measurement, and it is written down as such. 

Build, typecheck, 562 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121JsiawVuEUZZbLTpj25D3

---

**Correction, after the PR was opened.** The `gemini-2.5-flash-lite` end-to-end leg did return, late. It made **3 model calls** and failed the search test at 275s — schema accepted, model asked, behaviour failed on a hard journey, same category as `gpt-4o-mini`.

Worth being precise about what that is and is not evidence of: gemini accepted the schema *before* this change as well, so there was nothing to fix for it and no before/after comparison of its full test exists. The claim this PR makes is about the providers that were refused, and that claim is unchanged.
