### PR TITLE
fix: keep the drafts already paid for when one route cannot be written

### DIFF
--- a/openspec/changes/isolate-a-failed-write/.openspec.yaml
+++ b/openspec/changes/isolate-a-failed-write/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/isolate-a-failed-write/design.md
+++ b/openspec/changes/isolate-a-failed-write/design.md
@@ -1,0 +1,48 @@
+# Design: isolate-a-failed-write
+
+## Context
+
+The per-route loop in `planCommand` handles two failures. Generation is contained: any error that is not a budget stop is recorded against the route and the loop continues (D9). Persistence is contained only for `PlannerError`; anything else is rethrown and ends the run.
+
+`writeDraft` today wraps every filesystem fault in a `PlannerError` — @abhijeetnardele24-hash's fix for the missing directory (#77) put the `mkdir` and the `writeFile` inside one `try`. So the escape is currently unreachable, and the defect #75 describes is not reproducible on `main`.
+
+That is exactly the state worth writing down rather than closing quietly. The containment lives in the callee's discipline, not in the loop, and nothing says so — the next person to add a line to the write branch, or to narrow what `writeDraft` catches, restores the defect and no test notices.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The loop is isolated by its own construction, not by what the function it calls happens to throw
+- The behaviour #75 asks for is covered by a test that fails if the escape returns
+
+**Non-Goals:** changing which routes fail, retrying a failed write, or reshaping the error message.
+
+## Decisions
+
+### D1: Contain by kind-independence, not by adding kinds
+The write branch stops discriminating on the error type and does what the generation branch does: record the reason, print it, continue. Not `catch (PlannerError | SomeOtherError)` — the list of filesystem faults worth surviving is open-ended, and enumerating it is how this loop came to have two different answers for the same question.
+
+The alternative — leave the code, add only the test — was rejected. The test would pass today for a reason that is not the property being asserted: it would be exercising `writeDraft`'s wrapping, and it would keep passing if the loop were made worse.
+
+### D2: A route that fails to write is not a generated route
+`generated.push(route)` happens before the write, so the branch pops it. That is existing behaviour for the collision case and it stays: `Generated:` names routes that produced a file, and a route reported under both headings would be worse than either.
+
+### D3: The unreachable branch is worth a test
+The second test mocks `writeDraft` to throw a plain `Error`, which no current code path produces. That is deliberate. It pins the contract at the boundary — the loop survives a write failure it does not recognise — instead of pinning it at whatever `writeDraft` currently guarantees. It is the only test in this change that would have failed before it.
+
+## Rejected alternatives
+
+- **Test only, no code change** — asserts the callee's behaviour while claiming the caller's (D1)
+- **Rethrow only for programmer errors (`TypeError`, `RangeError`)** — a plausible-sounding rule that puts the drafts already paid for behind a taxonomy nobody will maintain, and every one of those errors is still reported and still exits non-zero when contained
+- **Persist drafts to a temporary location before the loop ends** — a real improvement to a different problem (a budget stop discards drafts too) and much larger; it belongs to whoever takes #13's ground
+
+## Risks / Trade-offs
+
+- **An unexpected error now prints one line instead of a stack.** The reason is reported, the route is named, and the exit code is non-zero — but a programmer error in this branch is quieter than it was. Accepted: the loop's job is to finish the routes, and a run that stops silently mid-way is the failure this change exists to prevent.
+
+## Migration Plan
+
+Nothing to migrate. Behaviour changes only on a path no current code reaches.
+
+## Open Questions
+
+- **Should a budget stop still discard the drafts it interrupted?** Same shape as this one, larger, and out of scope. Worth an issue.

--- a/openspec/changes/isolate-a-failed-write/proposal.md
+++ b/openspec/changes/isolate-a-failed-write/proposal.md
@@ -1,0 +1,32 @@
+# Proposal: isolate-a-failed-write
+
+## Why
+
+`plan --write` contains a *generation* failure and lets a *write* failure end the run (#75). One route that cannot be persisted discards the routes still to come, and no `--- Plan ---` summary prints, so the user is not even told which routes succeeded.
+
+Every draft is a model call against a live page. This is the one loop in the codebase where abandoning early costs money already spent.
+
+The escape is `throw error` in the write branch of `src/commands/plan.ts`, sixty lines after the generation branch does the opposite for the same class of fault.
+
+## What Changes
+
+- The write branch reports the route as failed and continues, whatever the error's kind — the same treatment the generation branch sixty lines above already gives
+- Tests covering both: a recognised write failure with routes after it, and an unrecognised one
+
+## Capabilities
+
+### Modified Capabilities
+
+- `test-generation`: per-route isolation covers persistence, not only generation, and does not depend on which error was raised
+
+## Impact
+
+- New dependencies: **none**
+- Affects: the write branch of `src/commands/plan.ts` and `tests/plan.test.ts`
+- No config surface, no flag, no output format change. A run where every route writes cleanly is byte-identical
+
+## Non-goals
+
+- **No change to what fails.** A collision still refuses to overwrite and still fails its route; this is only about what happens to the routes after it
+- **No retry, no partial write, no cleanup.** A route that could not be written stays unwritten
+- **Not the readability of the underlying filesystem error** — #75 separates that explicitly, and `writeDraft` already names the path and the remedy

--- a/openspec/changes/isolate-a-failed-write/specs/test-generation/spec.md
+++ b/openspec/changes/isolate-a-failed-write/specs/test-generation/spec.md
@@ -1,0 +1,18 @@
+# Spec delta: test-generation (isolate-a-failed-write)
+
+## MODIFIED Requirements
+
+### Requirement: Per-route isolation
+A failure affecting one route SHALL NOT prevent generation for the remaining routes. This SHALL hold for a failure to persist a draft as well as a failure to generate one, and SHALL NOT depend on which kind of error was raised: every draft is a model call against a live page, so the routes still to come are worth more than any distinction between one filesystem fault and another.
+
+#### Scenario: One route fails to load
+- **WHEN** generation is requested for `/cart` and `/settings` and `/settings` fails to load
+- **THEN** `/cart` still produces a draft and `/settings` is reported as failed with its reason
+
+#### Scenario: One route fails to persist
+- **WHEN** three routes are generated with `--write` and the second cannot be written
+- **THEN** the third is still attempted, the second is reported as failed with its reason, and the run exits non-zero
+
+#### Scenario: A write failure the command does not recognise
+- **WHEN** persisting a draft raises an error of a kind the command does not handle
+- **THEN** that route is reported as failed and the remaining routes are still attempted, rather than the run ending with no summary

--- a/openspec/changes/isolate-a-failed-write/tasks.md
+++ b/openspec/changes/isolate-a-failed-write/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: isolate-a-failed-write
+
+## 1. Contain the write branch
+
+- [x] 1.1 `src/commands/plan.ts` — the write branch records the route as failed and continues for any error, matching the generation branch above it (design D1)
+- [x] 1.2 The failed route is not counted as generated (design D2)
+
+## 2. Tests
+
+- [x] 2.1 `tests/plan.test.ts` — three routes with `--write`, the second colliding with an existing file: the third is still written, the summary names the second, exit code is 1
+- [x] 2.2 `tests/plan.test.ts` — `writeDraft` throws an error the command does not recognise: the route is reported and the remaining route is still attempted (design D3)
+- [x] 2.3 Mutation: restored `throw error` in the write branch — 2.2 fails, 2.1 and the other 18 pass. That is the predicted result: `writeDraft` wraps the collision itself, so only the kind-independent test protects the loop
+
+## 3. Verification
+
+- [x] 3.1 `npm run build`
+- [x] 3.2 `npm run typecheck`
+- [x] 3.3 `npm test` — 564 passed, 33 files

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -8,7 +8,6 @@ import { createModel, MissingApiKeyError } from '../llm/provider.js';
 import {
   coveredRoutes,
   generateForRoute,
-  PlannerError,
   renderTestYaml,
   writeDraft,
   type TestDraft,
@@ -311,13 +310,15 @@ export async function planCommand(options: PlanOptions): Promise<number> {
           written.push(path.relative(options.cwd, file));
           console.log(`  wrote ${path.relative(options.cwd, file)}`);
         } catch (error) {
-          if (error instanceof PlannerError) {
-            generated.pop();
-            failed.push({ route, reason: error.message });
-            console.log(`  X failed: ${error.message}`);
-            continue;
-          }
-          throw error;
+          // Per-route isolation (design D9) covers persistence too, and does not
+          // discriminate on the error's kind: every draft already cost a model call
+          // against a live page, so one route that cannot be written must not
+          // discard the routes still to come.
+          generated.pop();
+          const reason = error instanceof Error ? error.message : String(error);
+          failed.push({ route, reason });
+          console.log(`  X failed: ${reason}`);
+          continue;
         }
       } else {
         console.log(`\n${renderTestYaml(draft, { route, base })}`);

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -5,14 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DiffError } from '../src/diff.js';
 import { BudgetExhaustedError } from '../src/runner/budget.js';
 
-const { launchMock, getChangedFilesMock, createPlannerMock, generateForRouteMock } = vi.hoisted(
-  () => ({
+const { launchMock, getChangedFilesMock, createPlannerMock, generateForRouteMock, writeDraftMock } =
+  vi.hoisted(() => ({
     launchMock: vi.fn(),
     getChangedFilesMock: vi.fn(),
     createPlannerMock: vi.fn(),
     generateForRouteMock: vi.fn(),
-  }),
-);
+    // Spy, not a stand-in: it delegates to the real writeDraft unless a test says
+    // otherwise, so the write path stays exercised for real everywhere else.
+    writeDraftMock: vi.fn(),
+  }));
 
 vi.mock('playwright', () => ({ chromium: { launch: launchMock } }));
 
@@ -28,12 +30,15 @@ vi.mock('../src/llm/brain.js', async (importOriginal) => {
 
 vi.mock('../src/planner.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../src/planner.js')>();
-  return { ...original, generateForRoute: generateForRouteMock };
+  return { ...original, generateForRoute: generateForRouteMock, writeDraft: writeDraftMock };
 });
 
 import { EXIT_FAILED, EXIT_OK, EXIT_USAGE } from '../src/commands/run.js';
 import { planCommand } from '../src/commands/plan.js';
 import { PlannerError } from '../src/planner.js';
+
+const { writeDraft: realWriteDraft } =
+  await vi.importActual<typeof import('../src/planner.js')>('../src/planner.js');
 
 const CART_TEST = `summary: Cart discount
 priority: P0
@@ -75,6 +80,8 @@ beforeEach(async () => {
   getChangedFilesMock.mockReset();
   createPlannerMock.mockReset();
   generateForRouteMock.mockReset();
+  writeDraftMock.mockReset();
+  writeDraftMock.mockImplementation(realWriteDraft);
 
   launchMock.mockResolvedValue(fakeBrowser());
   // Preflight probes the provider and base_url with plain `fetch`; stubbed so
@@ -345,6 +352,50 @@ describe('planCommand failure isolation', () => {
     expect(await readdir(testsDir())).toEqual(['cart.yaml']);
     expect(out()).toContain('Failed:');
     expect(out()).toContain('/settings: Cannot load /settings: timeout');
+    expect(out()).toContain('Generated: /cart');
+  });
+
+  it('keeps writing after one route cannot be persisted, and still prints the summary', async () => {
+    // /settings already exists, so its write is refused (never overwrite). Every
+    // draft is a model call against a live page: the routes after it must survive.
+    await writeProject({ 'settings.yaml': CART_TEST });
+
+    const code = await planCommand({
+      cwd: dir,
+      routes: ['/cart', '/settings', '/profile'],
+      write: true,
+    });
+
+    expect(code).toBe(EXIT_FAILED);
+    expect((await readdir(testsDir())).sort()).toEqual(['cart.yaml', 'profile.yaml', 'settings.yaml']);
+    expect(out()).toContain('Failed:');
+    expect(out()).toContain('/settings: Refusing to overwrite');
+    // Reported as failed, not as generated: it produced no file.
+    expect(out()).toContain('Generated: /cart, /profile');
+    // The existing file is the one that was there before, untouched.
+    await expect(readFile(path.join(testsDir(), 'settings.yaml'), 'utf8')).resolves.toContain(
+      'apply a discount',
+    );
+  });
+
+  it('keeps writing after a write failure it does not recognise', async () => {
+    // No current code path produces this: writeDraft wraps every filesystem fault
+    // in a PlannerError. The isolation must belong to this loop rather than to
+    // what the function it calls happens to throw (design D3, #75).
+    await writeProject();
+    writeDraftMock.mockImplementation(
+      async (cwd: string, draft: unknown, meta: { route: string }) => {
+        if (meta.route === '/settings') throw new Error('EROFS: read-only file system');
+        return realWriteDraft(cwd, draft as never, meta as never);
+      },
+    );
+
+    const code = await planCommand({ cwd: dir, routes: ['/settings', '/cart'], write: true });
+
+    expect(code).toBe(EXIT_FAILED);
+    expect(writeDraftMock).toHaveBeenCalledTimes(2);
+    expect(await readdir(testsDir())).toEqual(['cart.yaml']);
+    expect(out()).toContain('/settings: EROFS: read-only file system');
     expect(out()).toContain('Generated: /cart');
   });
 });


### PR DESCRIPTION
`plan --write` contained a *generation* failure and let a *write* failure end the run. One route that could not be persisted discarded every route after it — along with the `--- Plan ---` summary that would have said which ones succeeded. Each of those drafts is a model call against a live page, so this is the one loop in the codebase where stopping early throws away money already spent.

The write branch now does what the generation branch sixty lines above it already does: record the reason, print it, continue.

```diff
-          if (error instanceof PlannerError) { … continue; }
-          throw error;
+          generated.pop();
+          const reason = error instanceof Error ? error.message : String(error);
+          failed.push({ route, reason });
+          console.log(`  X failed: ${reason}`);
+          continue;
```

It deliberately stops discriminating on the error's kind. The list of filesystem faults worth surviving is open-ended, and enumerating it is how this loop came to hold two different answers to the same question.

## The part worth knowing before reviewing

**The escape is unreachable on `main`.** @abhijeetnardele24-hash's #77 put the `mkdir` and the `writeFile` inside one `try`, so `writeDraft` wraps every fault in a `PlannerError` and the defect #75 describes does not reproduce today.

That is the reason to write it down rather than close the issue quietly: the containment lives in the callee's discipline, not in the loop, and nothing said so. The next person to narrow what `writeDraft` catches restores the defect and no test notices.

So the second test mocks a write failure the command does not recognise (`EROFS`), which no current path produces. It pins the property at the boundary — *the loop survives a write failure it does not recognise* — instead of at whatever `writeDraft` currently happens to guarantee.

## Verification

- **Mutation.** Restored `throw error`: the `EROFS` test fails, the other 19 pass. Exactly the predicted split — `writeDraft` wraps the collision itself, so only the kind-independent test protects the loop.
- Three routes with `--write`, the second colliding: the third is still written, the summary names the second, exit 1, and the pre-existing file is untouched.
- `npm run build`, `npm run typecheck`, `npm test` — 564 passed, 33 files.

## Not in scope

A collision still refuses to overwrite and still fails its route; this changes only what happens to the routes after it. No retry, no partial write, no cleanup. Making the underlying filesystem error readable is separate — #75 says so explicitly, and `writeDraft` already names the path and the remedy.

~~One thing this surfaces and does not fix: a budget stop still discards the drafts it interrupted.~~ **Retracted — this was asserted here without being checked, and it is false.** `generateForRoute` makes one model call per route and `countedGenerate` checks the budget before spending, so exhaustion is raised at the start of a route, never between two calls of one. Earlier routes are already written; the interrupted route cost a page load and a snapshot and no model call. `Not attempted` is the right report. Corrected in the design in #92.

Part of #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvjettzBPbQSrjvAFXpK8

