### PR TITLE
fix: ask for the exact accessible name before widening it

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Three questions. The first one decides most cases.
 
 **A hard requirement, not a preference.** blastproof finds elements the way a screen reader does — by role, by label, by visible text. That is what removes selectors and survives redesigns. The cost is that there is deliberately no CSS or XPath fallback, so anything the accessibility tree cannot describe cannot be driven at all.
 
+The name is matched **exactly first**, then by substring if nothing matches exactly — so a control named `Add` is found even when `Add New` sits above it. When several controls answer to the same name, the first one on the page wins. Give each control an accessible name no other control on the page shares; a page that cannot offer one cannot be driven unambiguously, and no matching rule fixes that.
+
 | works | cannot be driven |
 | --- | --- |
 | `<button>Add to cart</button>` | a `<div>` with a click handler |

--- a/openspec/changes/match-the-name-the-model-named/.openspec.yaml
+++ b/openspec/changes/match-the-name-the-model-named/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/match-the-name-the-model-named/design.md
+++ b/openspec/changes/match-the-name-the-model-named/design.md
@@ -1,0 +1,75 @@
+# Design: match-the-name-the-model-named
+
+## Context
+
+`resolveTarget` builds up to three candidates — `getByRole(role, {name})`, `getByLabel(name)`, `getByText(text ?? name)` — and returns the first whose `.first()` becomes visible within the configured timeout.
+
+Two defaults do the damage, and neither is written down anywhere a user reads. Playwright's `name` option matches by substring, case-insensitively, unless `exact: true` is passed. And `.first()` resolves ambiguity by DOM order, silently.
+
+The prompt has told the model to use the exact accessible name since the executor was written. The resolver has never asked for one.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A page that offers a unique accessible name is driven by that name, not by a longer one that happens to contain it
+- A name that answers to several visible controls stops being resolved by DOM order
+- A suite that works today keeps working
+
+**Non-Goals:** rescuing a page that genuinely has no unique name for the control (D5), normalization, a selector fallback, prompt changes.
+
+## Decisions
+
+### D1: Exact first, loose as fallback — within each strategy, not across them
+The chain stays as it is and each strategy tries exact then loose *within itself*, in order: role-exact, role-loose, label-exact, label-loose, text-exact, text-loose.
+
+The alternative — all three exact, then all three loose — sounds tidier and is wrong: it lets a *text* exact match beat a *role* match, and the role match is the one carrying the model's own reading of the snapshot. Strategy order is the stronger signal and stays outermost.
+
+A straight swap to `exact: true` with no fallback was rejected outright. It turns a working step into `Element not found` for anyone whose snapshot text differs from the accessible name by whitespace or truncation — a regression delivered to every existing user in exchange for a defect most of them have not hit.
+
+### D2: Ambiguity is refused, not guessed — and only among visible elements
+When a candidate matches more than one **visible** element, the action fails with a message naming the count, rather than `.first()` picking one. The model then re-decides with a fresh snapshot and can name something more specific; the refusal costs one attempt against the existing per-step retry budget.
+
+The precedent is the repeated-commit refusal (`A step does not repeat a commit it already performed`): a resolver that declines and explains is better than one that guesses, and the cost of declining is already budgeted for.
+
+`visible` is load-bearing and not a detail. A real application carries hidden duplicates constantly — a closed dropdown's options, an off-screen mobile nav, a modal not yet opened. Counting raw matches would refuse actions that are not ambiguous at all to a user, which is the expensive direction of error. Playwright's `filter({ visible: true })` is the same predicate resolution already waits on.
+
+### D3: Ambiguity is checked only where it can be acted on
+The refusal fires when the *exact* match is ambiguous. An ambiguous *loose* match is not refused — it is the fallback, reached only because nothing exact existed, and refusing there would break the forgiving behaviour D1 exists to preserve. The loose path keeps `.first()` and, being the fallback, is now reached far less often.
+
+### D4: The interfaces widen, and that is the real cost
+`PageLike.getByRole` takes `{name?}` only; `getByLabel` and `getByText` take a bare string; `LocatorLike` has no `count()` and no `filter()`. All three need widening, and the four test files implementing them (`actions`, `auth`, `containment`, `executor`) need updating.
+
+Worth stating in the proposal rather than discovering in review: the diff is larger than the behaviour change, and most of it is doubles. `PageLike` is *implemented* by every double rather than passed as options, deliberately — the comment on `waitForLoadState` explains why — so widening it is loud, which is the property we want.
+
+### D5: What this does not fix, said in the change rather than found later
+Both witnesses in #60 survive this change:
+
+- `Create` against a page offering only `Create a local account` — exact finds nothing, the loose fallback resolves it exactly as today
+- `Payee` naming a row cell when the column header is the only button with that name — exact matches the header, uniquely
+
+Neither is a matching defect. The page has no unique accessible name for the control the model wants, and no rule can conjure one. The honest answer is #60's own: *the page cannot be driven unambiguously*, which is a finding for the user, not something for the resolver to paper over. The obstruction half of the first witness is already handled by `name-what-blocks-the-click`.
+
+Writing this down is the point of the change having a design. A reader who assumes the witnesses are fixed will measure the wrong thing and conclude the fix failed.
+
+## Rejected alternatives
+
+- **`exact: true` with no fallback** — regresses every suite relying on the loose match, knowingly or not (D1)
+- **Normalizing whitespace and case before comparing** — reintroduces the widening this change removes, with a bespoke rule instead of Playwright's
+- **Naming the rival candidates in the refusal** — attractive, and it puts page content into a message that does not pass through the secrets mask. Deferred until that path is checked; the count alone is enough for the model to re-decide
+- **Counting all matches rather than visible ones** — refuses actions that are unambiguous to a user (D2)
+- **A CSS/XPath escape hatch for ambiguous names** — the absence of one is the product
+
+## Risks / Trade-offs
+
+- **`count()` adds a round trip per resolution attempt.** Bounded and small next to the model call it follows, but it is on the hot path and should be measured, not assumed.
+- **A page with two visible identical controls now fails where it previously acted.** That is the intent — it previously acted on an arbitrary one — but it will be experienced as a new failure by whoever was silently getting the right one.
+- **Exact-first changes which element is chosen** on any page where both an exact and a longer loose match exist. That is the fix, and it is also the only way this can surprise someone.
+
+## Migration Plan
+
+No config, no flag, no file format. Behaviour differs only on pages where the two matches disagree.
+
+## Open Questions
+
+- **Does `filter({ visible: true })` interact badly with the visibility wait already in the loop?** Resolution waits for `.first()` to become visible; counting visible matches *before* that wait can see zero on a page still settling. Order of operations needs deciding in implementation — most likely wait first, count after.
+- **Should an ambiguous name be surfaced to the user as a page finding, not only to the model?** #60 argues yes, and it is the more valuable half. Out of scope here; worth its own change once this one is measured.

