### PR TITLE
chore: release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes are recorded here. This project follows [semantic versioning](https://semver.org/);
 while it is pre-1.0, a minor bump may change existing behaviour and a patch never does.
 
+## [0.17.0] — 2026-09-03
+
+### Fixed
+
+- **An element named `Add` is no longer lost to an `Add New` above it.** The executor
+  is told to target elements by their exact accessible name; the resolver matched
+  that name by substring and, on a tie, took the first one in the page. It clicked,
+  it succeeded, and nothing in the report could say it had acted on a control nobody
+  targeted. Each strategy now asks for the exact name first and falls back to the
+  substring match only when nothing matches exactly, so a name that differs by
+  whitespace or truncation still works.
+- **One draft that cannot be written no longer discards the rest.** `plan --write`
+  contained a generation failure and let a write failure end the run — losing every
+  route after it, and the summary that would have said which ones succeeded. Each of
+  those drafts is a model call against a live page.
+
+### Known limitation
+
+- **When several visible controls share one accessible name, the first on the page
+  still wins, silently.** Refusing instead was designed and then measured out: on
+  real accessible sites a control's screen-reader twin shares its role and name and
+  counts as visible, so the refusal would have refused ordinary navigation. Give each
+  control a name no other visible control shares — a page that cannot is one this
+  tool cannot drive unambiguously.
+
 ## [0.16.0] — 2026-08-31
 
 ### Added

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,7 +27,7 @@ jobs:
 
       - run: npm start &          # however your app boots
 
-      - uses: hamc/blastproof@v0.16.0
+      - uses: hamc/blastproof@v0.17.0
         with:
           version: '0.11.0'       # pin both when this gates merges
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -51,7 +51,7 @@ failed" from "nothing ran".
 
 ```yaml
       - id: bp
-        uses: hamc/blastproof@v0.16.0
+        uses: hamc/blastproof@v0.17.0
         with:
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -73,7 +73,7 @@ workflow, which asserts that a shallow checkout is rejected.
 
 Two versions are in play, and they are independent:
 
-- the **action** ref (`hamc/blastproof@v0.16.0`) — the wrapper
+- the **action** ref (`hamc/blastproof@v0.17.0`) — the wrapper
 - the **`version`** input — which blastproof release the wrapper installs from
   npm, defaulting to `latest`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blastproof",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Open-source AI testing agent for pull requests. Diff in, confidence out.",
   "license": "MIT",
   "author": "Heitor Cardozo <heitor.augusto@gmail.com>",


### PR DESCRIPTION
Moves every version surface in one commit, per `RELEASING.md`: `package.json`, the changelog entry, and the **three** `hamc/blastproof@v0.16.0` refs in `docs/ci.md`.

- `grep -rn 'blastproof@v' README.md docs/` → nothing older than the new tag
- `node dist/cli.js --version` → `0.17.0`
- `npm test` → 569 passed, 33 files

## Minor, not patch

Exact-name resolution changes **which element is clicked** on any page where an exact and a longer substring match both exist. Pre-1.0, a minor bump may change existing behaviour and a patch never does.

## Verified on `697ea51` before tagging

The dogfood ran the full suite against a real browser on `main`:

```
8 passed, 0 failed, 8 total
Spent: 94 model call(s), 156003 token(s)
Score: 100 — min-score 80: pass
```

Worth waiting for: the resolver change touches every action of every test, and the local verification behind it used a single model on one machine.

## The entry has a section this changelog has not had before

**Known limitation.** A name shared by several visible controls is still resolved in document order, silently. It is the thing in this release most likely to surprise someone, and left only in the design and in #60 they would meet it as a wrong verdict rather than as a documented limit. The entry also says what to do about it — give each control a name no other visible control shares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvjettzBPbQSrjvAFXpK8
