### PR TITLE
chore: release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes are recorded here. This project follows [semantic versioning](https://semver.org/);
 while it is pre-1.0, a minor bump may change existing behaviour and a patch never does.
 
+## [0.16.0] — 2026-08-31
+
+### Added
+
+- **An agent skill.** `npx skills add hamc/blastproof`, then tell your coding agent
+  "set up e2e tests". It checks whether your markup is reachable at all, scaffolds,
+  generates drafts from your running app, and writes down the accessibility
+  constraints that keep the suite alive. It deliberately does not configure
+  authentication or CI.
+
+### Fixed
+
+- **`provider: openai` works.** It never had: the schema was refused before the
+  model was asked anything, so the documented default made zero model calls and
+  reported only `Provider returned error`. Anthropic does not enforce the rule that
+  refused it, which is why this went unseen.
+- **A provider's error reaches you.** Refusals used to arrive as a short phrase with
+  the provider's own explanation discarded. It is now quoted.
+- **The verdict no longer varies between identical runs.** The call that judges a
+  step is pinned; the calls that choose an action and draft a test are deliberately
+  left free, because that latitude is the self-healing.
+- **A blocked click says what is blocking it.** An overlay over a correct target
+  used to arrive as a timeout, which reads as "wrong element" — so the agent kept
+  re-resolving the right one. It now names what took the click and says that
+  re-targeting cannot help.
+- **`plan --write` creates the directory it writes into**, and a draft that cannot be
+  written no longer ends the whole run. Thanks to @abhijeetnardele24-hash for the
+  first outside contribution.
+
+### Changed
+
+- **An absent field is now sent as `null` rather than omitted.** This is what makes
+  strict providers accept the request. A provider that omits a key instead will have
+  its answer rejected and retried — visible, not silent. Four providers were checked
+  and none does.
+
 ## [0.15.0] — 2026-08-18
 
 ### Fixed

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,7 +27,7 @@ jobs:
 
       - run: npm start &          # however your app boots
 
-      - uses: hamc/blastproof@v0.15.0
+      - uses: hamc/blastproof@v0.16.0
         with:
           version: '0.11.0'       # pin both when this gates merges
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -51,7 +51,7 @@ failed" from "nothing ran".
 
 ```yaml
       - id: bp
-        uses: hamc/blastproof@v0.15.0
+        uses: hamc/blastproof@v0.16.0
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -73,7 +73,7 @@ workflow, which asserts that a shallow checkout is rejected.
 
 Two versions are in play, and they are independent:
 
-- the **action** ref (`hamc/blastproof@v0.15.0`) — the wrapper
+- the **action** ref (`hamc/blastproof@v0.16.0`) — the wrapper
 - the **`version`** input — which blastproof release the wrapper installs from
   npm, defaulting to `latest`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blastproof",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Open-source AI testing agent for pull requests. Diff in, confidence out.",
   "license": "MIT",
   "author": "Heitor Cardozo <heitor.augusto@gmail.com>",


### PR DESCRIPTION
Moves every version surface together, as `CONTRIBUTING.md` requires: `package.json`, the changelog entry, and the three `hamc/blastproof@v0.15.0` refs in `docs/ci.md`. `grep -rn 'blastproof@v' README.md docs/` finds nothing older than the new tag.

## Dogfooded first

The scheduled run against `main` this morning executed the full suite in a real browser: **8 of 8, Score 100, 93 model calls, 153k tokens.** That is the only end-to-end signal this project has of itself, and the twelve commits being released touched the executor loop, the action schema and the judge — so it was worth waiting a day for.

## What ships

The headline is that **`provider: openai` works, and never did.** The schema was refused before the model was asked anything, so the documented default made zero model calls for every user who ever tried it, and said only `Provider returned error`.

Alongside it: the agent skill, a pinned verdict, a blocked click that names what is blocking it, the first outside contribution, and provider errors that are quoted rather than summarised.

## The one thing that could surprise someone

An absent field is now sent as `null` rather than omitted — that is what makes strict providers accept the request. A provider that omits a key instead will have its answer rejected and retried. Four were checked and none does, and the changelog says so rather than leaving it to be discovered.

Build, typecheck, 562 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121JsiawVuEUZZbLTpj25D3