--- a/openspec/changes/match-the-name-the-model-named/design.md
+++ b/openspec/changes/match-the-name-the-model-named/design.md
@@ -33,8 +33,29 @@ The precedent is the repeated-commit refusal (`A step does not repeat a commit i
 
 `visible` is load-bearing and not a detail. A real application carries hidden duplicates constantly — a closed dropdown's options, an off-screen mobile nav, a modal not yet opened. Counting raw matches would refuse actions that are not ambiguous at all to a user, which is the expensive direction of error. Playwright's `filter({ visible: true })` is the same predicate resolution already waits on.
 
-### D3: Ambiguity is checked only where it can be acted on
-The refusal fires when the *exact* match is ambiguous. An ambiguous *loose* match is not refused — it is the fallback, reached only because nothing exact existed, and refusing there would break the forgiving behaviour D1 exists to preserve. The loose path keeps `.first()` and, being the fallback, is now reached far less often.
+### D3: Ambiguity is refused wherever it occurs, exact or loose
+The refusal fires whenever a candidate answers to more than one visible element — on the exact attempt and on the loose fallback alike.
+
+**This reverses the first version of this decision, which refused only on the exact path.** The reasoning there was that refusing on the fallback would break the forgiving behaviour D1 exists to preserve. That conflated two different things. Forgiveness is a loose match finding **one** element — a name differing by whitespace or truncation. Guessing is a loose match finding **several**. Refusing the second does not touch the first.
+
+Worse, the first version left the most common shape of this defect completely unguarded, because substring ambiguity is by its nature a *loose*-match phenomenon. Measured on a page with `Salvar o arquivo como PDF` and `Salvar o arquivo e sair`, against the name `Salvar o arquivo`:
+
+| attempt | matches | visible |
+|---|---|---|
+| `getByRole('button', { name: 'Salvar o arquivo', exact: true })` | 0 | 0 |
+| `getByRole('button', { name: 'Salvar o arquivo' })` | 2 | 2 |
+
+Exact finds nothing, the fallback finds two, and under the first version `.first()` picked one in silence — the exact defect #60 describes, surviving the change meant to fix it.
+
+The false positive that motivated the first version was measured and does not exist. Playwright matches the **smallest** element containing the text, so a `<div><p><span>` nesting counts once, not three times:
+
+```
+getByText('Salvar o arquivo', { exact: true })  ->  2 matches: SPAN, LABEL
+```
+
+Two genuinely distinct elements, not one element counted twice. There is no nesting inflation to protect against.
+
+What remains true from the first version is `visible`: hidden duplicates are real and must not count (D2).
 
 ### D4: The interfaces widen, and that is the real cost
 `PageLike.getByRole` takes `{name?}` only; `getByLabel` and `getByText` take a bare string; `LocatorLike` has no `count()` and no `filter()`. All three need widening, and the four test files implementing them (`actions`, `auth`, `containment`, `executor`) need updating.
@@ -57,12 +78,13 @@ Writing this down is the point of the change having a design. A reader who assum
 - **Normalizing whitespace and case before comparing** — reintroduces the widening this change removes, with a bespoke rule instead of Playwright's
 - **Naming the rival candidates in the refusal** — attractive, and it puts page content into a message that does not pass through the secrets mask. Deferred until that path is checked; the count alone is enough for the model to re-decide
 - **Counting all matches rather than visible ones** — refuses actions that are unambiguous to a user (D2)
+- **Refusing only when the *exact* match is ambiguous** — the first version of D3, reversed after measurement: it leaves the substring case, which is the defect in #60, entirely unguarded (D3)
 - **A CSS/XPath escape hatch for ambiguous names** — the absence of one is the product
 
 ## Risks / Trade-offs
 
 - **`count()` adds a round trip per resolution attempt.** Bounded and small next to the model call it follows, but it is on the hot path and should be measured, not assumed.
-- **A page with two visible identical controls now fails where it previously acted.** That is the intent — it previously acted on an arbitrary one — but it will be experienced as a new failure by whoever was silently getting the right one.
+- **A page with two visible controls answering to one name now fails where it previously acted.** This is the largest risk in the change and it grew with D3: refusing on the loose fallback means any suite whose step names a prefix of two controls stops working, where today `.first()` sometimes lands on the right one. That is luck, and luck that silently clicks the wrong control is the whole of #60 — but it will be experienced as a regression by whoever was lucky. Task 5.3 measures it against the demo suite before this ships.
 - **Exact-first changes which element is chosen** on any page where both an exact and a longer loose match exist. That is the fix, and it is also the only way this can surprise someone.
 
 ## Migration Plan

--- a/openspec/changes/match-the-name-the-model-named/design.md
+++ b/openspec/changes/match-the-name-the-model-named/design.md
@@ -15,7 +15,7 @@ The prompt has told the model to use the exact accessible name since the executo
 - A name that answers to several visible controls stops being resolved by DOM order
 - A suite that works today keeps working
 
-**Non-Goals:** rescuing a page that genuinely has no unique name for the control (D5), normalization, a selector fallback, prompt changes.
+**Non-Goals:** rescuing a page that genuinely has no unique name for the control (D5), widening what the resolver knows about a target beyond role and name (D7), normalization, a selector fallback, prompt changes.
 
 ## Decisions
 
@@ -26,15 +26,47 @@ The alternative — all three exact, then all three loose — sounds tidier and 
 
 A straight swap to `exact: true` with no fallback was rejected outright. It turns a working step into `Element not found` for anyone whose snapshot text differs from the accessible name by whitespace or truncation — a regression delivered to every existing user in exchange for a defect most of them have not hit.
 
-### D2: Ambiguity is refused, not guessed — and only among visible elements
+### D2: Ambiguity is refused, not guessed — counted among visible elements
 When a candidate matches more than one **visible** element, the action fails with a message naming the count, rather than `.first()` picking one. The model then re-decides with a fresh snapshot and can name something more specific; the refusal costs one attempt against the existing per-step retry budget.
 
 The precedent is the repeated-commit refusal (`A step does not repeat a commit it already performed`): a resolver that declines and explains is better than one that guesses, and the cost of declining is already budgeted for.
 
-`visible` is load-bearing and not a detail. A real application carries hidden duplicates constantly — a closed dropdown's options, an off-screen mobile nav, a modal not yet opened. Counting raw matches would refuse actions that are not ambiguous at all to a user, which is the expensive direction of error. Playwright's `filter({ visible: true })` is the same predicate resolution already waits on.
+**What `visible` does and does not do, measured rather than assumed.** The first draft of this decision claimed the filter was load-bearing across the board. Playwright 1.62, one visible control and one duplicate hidden four different ways, `name` matched exactly:
 
-### D3: Ambiguity is refused wherever it occurs, exact or loose
-The refusal fires whenever a candidate answers to more than one visible element — on the exact attempt and on the loose fallback alike.
+| how the duplicate is hidden | `getByRole` all / visible | `getByText` all / visible |
+|---|---|---|
+| `hidden` attribute | 1 / 1 | 2 / 1 |
+| `display: none` | 1 / 1 | 2 / 1 |
+| `visibility: hidden` | 1 / 1 | 2 / 1 |
+| closed `<details>` | 1 / 1 | 2 / 1 |
+| `.sr-only` (`clip-path: inset(50%)`, 1px) | **2 / 2** | **2 / 2** |
+| absolutely positioned off-screen | **2 / 2** | **2 / 2** |
+
+Two things follow, and neither was in the first draft.
+
+**The filter is nearly redundant on the role strategy.** `getByRole` reads the accessibility tree, which already excludes everything hidden the four ordinary ways. It earns its place on `getByLabel` and `getByText`, which match DOM nodes regardless. Keep it on all three — the cost is one round trip and the asymmetry is not worth encoding — but the justification is the text strategy, not the role one.
+
+**The filter does not catch the case that matters most to this project's audience.** The canonical `.sr-only` pattern keeps a real box, so Playwright calls it visible and both strategies count it. A page that gives a visible control an accessible-name twin for screen readers would now be refused where today it acts. That is a false positive landing precisely on people who wrote accessible markup — the only people blastproof works for at all.
+
+**Measured against real accessible sites, and the refusal did not survive it.** Task 0.1 asked how often a screen-reader twin shares a visible control's exact role and accessible name. Playwright's own locator, `exact: true`, `filter({ visible: true })`:
+
+| page | sampled name | all / visible | the refusal would |
+|---|---|---|---|
+| gov.uk | `link "Benefits"` | 2 / 2 | **refuse** |
+| gov.uk | `link "Business and self-employed"` | 2 / 2 | **refuse** |
+| gov.uk | `link "Driving and transport"` | 2 / 2 | **refuse** |
+| github.com | `link "Pricing"` | 2 / 2 | **refuse** |
+| github.com | `link "Sign in"` | 1 / 1 | resolve |
+| developer.mozilla.org | `link "Learn web development"` | 1 / 1 | resolve |
+
+Sweeping gov.uk's whole page: 25 accessible names are shared by two elements of the same role, and 22 of those pairs contain a twin whose box is 1px or less. This is not an exotic case; it is how a responsive accessible site is built.
+
+The refusal would therefore refuse ordinary navigation on the reference example of accessible markup — against the only audience blastproof works for at all. **D2 and D3 are not implemented.** `.first()` still resolves an ambiguous name by document order, as before, and that remains a real defect: unfixed, and now measured.
+
+The gate in task 0.2 did its job. This is the outcome it existed to produce, rather than a discovery made after shipping.
+
+### D3: Ambiguity is refused wherever it occurs, exact or loose — *not implemented*
+The refusal fires whenever a candidate answers to more than one visible element — on the exact attempt and on the loose fallback alike. **Superseded by the measurement in D2: this half of the change did not ship.** The reasoning below stands and is kept because it is what the next attempt has to beat.
 
 **This reverses the first version of this decision, which refused only on the exact path.** The reasoning there was that refusing on the fallback would break the forgiving behaviour D1 exists to preserve. That conflated two different things. Forgiveness is a loose match finding **one** element — a name differing by whitespace or truncation. Guessing is a loose match finding **several**. Refusing the second does not touch the first.
 
@@ -72,6 +104,20 @@ Neither is a matching defect. The page has no unique accessible name for the con
 
 Writing this down is the point of the change having a design. A reader who assumes the witnesses are fixed will measure the wrong thing and conclude the fix failed.
 
+### D6: The refusal carries the rule, not only the count — *not implemented, ships with the refusal*
+The message is read by the model, not by a person — it is the whole feedback loop this decision creates. So it states the count *and* what to do about it: give the shortest name that identifies this control on its own.
+
+A count alone tells the model that something is wrong and leaves it to guess the remedy; on a page with several similar controls the natural guess is to try a *different* control, which is the wrong move and spends another attempt. Naming the rule turns a refusal into an instruction, at no cost in bytes that matters.
+
+The message carries **no page text** — the count and the rule only. Naming the rival candidates would be more useful and would put page content into a string that does not pass through the secrets mask. Deferred until that path is checked (see rejected alternatives).
+
+### D7: The real limit is that resolution has one signal
+A role and an accessible name are all this resolver knows about a target. That is why ambiguity is unresolvable here: three `Excluir` buttons in three table rows are genuinely indistinguishable to a matcher that sees only role and name, and no rule over that pair separates them.
+
+Refusing is the correct answer *given one signal*. It is not the correct answer in general — a resolver that also knew the target's position, its enclosing structure, or its appearance would resolve most of these without asking the model anything.
+
+The measurement in D2 turns this from an observation into the conclusion of the whole change. Stating it changes what the `.sr-only` false positive is. It is not a bug in the counting rule to be patched with a better visibility predicate; it is the same one-signal limit showing up from the other side — two elements that share a role and a name and differ only in a signal we do not read. Widening the signal set is a change of its own and belongs in an issue, not in a heuristic bolted onto this one.
+
 ## Rejected alternatives
 
 - **`exact: true` with no fallback** — regresses every suite relying on the loose match, knowingly or not (D1)
@@ -80,12 +126,15 @@ Writing this down is the point of the change having a design. A reader who assum
 - **Counting all matches rather than visible ones** — refuses actions that are unambiguous to a user (D2)
 - **Refusing only when the *exact* match is ambiguous** — the first version of D3, reversed after measurement: it leaves the substring case, which is the defect in #60, entirely unguarded (D3)
 - **A CSS/XPath escape hatch for ambiguous names** — the absence of one is the product
+- **A stricter visibility predicate to exclude `.sr-only`** — a minimum box area, or an in-viewport test, would exclude the 1px clipped element and would be a heuristic invented to dodge a symptom. It would also start refusing genuinely visible small controls (an icon button). The honest framing is D7's
+- **Matching loosely by default, with exactness opted into per step** — the sensible default when the target is *described by a person*, because a loose match absorbs the author's typos. It does not transfer here: our name is an accessible name **transcribed from the snapshot by the model**, so there is no human typo to forgive, and the instruction already tells the model to give the name exactly. Defaulting to loose would mean widening a name that was never approximate to begin with
 
 ## Risks / Trade-offs
 
-- **`count()` adds a round trip per resolution attempt.** Bounded and small next to the model call it follows, but it is on the hot path and should be measured, not assumed.
-- **A page with two visible controls answering to one name now fails where it previously acted.** This is the largest risk in the change and it grew with D3: refusing on the loose fallback means any suite whose step names a prefix of two controls stops working, where today `.first()` sometimes lands on the right one. That is luck, and luck that silently clicks the wrong control is the whole of #60 — but it will be experienced as a regression by whoever was lucky. Task 5.3 measures it against the demo suite before this ships.
-- **Exact-first changes which element is chosen** on any page where both an exact and a longer loose match exist. That is the fix, and it is also the only way this can surprise someone.
+- ~~**A page with two visible controls answering to one name now fails where it previously acted.**~~ Removed with the refusal (D2). It was the largest risk in the change, and measuring it is what stopped the change from carrying it.
+- ~~**`count()` adds a round trip per resolution attempt.**~~ Gone with the refusal: nothing counts any more.
+- **Exact-first changes which element is chosen** on any page where an exact and a longer loose match both exist. That is the fix, and it is the only way what shipped can surprise someone.
+- **The defect in #60 is half closed, and the report still cannot say which half.** A name answering to several controls is resolved by document order exactly as before. The issue stays open.
 
 ## Migration Plan
 
@@ -95,3 +144,5 @@ No config, no flag, no file format. Behaviour differs only on pages where the tw
 
 - **Does `filter({ visible: true })` interact badly with the visibility wait already in the loop?** Resolution waits for `.first()` to become visible; counting visible matches *before* that wait can see zero on a page still settling. Order of operations needs deciding in implementation — most likely wait first, count after.
 - **Should an ambiguous name be surfaced to the user as a page finding, not only to the model?** #60 argues yes, and it is the more valuable half. Out of scope here; worth its own change once this one is measured.
+- ~~**What happens to a page carrying `.sr-only` twins of visible controls?**~~ Answered by measurement, and it changed what ships (D2). The argument for accepting the refusal — that an `.sr-only` twin of a *visible* control's exact role and name is rarer than it sounds — is false: 22 such pairs on a single page of gov.uk. The refusal is out. What stays open is its successor: **how does the resolver come to know more than a role and a name?** That is D7's question and needs a change of its own.
+- **Is a stricter visibility predicate worth revisiting now?** It was rejected as a heuristic invented to dodge a symptom, and the measurement makes it look more necessary without making it more principled. Recorded rather than reopened: it would still refuse a genuinely small visible control, and it would still leave two full-size twins ambiguous.

--- a/openspec/changes/match-the-name-the-model-named/proposal.md
+++ b/openspec/changes/match-the-name-the-model-named/proposal.md
@@ -11,7 +11,7 @@ The loud failures are the lucky ones. The unlucky one is a substring that resolv
 ## What Changes
 
 - Resolution asks for the **exact** accessible name first and falls back to today's substring match only when the exact one finds nothing, so a page that offers a unique name is driven by it
-- When a match is **ambiguous among visible elements** — on the exact attempt or on the loose fallback — the action is refused and the model is told how many controls answer to that name, instead of `.first()` choosing in silence. It costs one failed attempt, exactly as the repeated-commit refusal does. A name that is a prefix of two controls is ambiguous precisely on the fallback, which is where this defect lives
+- ~~Refusing an ambiguous name instead of letting `.first()` choose in silence.~~ **Cut before implementation, by this change's own gate.** Measured on real accessible sites, the refusal refuses ordinary navigation: on gov.uk, 22 accessible names are shared between a visible control and a screen-reader twin that Playwright counts as visible. `.first()` still resolves by document order, and that half of #60 stays open. The design carries the measurement and the reasoning the next attempt has to beat
 - The README stops promising "by role, by label, by visible text" without saying how the name is compared
 
 ## Capabilities
@@ -25,10 +25,16 @@ The loud failures are the lucky ones. The unlucky one is a substring that resolv
 - New dependencies: **none**
 - Affects: `resolveTarget` in `src/runner/actions.ts`, the `PageLike`/`LocatorLike` interfaces it resolves through, the four test files implementing them, and `README.md`
 - **This changes element resolution for every existing suite.** The fallback chain is what keeps it from being a regression: a step that works today because the loose match found the only candidate still works
+- Interfaces widen by one optional flag; `count()` and `filter()` are not needed, because the refusal was cut
+
+## Known limit, measured
+
+Resolution knows two things about a target: its role and its accessible name. Two controls sharing both are indistinguishable here, and every answer available to a matcher over that pair is either a guess or a refusal. Refusing was designed, then measured, then cut — the `.sr-only` pattern keeps a real box, so a screen-reader twin counts as visible and ordinary links become "ambiguous". The way out is not a better rule over two signals; it is more signals, and that is a change of its own.
 
 ## Non-goals
 
 - **No fix for the two Actual Budget witnesses in #60.** Stated plainly because the issue implies otherwise: a step naming `Create` where the page offers only `Create a local account` still falls back and still resolves it, and a `Payee` column header that is the only button with that name is still the exact match. Neither is a matching bug — the page has no unique name for the thing the model wants, and no matching rule can invent one. What this change fixes is the case where a unique name **does** exist and loses to a longer one, and the case where several controls share a name and one is picked silently
 - **No CSS or XPath fallback.** The absence of one is the product
 - **No normalization** of whitespace, case or truncation beyond what Playwright's exact match already does
-- **No change to the prompt.** The instruction was already right
+- **No change to the prompt.** The instruction was already right — the refusal message is where the rule is repeated, because that is where the model is listening
+- **No widening of what the resolver knows about a target.** Position, structure and appearance would dissolve most ambiguity and are a change of their own

--- a/openspec/changes/match-the-name-the-model-named/proposal.md
+++ b/openspec/changes/match-the-name-the-model-named/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: match-the-name-the-model-named
+
+## Why
+
+`prompts.ts` tells the executor to pick targets "using their exact role and accessible name". `actions.ts` then matches that name by **substring, case-insensitively**, and when several elements match it takes `.first()` in DOM order without telling anyone (#60).
+
+The model is not the problem here — it did what it was told. This is the same shape as #57 and #72: a rule stated in a prompt and quietly widened by the code beneath it.
+
+The loud failures are the lucky ones. The unlucky one is a substring that resolves to the wrong control and the action **succeeds** on it: the run then reports a verdict about a control nobody targeted, and nothing in the report can say so, because nothing knows.
+
+## What Changes
+
+- Resolution asks for the **exact** accessible name first and falls back to today's substring match only when the exact one finds nothing, so a page that offers a unique name is driven by it
+- When a match is **ambiguous among visible elements**, the action is refused and the model is told the name is ambiguous and how many controls answer to it, instead of `.first()` choosing in silence. It costs one failed attempt, exactly as the repeated-commit refusal does
+- The README stops promising "by role, by label, by visible text" without saying how the name is compared
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agentic-execution`: live element resolution prefers an exact accessible-name match, and refuses an ambiguous one rather than guessing
+
+## Impact
+
+- New dependencies: **none**
+- Affects: `resolveTarget` in `src/runner/actions.ts`, the `PageLike`/`LocatorLike` interfaces it resolves through, the four test files implementing them, and `README.md`
+- **This changes element resolution for every existing suite.** The fallback chain is what keeps it from being a regression: a step that works today because the loose match found the only candidate still works
+
+## Non-goals
+
+- **No fix for the two Actual Budget witnesses in #60.** Stated plainly because the issue implies otherwise: a step naming `Create` where the page offers only `Create a local account` still falls back and still resolves it, and a `Payee` column header that is the only button with that name is still the exact match. Neither is a matching bug — the page has no unique name for the thing the model wants, and no matching rule can invent one. What this change fixes is the case where a unique name **does** exist and loses to a longer one, and the case where several controls share a name and one is picked silently
+- **No CSS or XPath fallback.** The absence of one is the product
+- **No normalization** of whitespace, case or truncation beyond what Playwright's exact match already does
+- **No change to the prompt.** The instruction was already right

--- a/openspec/changes/match-the-name-the-model-named/proposal.md
+++ b/openspec/changes/match-the-name-the-model-named/proposal.md
@@ -11,7 +11,7 @@ The loud failures are the lucky ones. The unlucky one is a substring that resolv
 ## What Changes
 
 - Resolution asks for the **exact** accessible name first and falls back to today's substring match only when the exact one finds nothing, so a page that offers a unique name is driven by it
-- When a match is **ambiguous among visible elements**, the action is refused and the model is told the name is ambiguous and how many controls answer to it, instead of `.first()` choosing in silence. It costs one failed attempt, exactly as the repeated-commit refusal does
+- When a match is **ambiguous among visible elements** — on the exact attempt or on the loose fallback — the action is refused and the model is told how many controls answer to that name, instead of `.first()` choosing in silence. It costs one failed attempt, exactly as the repeated-commit refusal does. A name that is a prefix of two controls is ambiguous precisely on the fallback, which is where this defect lives
 - The README stops promising "by role, by label, by visible text" without saying how the name is compared
 
 ## Capabilities

--- a/openspec/changes/match-the-name-the-model-named/specs/agentic-execution/spec.md
+++ b/openspec/changes/match-the-name-the-model-named/specs/agentic-execution/spec.md
@@ -7,7 +7,9 @@ The executor SHALL resolve target elements exclusively from the current accessib
 
 An accessible name SHALL be matched exactly before it is matched loosely. Each resolution strategy SHALL attempt an exact match and fall back to a substring match only when the exact one finds nothing; strategy order SHALL remain outermost, so a role match still precedes a label or text match regardless of how precisely each matched. The model is instructed to name elements exactly, and the resolver SHALL NOT widen that instruction without first honouring it.
 
-When an exact match answers to more than one **visible** element, the action SHALL be refused and the model SHALL be told the name is ambiguous and how many controls answer to it, rather than an arbitrary one being chosen. The refusal SHALL count as one failed attempt against the existing per-step retry budget. Ambiguity SHALL be assessed among visible elements only, because a hidden duplicate — a closed menu's options, an unopened modal — is not ambiguous to a user. A loose match SHALL NOT be refused for ambiguity: it is reached only when nothing matched exactly, and refusing there would remove the forgiving behaviour the fallback exists to preserve.
+When a match answers to more than one **visible** element, the action SHALL be refused and the model SHALL be told the name is ambiguous and how many controls answer to it, rather than an arbitrary one being chosen. This SHALL apply to the exact attempt and to the loose fallback alike, because a name that is a prefix of two controls is ambiguous precisely on the fallback. The refusal SHALL count as one failed attempt against the existing per-step retry budget.
+
+Ambiguity SHALL be assessed among visible elements only, because a hidden duplicate — a closed menu's options, an unopened modal — is not ambiguous to a user. A loose match resolving to exactly one element SHALL still be used: that is the forgiveness the fallback exists for, and it is distinct from a loose match resolving to several, which is a guess.
 
 A control the page gives no unique accessible name SHALL NOT be resolved by any rule in this requirement, and that is the intended outcome: such a page cannot be driven unambiguously, which is a finding about the application rather than a defect in resolution.
 
@@ -42,6 +44,14 @@ A control the page gives no unique accessible name SHALL NOT be resolved by any 
 #### Scenario: An ambiguous name is refused, not guessed
 - **WHEN** two visible controls share the accessible name the model targeted
 - **THEN** the action is refused, the model is told how many controls answer to that name, and one failed attempt is spent
+
+#### Scenario: A name that is a prefix of two controls is refused
+- **WHEN** the model targets `Salvar o arquivo` and the page shows `Salvar o arquivo como PDF` and `Salvar o arquivo e sair`
+- **THEN** the exact attempt finds nothing, the loose fallback finds two, and the action is refused rather than resolved to whichever comes first in the document
+
+#### Scenario: A loose match with one candidate is still used
+- **WHEN** no element's name equals the name given and exactly one contains it
+- **THEN** that element is resolved, because one candidate is forgiveness and several is a guess
 
 #### Scenario: A hidden duplicate is not ambiguity
 - **WHEN** one visible control and several hidden ones share an accessible name

--- a/openspec/changes/match-the-name-the-model-named/specs/agentic-execution/spec.md
+++ b/openspec/changes/match-the-name-the-model-named/specs/agentic-execution/spec.md
@@ -1,0 +1,48 @@
+# Spec delta: agentic-execution (match-the-name-the-model-named)
+
+## MODIFIED Requirements
+
+### Requirement: Live element resolution
+The executor SHALL resolve target elements exclusively from the current accessibility snapshot (role/name/text) on every action attempt and SHALL NOT persist selectors between steps or runs. The configured browser timeout SHALL bound how long resolution waits for a candidate element to become visible, and SHALL bound navigation, so that a slow application is waited for rather than retried at.
+
+An accessible name SHALL be matched exactly before it is matched loosely. Each resolution strategy SHALL attempt an exact match and fall back to a substring match only when the exact one finds nothing; strategy order SHALL remain outermost, so a role match still precedes a label or text match regardless of how precisely each matched. The model is instructed to name elements exactly, and the resolver SHALL NOT widen that instruction without first honouring it.
+
+When an exact match answers to more than one **visible** element, the action SHALL be refused and the model SHALL be told the name is ambiguous and how many controls answer to it, rather than an arbitrary one being chosen. The refusal SHALL count as one failed attempt against the existing per-step retry budget. Ambiguity SHALL be assessed among visible elements only, because a hidden duplicate — a closed menu's options, an unopened modal — is not ambiguous to a user. A loose match SHALL NOT be refused for ambiguity: it is reached only when nothing matched exactly, and refusing there would remove the forgiving behaviour the fallback exists to preserve.
+
+A control the page gives no unique accessible name SHALL NOT be resolved by any rule in this requirement, and that is the intended outcome: such a page cannot be driven unambiguously, which is a finding about the application rather than a defect in resolution.
+
+#### Scenario: Self-healing after UI change
+- **WHEN** an action fails because the target element is not found
+- **THEN** the executor retries with a fresh snapshot, allowing the LLM to pick an alternative element, up to the configured per-step retry budget (default 3)
+
+#### Scenario: A slow element is waited for
+- **WHEN** the configured browser timeout is 10 seconds and a target element becomes visible after 4 seconds
+- **THEN** resolution succeeds without consuming a retry, because waiting is bounded by the configured timeout rather than by a fixed shorter one
+
+#### Scenario: Navigation honours the configured timeout
+- **WHEN** a `navigate` action runs against an application configured with a browser timeout
+- **THEN** that timeout bounds the navigation, rather than a value fixed in the code
+
+#### Scenario: The timeout is a wait, not a retry
+- **WHEN** an element never appears within the configured timeout
+- **THEN** the attempt fails and the existing retry budget applies unchanged, so raising the timeout never increases the number of attempts
+
+#### Scenario: An exact name is not lost to a longer one
+- **WHEN** a page shows a button named `Add New` before a button named `Add`, and the model targets `Add`
+- **THEN** the button named `Add` is resolved, rather than the first element whose name contains it
+
+#### Scenario: A name that matches nothing exactly still resolves
+- **WHEN** no element's accessible name equals the name given, and one contains it
+- **THEN** resolution falls back to the substring match, so a snapshot whose text differs by whitespace or truncation still drives the page
+
+#### Scenario: Strategy order outranks match precision
+- **WHEN** a role match is available loosely and a text match is available exactly
+- **THEN** the role match is used, because the strategy order carries the model's reading of the snapshot
+
+#### Scenario: An ambiguous name is refused, not guessed
+- **WHEN** two visible controls share the accessible name the model targeted
+- **THEN** the action is refused, the model is told how many controls answer to that name, and one failed attempt is spent
+
+#### Scenario: A hidden duplicate is not ambiguity
+- **WHEN** one visible control and several hidden ones share an accessible name
+- **THEN** the visible one is resolved, because ambiguity is assessed among visible elements only

--- a/openspec/changes/match-the-name-the-model-named/specs/agentic-execution/spec.md
+++ b/openspec/changes/match-the-name-the-model-named/specs/agentic-execution/spec.md
@@ -7,11 +7,9 @@ The executor SHALL resolve target elements exclusively from the current accessib
 
 An accessible name SHALL be matched exactly before it is matched loosely. Each resolution strategy SHALL attempt an exact match and fall back to a substring match only when the exact one finds nothing; strategy order SHALL remain outermost, so a role match still precedes a label or text match regardless of how precisely each matched. The model is instructed to name elements exactly, and the resolver SHALL NOT widen that instruction without first honouring it.
 
-When a match answers to more than one **visible** element, the action SHALL be refused and the model SHALL be told the name is ambiguous and how many controls answer to it, rather than an arbitrary one being chosen. This SHALL apply to the exact attempt and to the loose fallback alike, because a name that is a prefix of two controls is ambiguous precisely on the fallback. The refusal SHALL count as one failed attempt against the existing per-step retry budget.
+When a match answers to more than one visible element, the executor SHALL resolve it in document order, as it does today. Refusing an ambiguous name was designed and then measured out: on real accessible pages a control's screen-reader twin shares its role and accessible name and is counted visible, so the refusal would refuse ordinary navigation. This remains a known defect, not a decided behaviour.
 
-Ambiguity SHALL be assessed among visible elements only, because a hidden duplicate — a closed menu's options, an unopened modal — is not ambiguous to a user. A loose match resolving to exactly one element SHALL still be used: that is the forgiveness the fallback exists for, and it is distinct from a loose match resolving to several, which is a guess.
-
-A control the page gives no unique accessible name SHALL NOT be resolved by any rule in this requirement, and that is the intended outcome: such a page cannot be driven unambiguously, which is a finding about the application rather than a defect in resolution.
+Resolution SHALL identify a target by its role and accessible name only. A control the page gives no unique accessible name SHALL NOT be resolved by any rule in this requirement, and that is the intended outcome: such a page cannot be driven unambiguously by those two signals, which is a finding about the application rather than a defect in resolution.
 
 #### Scenario: Self-healing after UI change
 - **WHEN** an action fails because the target element is not found
@@ -41,18 +39,10 @@ A control the page gives no unique accessible name SHALL NOT be resolved by any 
 - **WHEN** a role match is available loosely and a text match is available exactly
 - **THEN** the role match is used, because the strategy order carries the model's reading of the snapshot
 
-#### Scenario: An ambiguous name is refused, not guessed
-- **WHEN** two visible controls share the accessible name the model targeted
-- **THEN** the action is refused, the model is told how many controls answer to that name, and one failed attempt is spent
-
-#### Scenario: A name that is a prefix of two controls is refused
-- **WHEN** the model targets `Salvar o arquivo` and the page shows `Salvar o arquivo como PDF` and `Salvar o arquivo e sair`
-- **THEN** the exact attempt finds nothing, the loose fallback finds two, and the action is refused rather than resolved to whichever comes first in the document
-
 #### Scenario: A loose match with one candidate is still used
 - **WHEN** no element's name equals the name given and exactly one contains it
 - **THEN** that element is resolved, because one candidate is forgiveness and several is a guess
 
-#### Scenario: A hidden duplicate is not ambiguity
-- **WHEN** one visible control and several hidden ones share an accessible name
-- **THEN** the visible one is resolved, because ambiguity is assessed among visible elements only
+#### Scenario: An ambiguous name still resolves in document order
+- **WHEN** two visible controls share the accessible name the model targeted
+- **THEN** the first in document order is used, unchanged from before, because refusing was measured to refuse ordinary navigation on real accessible pages

--- a/openspec/changes/match-the-name-the-model-named/tasks.md
+++ b/openspec/changes/match-the-name-the-model-named/tasks.md
@@ -15,10 +15,12 @@
 
 ## 3. Refuse an ambiguous name
 
-- [ ] 3.1 Refuse when the exact match answers to more than one **visible** element, naming the count (design D2/D3)
+- [ ] 3.1 Refuse when a match — exact attempt or loose fallback — answers to more than one **visible** element, naming the count (design D2/D3)
 - [ ] 3.2 Settle the ordering question from the design's open questions — wait, then count — and write the answer into the code comment
 - [ ] 3.3 Unit test: two visible controls sharing a name refuse, and the message names the count
 - [ ] 3.4 Unit test: one visible and three hidden controls sharing a name resolve normally — the hidden-duplicate case is the expensive false positive
+- [ ] 3.4a Unit test: `Salvar o arquivo` against `Salvar o arquivo como PDF` and `Salvar o arquivo e sair` — exact finds nothing, loose finds two, refused. This is the shape the first version of D3 left unguarded
+- [ ] 3.4b Unit test: a loose match with exactly one candidate still resolves, so forgiveness survives the refusal
 - [ ] 3.5 Unit test: the refusal spends one attempt and the model re-decides, rather than ending the step outright
 - [ ] 3.6 Confirm the refusal message carries no page text, only a count (design: rejected alternatives)
 
@@ -31,7 +33,7 @@
 
 - [ ] 5.1 Mutation: drop `exact` from the role strategy and confirm 2.2 fails
 - [ ] 5.2 Mutation: restore `.first()` in place of the ambiguity refusal and confirm 3.3 fails
-- [ ] 5.3 Live against `examples/demo-app`: the full suite still passes, unchanged. This is the regression that matters — every step in it resolves through this function
+- [ ] 5.3 Live against `examples/demo-app`: the full suite still passes, unchanged. This is the regression that matters — every step in it resolves through this function, and D3's risk is that a step relying on `.first()` landing well now refuses
 - [ ] 5.4 Live against a page with a real prefix collision, measuring which element is clicked before and after
 - [ ] 5.5 Measure the `count()` round trip on the hot path (design risk), or record that it was not measurable next to the model call
 - [ ] 5.6 `npm run build`, `npm run typecheck`, `npm test`

--- a/openspec/changes/match-the-name-the-model-named/tasks.md
+++ b/openspec/changes/match-the-name-the-model-named/tasks.md
@@ -1,39 +1,38 @@
 # Tasks: match-the-name-the-model-named
 
+## 0. Settle before implementing
+
+- [x] 0.1 Measured the `.sr-only` case against real accessible applications, not a fixture. gov.uk: 25 accessible names shared by two same-role elements, 22 with a 1px twin; `link "Benefits"`, `link "Business and self-employed"` and `link "Driving and transport"` each `all=2 visible=2`. github.com: `link "Pricing"` 2/2, `link "Sign in"` 1/1. developer.mozilla.org: 1/1 on both sampled (design D2)
+- [x] 0.2 **Decided: the refusal does not ship.** It would refuse ordinary navigation on the reference example of accessible markup, against the only audience the tool works for. Sections 3 and parts of 1 are cut; section 2 is unaffected and ships alone (design D2/D7)
+
 ## 1. Widen the interfaces
 
-- [ ] 1.1 `PageLike`: `getByRole(role, options?: { name?: string; exact?: boolean })`, `getByLabel(text, options?: { exact?: boolean })`, `getByText(text, options?: { exact?: boolean })`
-- [ ] 1.2 `LocatorLike`: `count(): Promise<number>` and `filter(options: { visible?: boolean }): LocatorLike`
-- [ ] 1.3 Update the four test doubles (`tests/actions.test.ts`, `tests/auth.test.ts`, `tests/containment.test.ts`, `tests/executor.test.ts`). Widening `PageLike` is deliberately loud (design D4) — a double that cannot express exactness cannot support this guarantee
+- [x] 1.1 `PageLike`: `getByRole(role, options?: { name?: string; exact?: boolean })`, `getByLabel(text, options?: { exact?: boolean })`, `getByText(text, options?: { exact?: boolean })`
+- [x] 1.2 ~~`LocatorLike`: `count()` and `filter()`~~ — not needed once the refusal was cut. Nothing counts
+- [x] 1.3 The four test doubles needed no change: each returns one locator regardless of options, which is why a name-aware double had to be written for section 2 (`pageOf` in `tests/actions.test.ts`)
 
 ## 2. Exact first, loose as fallback
 
-- [ ] 2.1 `resolveTarget`: each strategy tries exact then loose, strategy order unchanged (design D1)
-- [ ] 2.2 Unit test: a page offering both `Add` and `Add New`, with `Add New` first in DOM order, resolves `Add` to `Add` — this is the silent wrong-element case, and it fails before the change
-- [ ] 2.3 Unit test: a name that matches nothing exactly still resolves through the loose fallback, so today's forgiving behaviour survives
-- [ ] 2.4 Unit test: strategy order still beats match precision — a role match wins over a text exact match
+- [x] 2.1 `resolveTarget`: each strategy tries exact then loose, strategy order unchanged (design D1)
+- [x] 2.2 Unit test: `Add New` first in document order, `Add` targeted, resolves to `Add` — the silent wrong-element case
+- [x] 2.3 Unit test: a name matching nothing exactly still resolves through the loose fallback
+- [x] 2.4 Unit test: strategy order beats match precision — a loose *role* match wins over an exact *text* match, so a step naming a field does not resolve to the heading above it
+- [x] 2.5 Unit test: every strategy asks for the exact match before the loose one, in order
 
-## 3. Refuse an ambiguous name
+## 3. Refuse an ambiguous name — *cut by task 0.2*
 
-- [ ] 3.1 Refuse when a match — exact attempt or loose fallback — answers to more than one **visible** element, naming the count (design D2/D3)
-- [ ] 3.2 Settle the ordering question from the design's open questions — wait, then count — and write the answer into the code comment
-- [ ] 3.3 Unit test: two visible controls sharing a name refuse, and the message names the count
-- [ ] 3.4 Unit test: one visible and three hidden controls sharing a name resolve normally — the hidden-duplicate case is the expensive false positive
-- [ ] 3.4a Unit test: `Salvar o arquivo` against `Salvar o arquivo como PDF` and `Salvar o arquivo e sair` — exact finds nothing, loose finds two, refused. This is the shape the first version of D3 left unguarded
-- [ ] 3.4b Unit test: a loose match with exactly one candidate still resolves, so forgiveness survives the refusal
-- [ ] 3.5 Unit test: the refusal spends one attempt and the model re-decides, rather than ending the step outright
-- [ ] 3.6 Confirm the refusal message carries no page text, only a count (design: rejected alternatives)
+- [x] 3.1 Not implemented. A unit test pins the surviving behaviour instead: an ambiguous name resolves in document order, with the reason it was not refused written beside it
 
 ## 4. Documentation
 
-- [ ] 4.1 `README.md` — the "by role, by label, by visible text" promise says how the name is compared, and what happens when it is ambiguous
-- [ ] 4.2 Record in the docs that a page with no unique accessible name for a control cannot be driven unambiguously (design D5), rather than leaving it to be discovered as a wrong verdict
+- [x] 4.1 `README.md` — the accessibility section says the name is matched exactly first, then by substring, and that the first control wins when several share a name
+- [x] 4.2 Recorded that a page whose controls do not carry distinct accessible names cannot be driven unambiguously, in the README and in the skill's enforcement table
+- [x] 4.3 `skills/blastproof/SKILL.md` — the accessibility contract gains the uniqueness clause; `references/authoring.md` gains the row, marked not enforceable, naming what changed and what did not
 
 ## 5. Verification
 
-- [ ] 5.1 Mutation: drop `exact` from the role strategy and confirm 2.2 fails
-- [ ] 5.2 Mutation: restore `.first()` in place of the ambiguity refusal and confirm 3.3 fails
-- [ ] 5.3 Live against `examples/demo-app`: the full suite still passes, unchanged. This is the regression that matters — every step in it resolves through this function, and D3's risk is that a step relying on `.first()` landing well now refuses
-- [ ] 5.4 Live against a page with a real prefix collision, measuring which element is clicked before and after
-- [ ] 5.5 Measure the `count()` round trip on the hot path (design risk), or record that it was not measurable next to the model call
-- [ ] 5.6 `npm run build`, `npm run typecheck`, `npm test`
+- [x] 5.1 Mutation: dropped `exact` from the role strategy — 2.2 and 2.5 fail, the other 10 pass
+- [ ] 5.2 ~~Mutation on the ambiguity refusal~~ — nothing to mutate
+- [ ] 5.3 Live against `examples/demo-app`: the full suite still passes. **Not run** — needs a model key; the scheduled dogfood covers it on merge
+- [ ] 5.4 ~~Live against a page with a real prefix collision~~ — superseded by 0.1, which measured real pages directly
+- [x] 5.7 `npm run build`, `npm run typecheck`, `npm test`

--- a/openspec/changes/match-the-name-the-model-named/tasks.md
+++ b/openspec/changes/match-the-name-the-model-named/tasks.md
@@ -33,6 +33,8 @@
 
 - [x] 5.1 Mutation: dropped `exact` from the role strategy — 2.2 and 2.5 fail, the other 10 pass
 - [ ] 5.2 ~~Mutation on the ambiguity refusal~~ — nothing to mutate
-- [ ] 5.3 Live against `examples/demo-app`: the full suite still passes. **Not run** — needs a model key; the scheduled dogfood covers it on merge
+- [x] 5.3 Live against `examples/demo-app`, real browser, `claude-haiku-4.5` via OpenRouter: **8 passed, 0 failed, Score 100, 92 model calls, 152,174 tokens.** The dogfood on the commit before this one ran the same 8 tests in 93 calls, so nothing regressed
+- [x] 5.5 Live against OWASP Juice Shop 20.2.0, a real application: basket journey **PASS** (363.6s), search journey PASS after the step was corrected (231.5s). Exact-first resolved every target, including `role=button name="dismiss cookie message" text="Me want it!"`, where the accessible name and the visible text disagree — the case the fallback chain exists for
+- [x] 5.6 Measured ambiguous names on Juice Shop's landing page: **zero** names answered by two visible same-role elements. The `.sr-only` false positive that cut the refusal is site-dependent, not universal — which does not change the verdict, since gov.uk is the reference for accessible markup and it fails, but the sample is worth recording as uneven
 - [ ] 5.4 ~~Live against a page with a real prefix collision~~ — superseded by 0.1, which measured real pages directly
 - [x] 5.7 `npm run build`, `npm run typecheck`, `npm test`

--- a/openspec/changes/match-the-name-the-model-named/tasks.md
+++ b/openspec/changes/match-the-name-the-model-named/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: match-the-name-the-model-named
+
+## 1. Widen the interfaces
+
+- [ ] 1.1 `PageLike`: `getByRole(role, options?: { name?: string; exact?: boolean })`, `getByLabel(text, options?: { exact?: boolean })`, `getByText(text, options?: { exact?: boolean })`
+- [ ] 1.2 `LocatorLike`: `count(): Promise<number>` and `filter(options: { visible?: boolean }): LocatorLike`
+- [ ] 1.3 Update the four test doubles (`tests/actions.test.ts`, `tests/auth.test.ts`, `tests/containment.test.ts`, `tests/executor.test.ts`). Widening `PageLike` is deliberately loud (design D4) — a double that cannot express exactness cannot support this guarantee
+
+## 2. Exact first, loose as fallback
+
+- [ ] 2.1 `resolveTarget`: each strategy tries exact then loose, strategy order unchanged (design D1)
+- [ ] 2.2 Unit test: a page offering both `Add` and `Add New`, with `Add New` first in DOM order, resolves `Add` to `Add` — this is the silent wrong-element case, and it fails before the change
+- [ ] 2.3 Unit test: a name that matches nothing exactly still resolves through the loose fallback, so today's forgiving behaviour survives
+- [ ] 2.4 Unit test: strategy order still beats match precision — a role match wins over a text exact match
+
+## 3. Refuse an ambiguous name
+
+- [ ] 3.1 Refuse when the exact match answers to more than one **visible** element, naming the count (design D2/D3)
+- [ ] 3.2 Settle the ordering question from the design's open questions — wait, then count — and write the answer into the code comment
+- [ ] 3.3 Unit test: two visible controls sharing a name refuse, and the message names the count
+- [ ] 3.4 Unit test: one visible and three hidden controls sharing a name resolve normally — the hidden-duplicate case is the expensive false positive
+- [ ] 3.5 Unit test: the refusal spends one attempt and the model re-decides, rather than ending the step outright
+- [ ] 3.6 Confirm the refusal message carries no page text, only a count (design: rejected alternatives)
+
+## 4. Documentation
+
+- [ ] 4.1 `README.md` — the "by role, by label, by visible text" promise says how the name is compared, and what happens when it is ambiguous
+- [ ] 4.2 Record in the docs that a page with no unique accessible name for a control cannot be driven unambiguously (design D5), rather than leaving it to be discovered as a wrong verdict
+
+## 5. Verification
+
+- [ ] 5.1 Mutation: drop `exact` from the role strategy and confirm 2.2 fails
+- [ ] 5.2 Mutation: restore `.first()` in place of the ambiguity refusal and confirm 3.3 fails
+- [ ] 5.3 Live against `examples/demo-app`: the full suite still passes, unchanged. This is the regression that matters — every step in it resolves through this function
+- [ ] 5.4 Live against a page with a real prefix collision, measuring which element is clicked before and after
+- [ ] 5.5 Measure the `count()` round trip on the hot path (design risk), or record that it was not measurable next to the model call
+- [ ] 5.6 `npm run build`, `npm run typecheck`, `npm test`

--- a/skills/blastproof/SKILL.md
+++ b/skills/blastproof/SKILL.md
@@ -152,6 +152,7 @@ The e2e tests resolve elements from the accessibility tree. Code that breaks
 these makes its own feature untestable:
 
 - Every interactive element carries an accessible name — visible text, `aria-label`, or a `<label>`.
+- That name is unique among the controls visible at the same time. Two controls sharing one cannot be told apart, and the first on the page wins silently.
 - Use real `button`, `a`, `input` and `select` elements. Never a `div` with a click handler.
 - Every form field has a label associated with it.
 - No primary user flow lives on a `canvas` or inside an `iframe`.

--- a/skills/blastproof/references/authoring.md
+++ b/skills/blastproof/references/authoring.md
@@ -40,6 +40,7 @@ Being precise about this matters more than it looks. A rule you believe is check
 | A step that enters a value writes the value | **Guaranteed by the runner** — a fill or a select whose value is in neither the step nor the page is refused at run time — and warned about at authoring time by a grammar check, which `--fail-on-authoring` turns into exit 1. |
 | Every step says what it should produce | **Not enforced.** Nothing fails when a step is a bare action. |
 | A verification names an outcome only a correct page satisfies | **Not enforced.** See below. |
+| A control is identified by a name no other visible control shares | **Not enforced, and not enforceable here.** The runner asks for an exact accessible-name match before a substring one, so `Add` no longer loses to `Add New`. But when several controls answer to the same name the first on the page wins, silently — this is a property of the application, not of the test. |
 
 The authoring check reads **English only**. Silence from it means "nothing found in English", never "this suite is clean".
 

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -15,9 +15,17 @@ export interface LocatorLike {
 
 export interface PageLike {
   goto(url: string, options?: { timeout?: number }): Promise<unknown>;
-  getByRole(role: string, options?: { name?: string }): LocatorLike;
-  getByLabel(text: string): LocatorLike;
-  getByText(text: string): LocatorLike;
+  /**
+   * `exact` is passed explicitly at every call site (design match-the-name D1):
+   * Playwright's default matches an accessible name by substring, which silently
+   * widens the rule the prompt states — pick the element by its *exact* role and
+   * accessible name. An optional flag here would be the same shape that let
+   * `timeoutMs` go unset at one call site, so a double that cannot express
+   * exactness cannot support this guarantee.
+   */
+  getByRole(role: string, options?: { name?: string; exact?: boolean }): LocatorLike;
+  getByLabel(text: string, options?: { exact?: boolean }): LocatorLike;
+  getByText(text: string, options?: { exact?: boolean }): LocatorLike;
   keyboard: { press(key: string): Promise<void> };
   screenshot(options: { path: string; fullPage?: boolean }): Promise<unknown>;
   url(): string;
@@ -141,11 +149,19 @@ function describeTarget(target: AgentTarget): string {
 
 /**
  * Resolves an element from the live accessibility tree only (self-healing, design D4):
- * getByRole → getByLabel → getByText, each with a visibility wait bounded by
- * `resolveTimeoutMs` — the configured `browser.timeout_ms`, threaded here via
- * {@link ActionContext.resolveTimeoutMs} by every real caller. The `2_000` default
- * only applies to a caller that resolves a target without going through
- * `performAction`'s context (e.g. a direct unit test).
+ * getByRole → getByLabel → getByText, each tried with an **exact** accessible-name
+ * match before the substring one Playwright defaults to (design match-the-name D1),
+ * and each with a visibility wait bounded by `resolveTimeoutMs` — the configured
+ * `browser.timeout_ms`, threaded here via {@link ActionContext.resolveTimeoutMs} by
+ * every real caller. The `2_000` default only applies to a caller that resolves a
+ * target without going through `performAction`'s context (e.g. a direct unit test).
+ *
+ * An ambiguous name is still resolved by `.first()`, in document order, silently.
+ * That was designed away and then measured back in: refusing a name answering to
+ * several visible elements would refuse ordinary navigation on real accessible
+ * sites, because the `.sr-only` pattern keeps a real box and Playwright counts it
+ * visible. See the change's design (D2/D7) for the measurement and for why the
+ * answer is a wider signal set rather than a stricter visibility test.
  */
 export async function resolveTarget(
   page: PageLike,
@@ -153,14 +169,23 @@ export async function resolveTarget(
   resolveTimeoutMs = 2_000,
 ): Promise<LocatorLike> {
   const candidates: LocatorLike[] = [];
+  // Exact before loose, *within* each strategy rather than across them (design
+  // match-the-name D1). Strategy order carries the model's own reading of the
+  // snapshot and stays outermost: a role match must still beat a text match, even
+  // an exact one, or a step naming a field resolves to the heading above it.
   if (target.role) {
+    if (target.name) {
+      candidates.push(page.getByRole(target.role, { name: target.name, exact: true }));
+    }
     candidates.push(page.getByRole(target.role, target.name ? { name: target.name } : {}));
   }
   if (target.name) {
+    candidates.push(page.getByLabel(target.name, { exact: true }));
     candidates.push(page.getByLabel(target.name));
   }
   const text = target.text ?? target.name;
   if (text) {
+    candidates.push(page.getByText(text, { exact: true }));
     candidates.push(page.getByText(text));
   }
 

--- a/tests/actions.test.ts
+++ b/tests/actions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { ActionError, performAction, type LocatorLike, type PageLike } from '../src/runner/actions.js';
+import {
+  ActionError,
+  performAction,
+  resolveTarget,
+  type LocatorLike,
+  type PageLike,
+} from '../src/runner/actions.js';
 import type { AgentAction } from '../src/llm/schemas.js';
 
 const BASE = 'http://localhost:3000';
@@ -165,5 +171,155 @@ describe('an obstructed action', () => {
       waitForLoadState: async () => undefined,
     } as unknown as PageLike;
     await expect(performAction(page, CLICK, { baseUrl: BASE })).rejects.toThrow(/^Element not found:/);
+  });
+});
+
+/**
+ * A page whose elements have accessible names, so exact and substring matching are
+ * distinguishable — the doubles above return one locator whatever is asked for, which
+ * is fine for the failure paths they cover and useless here.
+ *
+ * `visible` is per element, and document order is array order, so the fake reproduces
+ * the two Playwright defaults this change is about: a name matches by substring, and
+ * `.first()` breaks a tie by position.
+ */
+interface FakeElement {
+  role: string;
+  name: string;
+  visible?: boolean;
+}
+
+function pageOf(elements: FakeElement[]): {
+  page: PageLike;
+  resolvedNames: () => string[];
+  queries: string[];
+} {
+  const queries: string[] = [];
+  const resolved: string[] = [];
+
+  const locatorFor = (matches: FakeElement[]): LocatorLike => {
+    const self: LocatorLike = {
+      click: async () => {},
+      fill: async () => {},
+      press: async () => {},
+      selectOption: async () => undefined,
+      waitFor: async () => {
+        const head = matches[0];
+        if (!head || head.visible === false) throw new Error('timeout');
+        resolved.push(head.name);
+      },
+      first: () => locatorFor(matches.slice(0, 1)),
+    };
+    return self;
+  };
+
+  const byName = (name: string, exact: boolean, role?: string): FakeElement[] =>
+    elements.filter(
+      (el) =>
+        (role === undefined || el.role === role) &&
+        (exact ? el.name === name : el.name.toLowerCase().includes(name.toLowerCase())),
+    );
+
+  const page = {
+    goto: async () => undefined,
+    getByRole: (role: string, options?: { name?: string; exact?: boolean }) => {
+      queries.push(`role:${role}:${options?.name ?? ''}:${options?.exact ? 'exact' : 'loose'}`);
+      return locatorFor(
+        options?.name === undefined
+          ? elements.filter((el) => el.role === role)
+          : byName(options.name, options.exact === true, role),
+      );
+    },
+    // No labels in this fake: the label strategy finds nothing, which is what a page
+    // of plain buttons does, and keeps these tests about role and text.
+    getByLabel: (text: string, options?: { exact?: boolean }) => {
+      queries.push(`label:${text}:${options?.exact ? 'exact' : 'loose'}`);
+      return locatorFor([]);
+    },
+    getByText: (text: string, options?: { exact?: boolean }) => {
+      queries.push(`text:${text}:${options?.exact ? 'exact' : 'loose'}`);
+      return locatorFor(byName(text, options?.exact === true));
+    },
+    keyboard: { press: async () => {} },
+    screenshot: async () => undefined,
+    url: () => BASE,
+    waitForLoadState: async () => undefined,
+  } as unknown as PageLike;
+
+  return { page, resolvedNames: () => resolved, queries };
+}
+
+describe('resolveTarget: exact accessible name before substring (spec agentic-execution: live element resolution)', () => {
+  it('does not lose an exact name to a longer one that contains it', async () => {
+    // "Add New" is first in document order, so today's substring match plus .first()
+    // clicks it — successfully, on the wrong control, with nothing able to say so.
+    const { page, resolvedNames } = pageOf([
+      { role: 'button', name: 'Add New' },
+      { role: 'button', name: 'Add' },
+    ]);
+
+    await resolveTarget(page, { role: 'button', name: 'Add' });
+
+    expect(resolvedNames()).toEqual(['Add']);
+  });
+
+  it('still resolves a name that matches nothing exactly', async () => {
+    // The forgiving behaviour the fallback exists for: a snapshot whose text differs
+    // from the accessible name by truncation still drives the page.
+    const { page, resolvedNames } = pageOf([{ role: 'button', name: 'Create a local account' }]);
+
+    await resolveTarget(page, { role: 'button', name: 'Create' });
+
+    expect(resolvedNames()).toEqual(['Create a local account']);
+  });
+
+  it('keeps strategy order above match precision', async () => {
+    // The heading matches the text strategy exactly; the field matches the role
+    // strategy only loosely. The field must win, or a step naming a field types into
+    // the heading above it.
+    const { page, resolvedNames, queries } = pageOf([
+      { role: 'heading', name: 'E-mail' },
+      { role: 'textbox', name: 'E-mail de contato' },
+    ]);
+
+    await resolveTarget(page, { role: 'textbox', name: 'E-mail' });
+
+    expect(resolvedNames()).toEqual(['E-mail de contato']);
+    // Locators are built up front and tried in order, so the text-exact query is
+    // still constructed — it simply never wins, because role comes first.
+    expect(queries.indexOf('role:textbox:E-mail:loose')).toBeLessThan(
+      queries.indexOf('text:E-mail:exact'),
+    );
+  });
+
+  it('asks for the exact match first on every strategy', async () => {
+    const { page, queries } = pageOf([]);
+
+    await expect(resolveTarget(page, { role: 'button', name: 'Ghost' })).rejects.toThrow(
+      /^Element not found:/,
+    );
+
+    expect(queries).toEqual([
+      'role:button:Ghost:exact',
+      'role:button:Ghost:loose',
+      'label:Ghost:exact',
+      'label:Ghost:loose',
+      'text:Ghost:exact',
+      'text:Ghost:loose',
+    ]);
+  });
+
+  it('resolves an ambiguous name by document order, as it did before', async () => {
+    // Not an oversight. Refusing here was designed and then measured out: on real
+    // accessible sites the .sr-only pattern gives ordinary links a visible twin, so
+    // the refusal would refuse navigation. See the change's design D2/D7.
+    const { page, resolvedNames } = pageOf([
+      { role: 'button', name: 'Excluir' },
+      { role: 'button', name: 'Excluir' },
+    ]);
+
+    await resolveTarget(page, { role: 'button', name: 'Excluir' });
+
+    expect(resolvedNames()).toEqual(['Excluir']);
   });
 });


### PR DESCRIPTION
`prompts.ts` tells the executor to pick targets "using their exact role and accessible name". `actions.ts` matched that name by **substring, case-insensitively** — Playwright's default without `exact: true` — and then took `.first()` in DOM order when several answered to it. The model was not the problem; it did what it was told. Same shape as #57 and #72: a rule stated in a prompt and widened by the code beneath it.

The loud failures were the lucky ones. The unlucky one is a substring resolving to the wrong control where the action then **succeeds**: the run reports a verdict about a control nobody targeted, and nothing in the report can say so.

## What shipped

**Exact before loose, within each strategy.** The chain is now role-exact, role-loose, label-exact, label-loose, text-exact, text-loose. A control named `Add` is no longer lost to an `Add New` sitting above it.

Strategy order stays outermost, deliberately: a *loose role* match must still beat an *exact text* match, or a step naming a field resolves to the heading above it. A test pins that.

The loose fallback is what keeps this from being a regression. A step working today because the loose match found the only candidate still works — verified live, including a real target whose accessible name and visible text disagree entirely (`role=button name="dismiss cookie message" text="Me want it!"` on Juice Shop).

## What did NOT ship, and why — read this before reviewing

**The ambiguity refusal was cut before implementation, by this change's own gate.**

The design proposed refusing a name that answers to several *visible* controls instead of letting `.first()` choose. It also required, as task 0.1, measuring that against a real accessible application before writing any code. That measurement:

| page | name | all / visible | the refusal would |
|---|---|---|---|
| gov.uk | `link "Benefits"` | 2 / 2 | **refuse** |
| gov.uk | `link "Business and self-employed"` | 2 / 2 | **refuse** |
| gov.uk | `link "Driving and transport"` | 2 / 2 | **refuse** |
| github.com | `link "Pricing"` | 2 / 2 | **refuse** |
| github.com | `link "Sign in"` | 1 / 1 | resolve |
| developer.mozilla.org | `link "Learn web development"` | 1 / 1 | resolve |

Sweeping gov.uk's whole page: **25 accessible names shared by two same-role elements, 22 of those pairs containing a twin whose box is 1px or less.** The canonical `.sr-only` pattern keeps a real box, so Playwright counts it visible.

The refusal would have refused ordinary navigation on the reference example of accessible markup — against the only audience this tool works for at all. It is out. The design keeps the measurement and the full reasoning, because that is what the next attempt has to beat.

One honest qualifier, measured the same day: Juice Shop's landing page has **zero** ambiguous names. The false positive is site-dependent, not universal. That does not change the verdict, but an uneven sample is recorded as uneven.

## So #60 stays open

An ambiguous name is still resolved by document order, silently, and the report still cannot say so. Half the issue is closed; the other half now has a measurement attached and a named cause.

That cause is worth stating plainly: **resolution knows two things about a target — a role and a name.** Every answer available to a matcher over those two signals is either a guess or a refusal that fires too often. The way out is more signals (position, enclosing structure), which is a change of its own and will get its own issue.

## Verification

- **Mutation.** Dropped `exact` from the role strategy: 2 tests fail, the other 10 pass.
- **demo-app, real browser**, `claude-haiku-4.5` via OpenRouter: **8 passed, 0 failed, Score 100, 92 model calls.** The dogfood on the commit before this ran the same 8 tests in 93 calls — nothing regressed.
- **OWASP Juice Shop 20.2.0**: basket journey PASS, search journey PASS. Both resolve every target through the new chain.
- `npm run build`, `npm run typecheck`, `npm test` — **569 passed**, 33 files.

## Also updated

`README.md` now says how the name is compared and that the first control wins a tie. The skill's accessibility contract gains a uniqueness clause, and `authoring.md` gains a row in the enforcement table marked **not enforceable** — naming exactly what changed and what did not, which is the point of that table.

Part of #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvjettzBPbQSrjvAFXpK8
