### PR TITLE
docs: fix the two things a release would publish wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1>
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./.github/logo-dark.svg">
-    <img src="./.github/logo-light.svg" alt="" width="30" height="30">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/hamc/blastproof/main/.github/logo-dark.svg">
+    <img src="https://raw.githubusercontent.com/hamc/blastproof/main/.github/logo-light.svg" alt="" width="30" height="30">
   </picture>
   blastproof
 </h1>
@@ -18,7 +18,7 @@ git diff → impact mapping → test generation → agentic execution → report
 
 100% local. MIT. Bring your own LLM key.
 
-<img src="./.github/dogfood.gif" width="100%"
+<img src="https://raw.githubusercontent.com/hamc/blastproof/main/.github/dogfood.gif" width="100%"
      alt="A terminal running blastproof against this repo's demo app. It passes four steps, then fails
           step 5: the page says the SAVE20 promo gave 20% off, but the discount shown is -$6.00 where
           20% of $120.00 would be -$24.00. Score: 0.">
@@ -108,7 +108,7 @@ It is **not** a guarantee of zero duplicate writes. An agent that reaches the sa
 
 ## How it works
 
-<img src="./.github/coverage-flow.svg" width="100%"
+<img src="https://raw.githubusercontent.com/hamc/blastproof/main/.github/coverage-flow.svg" width="100%"
      alt="How a diff becomes a merge decision. In CI, unattended: changed files are matched against the routes: and ignore: globs; matched files contribute affected routes, files matching neither are reported as unclassified and fail the run only under --fail-on-unmapped. Tests declaring an affected route are executed and produce a weighted score, which --min-score gates on. An affected route no test declares is reported as a coverage gap and never fails the run. Separately and manually, outside CI: blastproof plan loads such a route in Chromium, makes one model call, and produces a YAML draft you review, edit and run before committing it.">
 
 **The boundary in the middle is the point.** Everything above it runs unattended on every pull request and ends in an exit code. Everything below it is something you choose to run, on your machine, and review before it lands.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ export BLASTPROOF_LLM_API_KEY_ENV=OPENROUTER_API_KEY
 blastproof run --impacted --min-score 80
 ```
 
-### Ollama, for a run that leaves the machine
+### Ollama, for a run that never leaves the machine
 
 ```yaml
 llm:


### PR DESCRIPTION
Groundwork for the next tag. Both are about what reaches npmjs.com, which still shows 0.15.0's README — no dogfood GIF, no skill section, while the skill is being announced publicly.

**The Ollama heading said the opposite of its own section.**

```
### Ollama, for a run that leaves the machine
```

Three lines above "No key, no network beyond your own host." One missing word, and it is the sentence that answers the first question a company that will not use a SaaS tester asks.

**Every image used a relative path.** GitHub resolves `./.github/dogfood.gif`; npmjs.com does not. Releasing as-is would put a referenced, broken image on the package page — worse than no image at all. Absolute raw URLs work in both places. All four verified to return 200, and `docs-links.test.ts` still passes.

Deliberately separate from the release commit: that one moves `package.json`, the changelog and the three `hamc/blastproof@v0.15.0` refs in `docs/ci.md` together, and mixing content into it is how a checklist stops finding things.

562 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121JsiawVuEUZZbLTpj25D3