### PR TITLE
docs: move the release checklist out of the contributor's way

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Thanks for considering a contribution. Please read the first section before writ
 
 **No code change lands without an approved change proposal.** Specifications are the source of truth; the code implements them. This repository uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) to keep the two in step.
 
+For small, obvious fixes — a typo, a broken link, a wrong error message — open a pull request directly and say so. Judgment is welcome; the rule exists to keep behaviour and specification from drifting, not to add ceremony.
+
 The cycle:
 
 1. **Propose** — `openspec new change <kebab-name>`, then author `proposal.md` (why and what), `design.md` (how, with the alternatives you rejected and why) and `tasks.md` (checkboxes), plus spec deltas under `specs/<capability>/spec.md`
@@ -16,8 +18,6 @@ The cycle:
 Validate at any point with `openspec validate <change-name> --strict`.
 
 Specs use `SHALL` requirements, each with at least one `WHEN`/`THEN` scenario. Scenarios need exactly four hashtags (`#### Scenario:`) — three fails silently.
-
-For small, obvious fixes — a typo, a broken link, a wrong error message — open a pull request directly and say so. Judgment is welcome; the rule exists to keep behaviour and specification from drifting, not to add ceremony.
 
 **Do not edit `CHANGELOG.md`.** It is written at release time by whoever cuts the release. Every pull request that touches it edits the same top section, so it conflicts with every other pull request that does — two open ones already did. Describe the change in the pull request instead; that is what the entry gets written from.
 
@@ -62,29 +62,9 @@ Agentic runs cost tokens and need a real provider. Everything else — unit test
 
 ## Releases
 
-Publishing runs from a tag, never from a merge — a released version can never be edited and the package name is claimed permanently, so it takes a deliberate act:
+Publishing runs from a **tag**, never from a merge: the workflow refuses to publish if the tag and the manifest version disagree, rebuilds, re-runs the full verification, and publishes with npm provenance. So the package you install is built from a commit you can name.
 
-One commit moves every version surface together — `package.json`, the changelog entry, and the Action example in `docs/ci.md` — and the tag points at it:
-
-```bash
-# in one commit: bump package.json, write the CHANGELOG entry, update every
-# `uses: hamc/blastproof@vX.Y.Z` in docs/ci.md, then
-grep -rn 'blastproof@v' README.md docs/   # nothing older than the new tag
-git tag v0.1.0 && git push origin v0.1.0
-```
-
-The Action example lived in the README until 0.12.0 and this checklist still said so afterwards —
-the grep is here because a version surface that moves is exactly the one a checklist stops finding.
-
-The changelog entry is written **here**, not in the pull requests, and it is derived from what has landed since the last tag:
-
-```bash
-git log --oneline v0.1.0..main
-```
-
-Read that list before tagging. 0.7.0 shipped without a changelog entry because nobody did, and every other surface agreed with itself — which is exactly why the one that disagreed went unnoticed.
-
-The release workflow refuses to publish if the tag and the manifest version disagree, rebuilds and re-runs the full verification, and publishes with npm provenance. It needs an `NPM_TOKEN` secret on the repository.
+Cutting one is a maintainer task and lives in [RELEASING.md](RELEASING.md). The only part that binds a pull request is the rule above: **do not edit `CHANGELOG.md`.**
 
 ## Finding something to work on
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,41 @@
+# Releasing blastproof
+
+This is a maintainer's checklist. Nothing here is needed to open a pull request — see [CONTRIBUTING.md](CONTRIBUTING.md) for that.
+
+Publishing runs from a tag, never from a merge — a released version can never be edited and the package name is claimed permanently, so it takes a deliberate act:
+
+One commit moves every version surface together — `package.json`, the changelog entry, and the Action example in `docs/ci.md` — and the tag points at it:
+
+```bash
+# in one commit: bump package.json, write the CHANGELOG entry, update every
+# `uses: hamc/blastproof@vX.Y.Z` in docs/ci.md, then
+grep -rn 'blastproof@v' README.md docs/   # nothing older than the new tag
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+The Action example lived in the README until 0.12.0 and this checklist still said so afterwards —
+the grep is here because a version surface that moves is exactly the one a checklist stops finding.
+
+The changelog entry is written **here**, not in the pull requests, and it is derived from what has landed since the last tag:
+
+```bash
+git log --oneline v0.1.0..main
+```
+
+Read that list before tagging. 0.7.0 shipped without a changelog entry because nobody did, and every other surface agreed with itself — which is exactly why the one that disagreed went unnoticed.
+
+The release workflow refuses to publish if the tag and the manifest version disagree, rebuilds and re-runs the full verification, and publishes with npm provenance. It needs an `NPM_TOKEN` secret on the repository.
+
+`npm view blastproof version` can lag the workflow by a few minutes — `npm notice Your package is being processed` is the publish succeeding, not failing. Check the registry again before concluding anything went wrong.
+
+## The workflow does not create the GitHub Release
+
+Publishing to npm and tagging are automated. The Release on the repository's front page is not, and nothing fails when it is missing:
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z — <lowercase phrase>" --latest --notes-file <notes>
+```
+
+0.16.0 shipped to npm with the tag pushed and no Release, so the repository kept announcing 0.15.0 as the latest version to everyone who visited. It was caught by a person looking, which is the same way every version-surface gap here has been caught.
+
+The notes are narrative and worth more than the changelog entry they are drawn from: the changelog says what changed, the Release says why it mattered. Match the house format — `vX.Y.Z — <lowercase phrase>` for the title — by reading the previous one.

--- a/tests/docs-links.test.ts
+++ b/tests/docs-links.test.ts
@@ -19,11 +19,14 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
  * Markdown files that are part of the published documentation surface. The
  * skill is in here because AGENTS.md declares it user-facing content held to
  * the same bar as `action.yml`, and because its reader is a coding agent that
- * will follow a broken relative link without reporting anything.
+ * will follow a broken relative link without reporting anything. `RELEASING.md`
+ * is in here because it is reached only from `CONTRIBUTING.md`: a file nobody
+ * navigates to directly is the one whose link rots unnoticed.
  */
 const DOC_ROOTS = [
   'README.md',
   'CONTRIBUTING.md',
+  'RELEASING.md',
   'AGENTS.md',
   'skills/blastproof/SKILL.md',
   'skills/blastproof/references/authoring.md',


### PR DESCRIPTION
`## Releases` was **26 of CONTRIBUTING.md's 103 lines** — a quarter of the file — and none of it is actionable for someone opening a pull request. It also sat directly above "Finding something to work on", so a first-time reader crossed a publishing checklist they will never run to reach the section they came for.

No rule changes here. Only where someone meets it.

## Three moves

**The checklist goes to `RELEASING.md`.** Bumping the manifest, the `grep` for stale version references, the tag, reading `git log` since the last one.

**A three-line `## Releases` stays in CONTRIBUTING.md**, carrying the part that is not procedure: publishing runs from a tag with npm provenance, so the package you install is built from a commit you can name. That is supply-chain transparency and it is worth saying to a stranger deciding whether to install this. It also keeps the one release rule that binds a pull request — do not edit `CHANGELOG.md`.

**The "small, obvious fixes" paragraph moves up beside the bold rule it qualifies.** It said a typo or a wrong error message can go straight to a pull request, and that the proposal rule "exists to keep behaviour and specification from drifting, not to add ceremony" — while sitting twenty lines below the bold line, after four steps, four artifacts and a rule about hashtag counts.

That ordering matters more than the release split does. This project's one outside contribution so far was a missing `mkdir` — exactly the shape that paragraph permits, and exactly the contributor most likely to bounce off **"No code change lands without an approved change proposal"** before ever reaching the sentence that lets them in.

## RELEASING.md gains the step that was missing

The workflow publishes to npm and the tag is pushed by hand. **Nothing creates the GitHub Release**, and nothing fails when it is skipped:

> 0.16.0 shipped to npm with its tag pushed and no Release, so the repository kept announcing 0.15.0 as the latest version to everyone who visited. It was caught by a person looking.

Also recorded: `npm view` can lag the workflow by minutes, and `npm notice Your package is being processed` is the publish succeeding. That already read as a failed publish once.

## Verification

`tests/docs-links.test.ts` now covers `RELEASING.md` — it is reachable only from CONTRIBUTING.md, and a page nobody navigates to directly is the one whose links rot unnoticed. 569 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvjettzBPbQSrjvAFXpK8
